### PR TITLE
Improve event embedding generation by recursively flattening nested event data

### DIFF
--- a/core/services/embeddings.py
+++ b/core/services/embeddings.py
@@ -1,6 +1,7 @@
 import httpx
 import json
 import logging
+from typing import Any
 
 from db.connection import get_redis
 from services.embedding_config import (
@@ -34,6 +35,7 @@ async def generate_embedding_with_config(
         return None
 
     cache_key = f"emb:{config.provider}:{config.model}:{hash(text)}"
+
     try:
         redis = get_redis()
         cached = await redis.get(cache_key)
@@ -51,6 +53,7 @@ async def generate_embedding_with_config(
 
         if not embedding:
             return None
+
         if len(embedding) != VECTOR_SIZE:
             logger.warning(
                 "Embedding dimension %s != %s for tenant %s",
@@ -67,34 +70,84 @@ async def generate_embedding_with_config(
             pass
 
         return embedding
+
     except Exception as e:
-        logger.warning("Embedding generation failed for tenant %s: %s", config.tenant_id, e)
+        logger.warning(
+            "Embedding generation failed for tenant %s: %s",
+            config.tenant_id,
+            e,
+        )
         return None
 
 
-async def _openai_embedding(text: str, config: TenantEmbeddingConfig) -> list[float] | None:
-    payload: dict = {"input": text, "model": config.model}
-    for m in EMBEDDING_MODELS.get("openai", []):
-        if m["id"] == config.model and m.get("dimensions_param"):
-            payload["dimensions"] = m["dimensions_param"]
+async def _openai_embedding(
+    text: str,
+    config: TenantEmbeddingConfig,
+) -> list[float] | None:
+    payload: dict = {
+        "input": text,
+        "model": config.model,
+    }
+
+    for model in EMBEDDING_MODELS.get("openai", []):
+        if model["id"] == config.model and model.get("dimensions_param"):
+            payload["dimensions"] = model["dimensions_param"]
             break
 
     async with httpx.AsyncClient(timeout=15.0) as client:
         response = await client.post(
             "https://api.openai.com/v1/embeddings",
-            headers={"Authorization": f"Bearer {config.api_key}"},
+            headers={
+                "Authorization": f"Bearer {config.api_key}",
+            },
             json=payload,
         )
+
         response.raise_for_status()
+
         return response.json()["data"][0]["embedding"]
 
 
+def _flatten_data(value: Any, prefix: str = "") -> list[str]:
+    """
+    Recursively flatten nested dictionaries and lists into
+    key:value strings suitable for semantic embeddings.
+
+    Example:
+        {"user": {"city": "Paris"}}
+            -> ["user.city:Paris"]
+
+        {"docs": ["a", "b"]}
+            -> ["docs.0:a", "docs.1:b"]
+    """
+
+    parts: list[str] = []
+
+    if isinstance(value, dict):
+        for key, item in value.items():
+            new_prefix = f"{prefix}.{key}" if prefix else key
+            parts.extend(_flatten_data(item, new_prefix))
+
+    elif isinstance(value, list):
+        for index, item in enumerate(value):
+            new_prefix = f"{prefix}.{index}" if prefix else str(index)
+            parts.extend(_flatten_data(item, new_prefix))
+
+    elif isinstance(value, (str, int, float, bool)):
+        parts.append(f"{prefix}:{value}")
+
+    return parts
+
+
 def event_to_text(event_type: str, data: dict) -> str:
-    """Convert an event to a text representation for embedding."""
+    """
+    Convert an event into a semantic text representation
+    for embedding generation.
+
+    Supports nested dictionaries and lists.
+    """
+
     parts = [f"event_type:{event_type}"]
-    for key, value in data.items():
-        if isinstance(value, str):
-            parts.append(f"{key}:{value}")
-        elif isinstance(value, (int, float, bool)):
-            parts.append(f"{key}:{value}")
+    parts.extend(_flatten_data(data))
+
     return " ".join(parts)

--- a/core/tests/test_embeddings.py
+++ b/core/tests/test_embeddings.py
@@ -1,0 +1,47 @@
+from services.embeddings import event_to_text
+
+
+def test_event_to_text_includes_primitives():
+    text = event_to_text(
+        "tool_call",
+        {
+            "tool": "weather",
+            "temperature": 22,
+            "success": True,
+        },
+    )
+
+    assert "event_type:tool_call" in text
+    assert "tool:weather" in text
+    assert "temperature:22" in text
+    assert "success:True" in text
+
+
+def test_event_to_text_nested_dict():
+    text = event_to_text(
+        "tool_call",
+        {
+            "arguments": {
+                "city": "Paris",
+                "country": "France",
+            }
+        },
+    )
+
+    assert "arguments.city:Paris" in text
+    assert "arguments.country:France" in text
+
+
+def test_event_to_text_lists():
+    text = event_to_text(
+        "retrieval",
+        {
+            "documents": [
+                "doc1",
+                "doc2",
+            ]
+        },
+    )
+
+    assert "documents.0:doc1" in text
+    assert "documents.1:doc2" in text


### PR DESCRIPTION
## Summary

This PR improves semantic embedding generation by recursively flattening nested event data before generating embedding text.

Previously, `event_to_text()` only included top-level primitive values (`str`, `int`, `float`, `bool`), so nested dictionaries and lists were ignored. As a result, valuable contextual information was not included in the generated embeddings, reducing semantic search quality.

### Example

Input:

```python
{
    "arguments": {
        "city": "Paris",
        "country": "France"
    },
    "documents": [
        "doc1",
        "doc2"
    ]
}
```

Before:

```
event_type:tool_call
```

After:

```
event_type:tool_call
arguments.city:Paris
arguments.country:France
documents.0:doc1
documents.1:doc2
```

## Changes

* Added recursive flattening for nested dictionaries.
* Added recursive flattening for lists.
* Preserved existing behavior for primitive values.
* Added unit tests covering:

  * Primitive values
  * Nested dictionaries
  * Lists

## Testing

```bash
python -m pytest tests/test_embeddings.py -v
```

Result:

```
3 passed
```

The existing integration test failures (`memory/forget` and `search_with_embeddings`) are unrelated to this change.
