### PR TITLE
test: add mocked SDK and MCP coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,24 @@ await db.log({ agent: 'sales-bot', event: 'tool_call', data: { tool: 'crm_lookup
   <a href="https://db.zizka.ai/signup?plan=team"><strong>Get started with Team →</strong></a>
 </p>
 
+### Tests
+
+Core unit tests plus the SDK and MCP package tests do not require a running ZizkaDB stack:
+
+```bash
+# Core tests
+(cd core && python -m pip install -r requirements.txt -r requirements-dev.txt && python -m pytest tests -q)
+
+# Python SDK tests
+(cd sdk/python && python -m pip install -e '.[dev]' && python -m pytest tests -q)
+
+# MCP tests
+(cd mcp && python -m pip install -e '.[dev]' && python -m pytest tests -q)
+
+# TypeScript SDK tests
+(cd sdk/typescript && npm ci && npm test)
+```
+
 ---
 
 ## Compare capabilities

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "httpx>=0.27.0",
 ]
 
+[project.optional-dependencies]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
+
 [project.scripts]
 zizkadb-mcp = "zizkadb_mcp.server:main"
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = ["httpx>=0.27.0"]
 zizkadb = "zizkadb.cli:main"
 
 [project.optional-dependencies]
-dev = ["pytest>=8.0"]
+dev = ["pytest>=8.0", "pytest-asyncio>=0.23"]
 
 [project.urls]
 Homepage = "https://db.zizka.ai"

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -1,0 +1,129 @@
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from zizkadb.client import ZizkaDB
+from zizkadb.exceptions import AgentScopeError, AuthError, NotFoundError, RateLimitError, ZizkaDBError
+
+
+def _prevent_telemetry(monkeypatch):
+    """Stop telemetry from firing before/inside ZizkaDB.__init__."""
+    monkeypatch.setattr("zizkadb.client._telemetry_ping", lambda mode: None)
+    monkeypatch.setenv("ZIZKADB_TELEMETRY", "false")
+
+
+def _client(monkeypatch, response_handler, api_key="zizkadb_live_test", host="https://example.test"):
+    _prevent_telemetry(monkeypatch)
+    db = ZizkaDB(api_key=api_key, host=host)
+    db._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(response_handler),
+        base_url=db._base_url,
+        headers=db._headers(),
+    )
+    return db
+
+
+async def _close(db):
+    await db._client.aclose()
+
+
+def test_log_posts_expected_event_payload(monkeypatch):
+    captures = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captures["method"] = request.method
+        captures["url"] = str(request.url)
+        captures["auth"] = request.headers.get("authorization")
+        captures["body"] = request.read().decode()
+        return httpx.Response(
+            200,
+            json={
+                "event_id": "00000000-0000-0000-0000-000000000001",
+                "timestamp": "2026-06-19T00:00:00Z",
+                "sequence_no": 1,
+                "checksum": "abc123",
+            },
+        )
+
+    db = _client(monkeypatch, handler)
+    try:
+        result = asyncio.run(
+            db.log(
+                agent="test-agent",
+                event="tool_call",
+                data={"tool": "search"},
+                parent_id="parent-1",
+                session_id="session-1",
+            )
+        )
+    finally:
+        asyncio.run(_close(db))
+
+    assert captures["method"] == "POST"
+    assert captures["url"] == "https://example.test/v1/events"
+    assert captures["auth"] == "Bearer zizkadb_live_test"
+    body_json = captures["body"]
+    body = json.loads(body_json)
+    assert body["agent"] == "test-agent"
+    assert body["event"] == "tool_call"
+    assert body["data"] == {"tool": "search"}
+    assert body["parent_id"] == "parent-1"
+    assert body["session_id"] == "session-1"
+    assert body["metadata"] is None
+    assert result.event_id == "00000000-0000-0000-0000-000000000001"
+    assert result.sequence_no == 1
+
+
+@pytest.mark.parametrize(
+    ("status", "payload", "error_type"),
+    [
+        (401, {"detail": "bad key"}, AuthError),
+        (403, {"detail": "wrong agent"}, AgentScopeError),
+        (404, {"detail": "missing"}, NotFoundError),
+        (429, {"detail": "slow down"}, RateLimitError),
+        (500, {"detail": "boom"}, ZizkaDBError),
+    ],
+)
+def test_error_mapping(monkeypatch, status, payload, error_type):
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status, json=payload)
+
+    db = _client(monkeypatch, handler)
+    try:
+        with pytest.raises(error_type):
+            asyncio.run(db.query(agent="test-agent"))
+    finally:
+        asyncio.run(_close(db))
+
+
+def test_localhost_auto_injects_dev_key(monkeypatch):
+    _prevent_telemetry(monkeypatch)
+    monkeypatch.delenv("ZIZKADB_API_KEY", raising=False)
+    monkeypatch.delenv("AGENTDB_API_KEY", raising=False)
+    monkeypatch.delenv("DEV_API_KEY", raising=False)
+
+    db = ZizkaDB(host="http://localhost:8000")
+
+    assert db._api_key == "zizkadb_dev_local"
+    assert db._headers()["Authorization"] == "Bearer zizkadb_dev_local"
+
+
+def test_log_sends_null_for_omitted_parent_and_session(monkeypatch):
+    """The SDK sends parent_id: null and session_id: null when not provided."""
+    captured = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["body"] = request.read().decode()
+        return httpx.Response(200, json={"event_id": "evt-1", "timestamp": "2026-01-01T00:00:00Z", "sequence_no": 1, "checksum": "x"})
+
+    db = _client(monkeypatch, handler)
+    try:
+        asyncio.run(db.log(agent="a", event="e", data={}))
+    finally:
+        asyncio.run(_close(db))
+
+    body = json.loads(captured["body"])
+    assert body["parent_id"] is None
+    assert body["session_id"] is None

--- a/sdk/typescript/tests/client.test.mjs
+++ b/sdk/typescript/tests/client.test.mjs
@@ -1,0 +1,131 @@
+/**
+ * ZizkaDB TypeScript SDK — Vitest coverage.
+ *
+ * No external services.  Mock fetch, disable telemetry, and test that the
+ * SDK constructs expected request shapes and maps errors correctly.
+ *
+ * Uses the package's existing Vitest test runner.
+ */
+
+import { afterAll, expect, it } from 'vitest'
+
+// Save the original fetch so we can restore it after all tests finish.
+const _originalFetch = globalThis.fetch
+
+// Disable telemetry before loading the SDK so the constructor doesn't fire it.
+process.env.ZIZKADB_TELEMETRY = 'false'
+
+import { AgentScopeError, AuthError, ZizkaDB, ZizkaDBError } from '../src/index.ts'
+
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+
+it('log posts the expected event payload', async () => {
+  const calls = []
+
+  globalThis.fetch = async (url, init) => {
+    calls.push({ url, init })
+    return jsonResponse({
+      event_id: '00000000-0000-0000-0000-000000000001',
+      timestamp: '2026-06-19T00:00:00Z',
+      sequence_no: 1,
+      checksum: 'abc123',
+    })
+  }
+
+  const db = new ZizkaDB({
+    apiKey: 'zizkadb_live_test',
+    host: 'https://example.test',
+  })
+
+  const result = await db.log({
+    agent: 'test-agent',
+    event: 'tool_call',
+    data: { tool: 'search' },
+    parentId: 'parent-1',
+    sessionId: 'session-1',
+  })
+
+  expect(calls).toHaveLength(1)
+  expect(calls[0].url).toBe('https://example.test/v1/events')
+  expect(calls[0].init.method).toBe('POST')
+  expect(calls[0].init.headers.Authorization).toBe('Bearer zizkadb_live_test')
+
+  const body = JSON.parse(calls[0].init.body)
+  expect(body.agent).toBe('test-agent')
+  expect(body.event).toBe('tool_call')
+  expect(body.data).toEqual({ tool: 'search' })
+  expect(body.parent_id).toBe('parent-1')
+  expect(body.session_id).toBe('session-1')
+  expect(result.eventId).toBe('00000000-0000-0000-0000-000000000001')
+})
+
+
+it('403 responses raise AgentScopeError', async () => {
+  globalThis.fetch = async () =>
+    jsonResponse({ detail: 'wrong agent' }, 403)
+
+  const db = new ZizkaDB({
+    apiKey: 'zizkadb_live_test',
+    host: 'https://example.test',
+  })
+
+  await expect(db.query({ agent: 'wrong-agent' })).rejects.toBeInstanceOf(AgentScopeError)
+})
+
+
+it('401 responses raise AuthError', async () => {
+  globalThis.fetch = async () =>
+    jsonResponse({ detail: 'bad key' }, 401)
+
+  const db = new ZizkaDB({
+    apiKey: 'zizkadb_live_test',
+    host: 'https://example.test',
+  })
+
+  await expect(db.query({ agent: 'test-agent' })).rejects.toBeInstanceOf(AuthError)
+})
+
+
+it('500 responses raise ZizkaDBError', async () => {
+  globalThis.fetch = async () =>
+    jsonResponse({ detail: 'boom' }, 500)
+
+  const db = new ZizkaDB({
+    apiKey: 'zizkadb_live_test',
+    host: 'https://example.test',
+  })
+
+  await expect(db.query({ agent: 'test-agent' })).rejects.toBeInstanceOf(ZizkaDBError)
+})
+
+
+it('localhost auto-injects dev key', async () => {
+  delete process.env.ZIZKADB_API_KEY
+  delete process.env.AGENTDB_API_KEY
+  delete process.env.DEV_API_KEY
+
+  let authHeader
+
+  globalThis.fetch = async (url, init) => {
+    authHeader = init.headers.Authorization
+    return jsonResponse({ event_id: 'evt-1', timestamp: '2026-01-01T00:00:00Z', sequence_no: 1, checksum: 'x' })
+  }
+
+  const db = new ZizkaDB({ host: 'http://localhost:8000' })
+  await db.log({ agent: 'test-agent', event: 'tool_call', data: {} })
+
+  expect(authHeader).toBe('Bearer zizkadb_dev_local')
+})
+
+
+// Restore original fetch after all tests run.
+afterAll(() => {
+  globalThis.fetch = _originalFetch
+})


### PR DESCRIPTION
Adds mocked HTTP tests for Python SDK, MCP server, and TypeScript SDK — no Docker, cloud, or network required.

## Changes

- **sdk/python/tests/test_client.py** (new) — 8 tests: request shape, error mapping (5 codes), localhost dev-key, null parent/session
- **mcp/tests/test_server.py** (new) — 3 tests: log_event, search_memory, missing-key error
- **mcp/pyproject.toml** — added dev extra with pytest
- **sdk/typescript/tests/client.test.mjs** (new) — 5 tests: request shape, error mapping (3 codes), localhost dev-key with Authorization header verification
- **sdk/typescript/package.json** — added `npm test` script
- **sdk/typescript/src/index.ts** — SDK_VERSION aligned to 0.2.4
- **sdk/typescript/package-lock.json** — version aligned to 0.2.4
- **README.md** — documented package test commands

## How to run

```bash
# Python SDK
cd sdk/python && python -m pip install -e '.[dev]' && python -m pytest tests -q

# MCP
cd mcp && python -m pip install -e '.[dev]' && python -m pytest tests -q

# TypeScript SDK
cd sdk/typescript && npm test
```

## Verification

- Python SDK: 8 passed
- MCP: 3 passed
- TypeScript SDK: 5 passed (build + tests)