### PR TITLE
chore: fix test defaults and SDK metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,28 @@ python scripts/demo-why.py
 
 Localhost uses an auto-injected dev key — no API key required.
 
+### Tests
+
+Core unit/smoke tests can run without the Docker stack:
+
+```bash
+cd core
+python -m pip install -r requirements.txt -r requirements-dev.txt
+python -m pytest tests -q
+```
+
+Integration tests require a running local ZizkaDB stack:
+
+```bash
+# from the repository root
+bash scripts/setup-local.sh
+
+cd core
+ZIZKADB_RUN_INTEGRATION=1 python -m pytest tests -q -m integration
+```
+
+You can also pass `--run-integration` instead of setting `ZIZKADB_RUN_INTEGRATION=1`.
+
 ### Managed cloud (same SDK)
 
 ```bash

--- a/core/pytest.ini
+++ b/core/pytest.ini
@@ -2,4 +2,4 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 markers =
-    integration: requires running ZizkaDB stack (docker compose up)
+    integration: requires running ZizkaDB stack (set ZIZKADB_RUN_INTEGRATION=1 or pass --run-integration)

--- a/core/tests/conftest.py
+++ b/core/tests/conftest.py
@@ -1,8 +1,42 @@
+import os
 import sys
 from pathlib import Path
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
 SDK = ROOT.parent / "sdk" / "python"
 
 sys.path.insert(0, str(ROOT))
 sys.path.insert(0, str(SDK))
+
+
+def _truthy(value: str | None) -> bool:
+    return (value or "").lower() in {"1", "true", "yes", "on"}
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--run-integration",
+        action="store_true",
+        default=False,
+        help="Run integration tests that require a running ZizkaDB stack.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    run_integration = config.getoption("--run-integration") or _truthy(
+        os.getenv("ZIZKADB_RUN_INTEGRATION")
+    )
+    if run_integration:
+        return
+
+    skip_integration = pytest.mark.skip(
+        reason=(
+            "requires a running ZizkaDB stack; set ZIZKADB_RUN_INTEGRATION=1 "
+            "or pass --run-integration to enable"
+        )
+    )
+    for item in items:
+        if "integration" in item.keywords:
+            item.add_marker(skip_integration)

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zizkadb-sdk",
-  "version": "0.2.1",
+  "version": "0.2.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zizkadb-sdk",
-      "version": "0.2.1",
+      "version": "0.2.4",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -40,7 +40,7 @@ export * from './types'
 
 const CLOUD_HOST = 'https://db.zizka.ai'
 const TELEMETRY_URL = 'https://db.zizka.ai/v1/telemetry'
-const SDK_VERSION = '0.2.3'
+const SDK_VERSION = '0.2.4'
 const DEFAULT_DEV_API_KEY = 'zizkadb_dev_local'
 
 function isLocalHost(host: string): boolean {


### PR DESCRIPTION
Integration tests now skip by default so contributors can run `pytest` without Docker. SDK version aligned across all three sources.

## Changes

- **core/tests/conftest.py** — integration tests skip by default unless `ZIZKADB_RUN_INTEGRATION=1` or `--run-integration` is set
- **core/pytest.ini** — updated marker description
- **README.md** — documented offline vs integration test commands
- **sdk/typescript/src/index.ts** — SDK_VERSION `0.2.3` → `0.2.4`
- **sdk/typescript/package-lock.json** — version `0.2.1` → `0.2.4`

## Verification

- Default core tests: 5 passed, 2 skipped
- Integration tests with opt-in: attempted (fail without stack as expected)
- TypeScript SDK build: passes
- Version alignment: all 3 sources read 0.2.4