### PR TITLE
chore: fix test defaults and SDK metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,28 @@ python scripts/demo-why.py
 
 Localhost uses an auto-injected dev key — no API key required.
 
+### Tests
+
+Core unit/smoke tests can run without the Docker stack:
+
+```bash
+cd core
+python -m pip install -r requirements.txt -r requirements-dev.txt
+python -m pytest tests -q
+```
+
+Integration tests require a running local ZizkaDB stack:
+
+```bash
+# from the repository root
+bash scripts/setup-local.sh
+
+cd core
+ZIZKADB_RUN_INTEGRATION=1 python -m pytest tests -q -m integration
+```
+
+You can also pass `--run-integration` instead of setting `ZIZKADB_RUN_INTEGRATION=1`.
+
 ### Managed cloud (same SDK)
 
 ```bash

--- a/core/pytest.ini
+++ b/core/pytest.ini
@@ -2,4 +2,4 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =
-    integration: requires running ZizkaDB stack (docker compose up)
+    integration: requires running ZizkaDB stack (set ZIZKADB_RUN_INTEGRATION=1 or pass --run-integration)

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,8 +1,42 @@
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SDK = ROOT.parent / "sdk" / "python"
 
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(SDK))
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").lower() in {"1", "true", "yes", "on"}
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests that require a running ZizkaDB stack.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    run_integration = config.getoption("--run-integration") or _truthy(
+        os.getenv("ZIZKADB_RUN_INTEGRATION")
+    )
+    if run_integration:
+        return
+
+    skip_integration = pytest.mark.skip(
+        reason=(
+            "requires a running ZizkaDB stack; set ZIZKADB_RUN_INTEGRATION=1 "
+            "or pass --run-integration to enable"
+        )
+    )
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zizkadb-sdk",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zizkadb-sdk",
-      "version": "0.2.1",
+      "version": "0.2.4",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -40,7 +40,7 @@ export * from './types'
 
 const CLOUD_HOST = 'https://db.zizka.ai'
 const TELEMETRY_URL = 'https://db.zizka.ai/v1/telemetry'
-const SDK_VERSION = '0.2.3'
+const SDK_VERSION = '0.2.4'
 const DEFAULT_DEV_API_KEY = 'zizkadb_dev_local'
 
 function isLocalHost(host: string): boolean {


### PR DESCRIPTION
A small credibility PR before larger contributions: fix integration-test defaults so the core test suite is safe to run without a running stack, document the test commands in README, and align the TypeScript SDK version across all three places it appears (SDK runtime constant, package.json, package-lock.json).

## Changes

- **core/tests/conftest.py** — add pytest gating for integration tests. Default runs skip integration tests. Set ZIZKADB_RUN_INTEGRATION=1 or pass --run-integration to enable them.
- **core/pytest.ini** — update the 'integration' marker help text to match the new env/flag mechanism.
- **README.md** — document how to run unit/smoke tests vs integration tests, including the setup command and the env/flag you need.
- **sdk/typescript/src/index.ts** — bump SDK_VERSION runtime constant from 0.2.3 to 0.2.4 to match package.json.
- **sdk/typescript/package-lock.json** — align top-level version fields (root and packages[""] ) from stale 0.2.1 to 0.2.4 to match the rest of the SDK.

## Verification

- All Python files compile clean (52 files, 0 errors).
- Core default tests pass (5 passed, 2 skipped).
- Integration tests are skipped by default (2 skipped, 5 deselected) and run when opted in (connect error expected without local stack).
- TypeScript SDK builds clean (CJS, ESM, DTS).
- Version alignment check: all four sources (package.json, two lockfile locations, SDK runtime constant) read 0.2.4.