### PR TITLE
fix(security): fail fast in production when JWT/encryption secrets are unset

### DIFF
--- a/core/services/auth.py
+++ b/core/services/auth.py
@@ -11,8 +11,31 @@ from email.mime.multipart import MIMEMultipart
 from datetime import datetime, timedelta, timezone
 from db.connection import get_pool
 
-JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret")
-JWT_REFRESH_SECRET = os.getenv("JWT_REFRESH_SECRET", "dev-refresh-secret")
+def _required_secret(env_var: str, dev_fallback: str) -> str:
+    """
+    Resolve a signing secret from the environment.
+
+    In development this falls back to a fixed insecure string so local
+    self-host works without any env setup. In production (ENV !=
+    "development"), the fallback string is visible in this public
+    repository — using it to sign JWTs would let anyone forge a valid
+    auth token. Refuse to start rather than silently sign tokens with a
+    known secret.
+    """
+    secret = os.getenv(env_var)
+    if secret:
+        return secret
+    if os.getenv("ENV", "development") != "development":
+        raise RuntimeError(
+            f"{env_var} must be set in production. Refusing to sign tokens "
+            f"with the hardcoded development fallback, since that value is "
+            f"visible in the public source code."
+        )
+    return dev_fallback
+
+
+JWT_SECRET = _required_secret("JWT_SECRET", "dev-secret")
+JWT_REFRESH_SECRET = _required_secret("JWT_REFRESH_SECRET", "dev-refresh-secret")
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days
 REFRESH_TOKEN_EXPIRE_DAYS = 30
 

--- a/core/services/embedding_config.py
+++ b/core/services/embedding_config.py
@@ -84,7 +84,28 @@ def model_dimensions(provider: str, model: str) -> int:
 
 
 def _fernet() -> Fernet:
-    secret = os.getenv("EMBEDDING_ENCRYPTION_KEY") or os.getenv("JWT_SECRET", "dev-insecure-key")
+    """
+    Derive the Fernet key used to encrypt per-tenant BYOK embedding API keys.
+
+    Falls back to JWT_SECRET when EMBEDDING_ENCRYPTION_KEY is unset, matching
+    .env.example. In development this also falls back to a fixed insecure
+    string so local self-host works out of the box without any env setup.
+
+    In production (ENV != "development"), neither secret being set is a
+    misconfiguration, not something to silently paper over: the hardcoded
+    fallback string is visible in this public repository, so encrypting
+    tenant API keys with it would mean every BYOK key is effectively
+    unencrypted. Refuse to start serving embeddings in that case.
+    """
+    secret = os.getenv("EMBEDDING_ENCRYPTION_KEY") or os.getenv("JWT_SECRET")
+    if not secret:
+        if os.getenv("ENV", "development") != "development":
+            raise RuntimeError(
+                "EMBEDDING_ENCRYPTION_KEY or JWT_SECRET must be set in production. "
+                "Refusing to encrypt tenant API keys with a hardcoded fallback "
+                "value, since that value is visible in the public source code."
+            )
+        secret = "dev-insecure-key"
     key = base64.urlsafe_b64encode(hashlib.sha256(secret.encode()).digest())
     return Fernet(key)
 

--- a/core/tests/test_secret_fallback_security.py
+++ b/core/tests/test_secret_fallback_security.py
@@ -1,0 +1,139 @@
+"""
+Unit tests for the insecure-fallback-secret fix in auth.py and
+embedding_config.py.
+
+These tests verify that:
+1. In development (ENV unset or "development"), the hardcoded fallback
+   secrets still work, so local self-host / first-run experience is
+   unaffected.
+2. In production (ENV set to anything else), missing secrets raise
+   RuntimeError instead of silently using a value that is visible in
+   the public source code.
+
+No database or network required — these are pure function tests against
+the secret-resolution logic.
+"""
+
+import importlib
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# embedding_config.py imports `from db.connection import get_pool`, which in
+# turn imports asyncpg + redis. These tests only exercise pure secret-
+# resolution logic and never touch the database, so we stub db.connection
+# out rather than requiring the full infra dependency chain to be installed.
+_fake_db_connection = types.ModuleType("db.connection")
+_fake_db_connection.get_pool = MagicMock()
+sys.modules.setdefault("db", types.ModuleType("db"))
+sys.modules["db.connection"] = _fake_db_connection
+
+
+def _reload_with_env(module_name: str, env: dict) -> None:
+    """Reload a module with a patched environment so its module-level
+    secret resolution re-runs under the new env vars."""
+    old_env = {k: os.environ.get(k) for k in env}
+    try:
+        for k, v in env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+        return importlib.import_module(module_name)
+    finally:
+        for k, v in old_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+
+# ── auth.py — JWT_SECRET / JWT_REFRESH_SECRET ──────────────────────────────
+
+class TestAuthSecretFallback:
+    def test_dev_fallback_used_when_env_unset(self):
+        from services.auth import _required_secret
+        result = _required_secret("NONEXISTENT_VAR_XYZ", "dev-fallback")
+        assert result == "dev-fallback"
+
+    def test_dev_fallback_used_when_env_is_development(self, monkeypatch):
+        monkeypatch.setenv("ENV", "development")
+        monkeypatch.delenv("NONEXISTENT_VAR_XYZ", raising=False)
+        from services.auth import _required_secret
+        result = _required_secret("NONEXISTENT_VAR_XYZ", "dev-fallback")
+        assert result == "dev-fallback"
+
+    def test_explicit_secret_always_used(self, monkeypatch):
+        monkeypatch.setenv("ENV", "production")
+        monkeypatch.setenv("MY_TEST_SECRET", "real-secret-value")
+        from services.auth import _required_secret
+        result = _required_secret("MY_TEST_SECRET", "dev-fallback")
+        assert result == "real-secret-value"
+
+    def test_production_without_secret_raises(self, monkeypatch):
+        monkeypatch.setenv("ENV", "production")
+        monkeypatch.delenv("NONEXISTENT_VAR_XYZ", raising=False)
+        from services.auth import _required_secret
+        with pytest.raises(RuntimeError, match="must be set in production"):
+            _required_secret("NONEXISTENT_VAR_XYZ", "dev-fallback")
+
+    def test_staging_treated_as_production(self, monkeypatch):
+        # Anything other than "development" should be treated as production —
+        # we don't want a typo'd ENV value to silently disable the guard.
+        monkeypatch.setenv("ENV", "staging")
+        monkeypatch.delenv("NONEXISTENT_VAR_XYZ", raising=False)
+        from services.auth import _required_secret
+        with pytest.raises(RuntimeError):
+            _required_secret("NONEXISTENT_VAR_XYZ", "dev-fallback")
+
+
+# ── embedding_config.py — _fernet() ─────────────────────────────────────────
+
+class TestEmbeddingKeyFallback:
+    def test_dev_fallback_when_no_secrets_set(self, monkeypatch):
+        monkeypatch.delenv("EMBEDDING_ENCRYPTION_KEY", raising=False)
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.setenv("ENV", "development")
+        from services.embedding_config import _fernet
+        f = _fernet()
+        # Should produce a working Fernet instance, not raise
+        token = f.encrypt(b"test")
+        assert f.decrypt(token) == b"test"
+
+    def test_uses_embedding_encryption_key_when_set(self, monkeypatch):
+        monkeypatch.setenv("EMBEDDING_ENCRYPTION_KEY", "my-encryption-key")
+        monkeypatch.setenv("ENV", "production")
+        from services.embedding_config import _fernet
+        f = _fernet()
+        token = f.encrypt(b"secret-api-key")
+        assert f.decrypt(token) == b"secret-api-key"
+
+    def test_falls_back_to_jwt_secret_when_embedding_key_unset(self, monkeypatch):
+        monkeypatch.delenv("EMBEDDING_ENCRYPTION_KEY", raising=False)
+        monkeypatch.setenv("JWT_SECRET", "shared-jwt-secret")
+        monkeypatch.setenv("ENV", "production")
+        from services.embedding_config import _fernet
+        f = _fernet()
+        token = f.encrypt(b"test")
+        assert f.decrypt(token) == b"test"
+
+    def test_production_without_any_secret_raises(self, monkeypatch):
+        monkeypatch.delenv("EMBEDDING_ENCRYPTION_KEY", raising=False)
+        monkeypatch.delenv("JWT_SECRET", raising=False)
+        monkeypatch.setenv("ENV", "production")
+        from services.embedding_config import _fernet
+        with pytest.raises(RuntimeError, match="must be set in production"):
+            _fernet()
+
+    def test_round_trip_encrypt_decrypt_api_key(self, monkeypatch):
+        monkeypatch.setenv("EMBEDDING_ENCRYPTION_KEY", "test-key-for-roundtrip")
+        from services.embedding_config import encrypt_api_key, decrypt_api_key
+        original = "sk-test-1234567890abcdef"
+        encrypted = encrypt_api_key(original)
+        assert encrypted != original
+        assert decrypt_api_key(encrypted) == original


### PR DESCRIPTION
## Problem

Three secrets fall back to hardcoded values when their env vars are unset:

- `JWT_SECRET` (`auth.py`) → `"dev-secret"`
- `JWT_REFRESH_SECRET` (`auth.py`) → `"dev-refresh-secret"`
- `EMBEDDING_ENCRYPTION_KEY` / `JWT_SECRET` (`embedding_config.py`) → `"dev-insecure-key"`

These fallback strings are **visible in this public repository's source code**. If a production deployment forgets to set the corresponding env var, auth tokens get signed — and per-tenant BYOK embedding API keys get encrypted — with a secret anyone can read on GitHub.

Concretely:
- An attacker who notices the misconfiguration could **forge valid auth JWTs** using the known `dev-secret` fallback, since `auth.py` uses `JWT_SECRET` for both signing (`create_access_token` / `create_refresh_token` style flows) and verification (`jwt.decode(..., JWT_SECRET, ...)` in `admin.py`).
- A tenant's **BYOK OpenAI API key**, stored encrypted via `encrypt_api_key()` in `embedding_config.py`, could be decrypted by anyone who knows the public fallback string.

This is the kind of bug that is silent in every environment, including a misconfigured production one, until someone actually abuses it.

## Fix

Both secret-resolution points now check `ENV` — the same variable `.env.example` already documents tenants should set to `"production"` for managed cloud (line 24: `# Managed cloud production: leave unset and set ENV=production`).

When `ENV != "development"` and no real secret is configured, the app now raises `RuntimeError` at startup instead of silently signing/encrypting with the public fallback value.

**Local self-host and the default dev experience are unaffected** — when `ENV` is unset or `"development"`, the original fallback values are used exactly as before, so onboarding with zero env setup still works out of the box.

```python
# auth.py — before
JWT_SECRET = os.getenv("JWT_SECRET", "dev-secret")

# auth.py — after
JWT_SECRET = _required_secret("JWT_SECRET", "dev-secret")
# raises RuntimeError in production if unset; dev fallback unchanged otherwise
```

## Tests

10 new tests in `core/tests/test_secret_fallback_security.py`:

```bash
cd core && pytest tests/test_secret_fallback_security.py -v
# 10 passed
```

Covers:
- Dev fallback used when `ENV` unset or `"development"` (confirms zero behavior change for local self-host)
- Explicit secret always takes precedence over fallback
- Production without a secret raises `RuntimeError`
- A non-`"development"` `ENV` value (e.g. `"staging"`) is treated as production, so a typo in `ENV` doesn't silently disable the guard
- `embedding_config._fernet()` correctly falls back `EMBEDDING_ENCRYPTION_KEY` → `JWT_SECRET`, and the full encrypt/decrypt round-trip for a BYOK API key still works

No database connection required — `db.connection` is stubbed in the test file since these tests only exercise pure secret-resolution logic, not anything that touches Postgres.

## Behavioral proof

```
$ ENV=production python3 -c "from services.auth import _required_secret; _required_secret('MISSING', 'fallback')"
RuntimeError: MISSING must be set in production. Refusing to sign tokens with the hardcoded development fallback, since that value is visible in the public source code.

$ python3 -c "from services.auth import _required_secret; print(_required_secret('MISSING', 'fallback'))"
fallback
```

## Files changed

```
core/services/auth.py                       — guard JWT_SECRET / JWT_REFRESH_SECRET
core/services/embedding_config.py           — guard the Fernet key derivation
core/tests/test_secret_fallback_security.py — new: 10 tests
```