### PR TITLE
feat(core): implement centralized rate-limiting strategy

### DIFF
--- a/core/api/admin.py
+++ b/core/api/admin.py
@@ -27,7 +27,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 
 from db.connection import get_pool
-from api.auth import _check_otp_rate_limit
+from api.auth import otp_limiter
 from services.auth import JWT_SECRET, request_otp, verify_otp
 
 router = APIRouter()
@@ -91,7 +91,7 @@ async def require_admin(
 async def admin_request_otp(body: AdminOTPRequest):
     if not _is_admin_email(body.email):
         raise HTTPException(status_code=404, detail="Not Found")
-    _check_otp_rate_limit(ADMIN_EMAIL)
+    await otp_limiter.check(ADMIN_EMAIL)
     try:
         await request_otp(ADMIN_EMAIL)
     except Exception as e:

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -3,7 +3,7 @@ import time
 import logging
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Response, Depends
 from pydantic import BaseModel, EmailStr
 from services.auth import request_otp, verify_otp, _issue_tokens, email_exists
 from services.api_keys import (
@@ -13,8 +13,8 @@ from services.api_keys import (
     revoke_api_key_record,
 )
 from api.deps import get_tenant, require_dashboard_session
-from fastapi import Depends
 from db.connection import get_pool
+from services.rate_limiter import RateLimiter, InMemoryStorage, SlidingWindowStrategy
 from services.event_write import write_event
 
 router = APIRouter()
@@ -23,21 +23,15 @@ log = logging.getLogger(__name__)
 # Per-email OTP request limits (in-memory; resets after window)
 _OTP_RATE_WINDOW_SEC = 15 * 60   # 15 minutes
 _OTP_RATE_MAX = 10               # max requests per email per window
-_otp_rate: dict[str, list[float]] = {}
 
+otp_limiter = RateLimiter(
+    limit=_OTP_RATE_MAX,
+    window_sec=_OTP_RATE_WINDOW_SEC,
+    storage=InMemoryStorage(),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many code requests. Wait 15 minutes and try again."
+)
 
-def _check_otp_rate_limit(email: str) -> None:
-    key = email.lower().strip()
-    now = time.time()
-    window_start = now - _OTP_RATE_WINDOW_SEC
-    hits = [t for t in _otp_rate.get(key, []) if t > window_start]
-    if len(hits) >= _OTP_RATE_MAX:
-        raise HTTPException(
-            status_code=429,
-            detail="Too many code requests. Wait 15 minutes and try again.",
-        )
-    hits.append(now)
-    _otp_rate[key] = hits
 
 _DEV_TENANT_ID = "00000000-0000-0000-0000-000000000001"
 _DEV_USER_ID   = "00000000-0000-0000-0000-000000000001"
@@ -67,7 +61,7 @@ async def request_otp_route(body: RequestOTPBody):
     log = logging.getLogger(__name__)
 
     email = body.email.lower().strip()
-    _check_otp_rate_limit(email)
+    await otp_limiter.check(email)
 
     if body.intent == "signup" and await email_exists(email):
         raise HTTPException(

--- a/core/api/community.py
+++ b/core/api/community.py
@@ -9,7 +9,6 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
@@ -17,6 +16,7 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
 from db.connection import get_pool
+from services.rate_limiter import RateLimiter, InMemoryStorage, SlidingWindowStrategy
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -26,10 +26,17 @@ MAX_UPLOAD_BYTES = 3 * 1024 * 1024
 ALLOWED_EXT = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 CATEGORIES = {"question", "experience", "showcase"}
 
-# Simple in-memory rate limit: IP -> list of timestamps
-_rate: dict[str, list[float]] = {}
+
 RATE_WINDOW_SEC = 3600
 RATE_MAX_POSTS = 10
+
+community_limiter = RateLimiter(
+    limit=RATE_MAX_POSTS,
+    window_sec=RATE_WINDOW_SEC,
+    storage=InMemoryStorage(),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many posts. Try again later."
+)
 
 
 class CreatePostBody(BaseModel):
@@ -56,14 +63,6 @@ def _client_ip(request: Request) -> str:
     return request.client.host if request.client else "unknown"
 
 
-def _check_rate(ip: str) -> None:
-    import time
-    now = time.time()
-    hits = [t for t in _rate.get(ip, []) if now - t < RATE_WINDOW_SEC]
-    if len(hits) >= RATE_MAX_POSTS:
-        raise HTTPException(status_code=429, detail="Too many posts. Try again later.")
-    hits.append(now)
-    _rate[ip] = hits
 
 
 def _public_base_url(request: Request) -> str:
@@ -173,7 +172,7 @@ async def create_post(body: CreatePostBody, request: Request):
     if body.category not in CATEGORIES:
         raise HTTPException(status_code=400, detail="Invalid category")
 
-    _check_rate(_client_ip(request))
+    await community_limiter.check(_client_ip(request))
     pool = get_pool()
     urls = [u for u in body.image_urls if isinstance(u, str) and u.startswith("/v1/community/media/")][:6]
 
@@ -200,7 +199,7 @@ async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
     if body.website:
         raise HTTPException(status_code=400, detail="Invalid submission")
 
-    _check_rate(_client_ip(request))
+    await community_limiter.check(_client_ip(request))
     pool = get_pool()
     try:
         pid = uuid.UUID(post_id)
@@ -237,7 +236,7 @@ async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
 
 @router.post("/upload")
 async def upload_image(request: Request, file: UploadFile = File(...)):
-    _check_rate(_client_ip(request) + ":upload")
+    await community_limiter.check(_client_ip(request) + ":upload")
 
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file")

--- a/core/api/demo_requests.py
+++ b/core/api/demo_requests.py
@@ -5,19 +5,25 @@ Public demo request form — landing page "Book demo" submissions.
 from __future__ import annotations
 
 import logging
-import time
-
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
-
 from db.connection import get_pool
+from services.rate_limiter import RateLimiter, InMemoryStorage, SlidingWindowStrategy
 
 router = APIRouter()
 log = logging.getLogger(__name__)
 
-_rate: dict[str, list[float]] = {}
+
 RATE_WINDOW_SEC = 3600
 RATE_MAX = 8
+
+demo_limiter = RateLimiter(
+    limit=RATE_MAX,
+    window_sec=RATE_WINDOW_SEC,
+    storage=InMemoryStorage(),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many requests. Try again later."
+)
 
 
 class CreateDemoRequestBody(BaseModel):
@@ -36,22 +42,13 @@ def _client_ip(request: Request) -> str:
     return request.client.host if request.client else "unknown"
 
 
-def _check_rate(ip: str) -> None:
-    now = time.time()
-    hits = [t for t in _rate.get(ip, []) if now - t < RATE_WINDOW_SEC]
-    if len(hits) >= RATE_MAX:
-        raise HTTPException(status_code=429, detail="Too many requests. Try again later.")
-    hits.append(now)
-    _rate[ip] = hits
-
-
 @router.post("", status_code=201)
 async def create_demo_request(body: CreateDemoRequestBody, request: Request):
     if body.botcheck:
         raise HTTPException(status_code=400, detail="Invalid submission")
 
     ip = _client_ip(request)
-    _check_rate(ip)
+    await demo_limiter.check(ip)
 
     pool = get_pool()
     row = await pool.fetchrow(

--- a/core/requirements-dev.txt
+++ b/core/requirements-dev.txt
@@ -2,3 +2,4 @@ pytest>=8.2.0
 pytest-asyncio>=0.23.0
 httpx>=0.27.0
 ruff>=0.8.0
+fakeredis>=2.20.0

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -1,0 +1,226 @@
+"""
+Rate Limiting for ZizkaDB
+"""
+
+import time
+import logging
+import threading
+from abc import ABC, abstractmethod
+from fastapi import HTTPException
+from db.connection import get_redis
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Storage Interfaces and Implementations
+# ──────────────────────────────────────────────────────────────────────────────
+
+class RateLimitStorage(ABC):
+    @abstractmethod
+    async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        """Retrieve all active hit timestamps for key within the window."""
+        pass
+
+    @abstractmethod
+    async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        """Record a hit timestamp for key with an expiration window."""
+        pass
+
+    @abstractmethod
+    async def clear(self) -> None:
+        """Clear all rate limit entries (useful for test resets)."""
+        pass
+
+
+class InMemoryStorage(RateLimitStorage):
+    def __init__(
+        self,
+        enable_cleanup: bool = False,
+        cleanup_method: str = "lazy",
+        default_ttl_sec: float = 3600.0,
+        cleanup_interval_sec: float = 60.0
+    ):
+        self._data: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+        self.enable_cleanup = enable_cleanup
+        self.cleanup_method = cleanup_method
+        self.default_ttl_sec = default_ttl_sec
+        self.cleanup_interval_sec = cleanup_interval_sec
+        
+        self._gc_thread: threading.Thread | None = None
+        self._stop_gc = threading.Event()
+
+        if self.enable_cleanup and self.cleanup_method == "periodic":
+            self._start_gc_thread()
+
+    def _start_gc_thread(self):
+        self._gc_thread = threading.Thread(target=self._gc_loop, daemon=True, name="InMemoryStorage-GC")
+        self._gc_thread.start()
+        logger.info("Started periodic background garbage collection thread for InMemoryStorage")
+
+    def _gc_loop(self):
+        while not self._stop_gc.wait(self.cleanup_interval_sec):
+            self.prune_expired_keys()
+
+    def prune_expired_keys(self):
+        now = time.time()
+        cutoff = now - self.default_ttl_sec
+        pruned_count = 0
+        with self._lock:
+            for key, hits in list(self._data.items()):
+                valid_hits = [t for t in hits if t > cutoff]
+                if not valid_hits:
+                    self._data.pop(key, None)
+                    pruned_count += 1
+                else:
+                    self._data[key] = valid_hits
+        if pruned_count > 0:
+            logger.debug(f"InMemoryStorage GC pruned {pruned_count} keys")
+
+    async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        now = time.time()
+        cutoff = now - window_sec
+        with self._lock:
+            hits = [t for t in self._data.get(key, []) if t > cutoff]
+            if self.enable_cleanup and self.cleanup_method == "lazy" and not hits:
+                self._data.pop(key, None)
+            else:
+                if key in self._data or hits:
+                    self._data[key] = hits
+            return hits
+
+    async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        with self._lock:
+            if key not in self._data:
+                self._data[key] = []
+            self._data[key].append(timestamp)
+
+    async def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+    def close(self):
+        """Stop periodic GC thread if running."""
+        if self._gc_thread:
+            self._stop_gc.set()
+            self._gc_thread.join(timeout=1.0)
+
+
+class RedisStorage(RateLimitStorage):
+    def __init__(self, key_prefix: str = "ratelimit"):
+        self.key_prefix = key_prefix
+
+    def _get_redis_key(self, key: str) -> str:
+        return f"{self.key_prefix}:{key}"
+
+    async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        redis_client = get_redis()
+        rkey = self._get_redis_key(key)
+        now = time.time()
+        cutoff = now - window_sec
+        
+        # Remove timestamps older than the window
+        await redis_client.zremrangebyscore(rkey, "-inf", cutoff)
+        
+        # Retrieve remaining hits
+        results = await redis_client.zrange(rkey, 0, -1, withscores=True)
+        return [score for _, score in results]
+
+    async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        redis_client = get_redis()
+        rkey = self._get_redis_key(key)
+        
+        # Add hit (use stringified timestamp as value to avoid duplication in same microsecond)
+        val = f"{timestamp}:{threading.get_ident()}"
+        await redis_client.zadd(rkey, {val: timestamp})
+        
+        # Set expiry to prevent memory leak
+        await redis_client.expire(rkey, window_sec)
+
+    async def clear(self) -> None:
+        redis_client = get_redis()
+        # Find all keys matching key_prefix and delete them
+        pattern = f"{self.key_prefix}:*"
+        keys = await redis_client.keys(pattern)
+        if keys:
+            await redis_client.delete(*keys)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Rate Limiting Strategies
+# ──────────────────────────────────────────────────────────────────────────────
+
+class RateLimitStrategy(ABC):
+    @abstractmethod
+    async def check(
+        self,
+        key: str,
+        limit: int,
+        window_sec: int,
+        storage: RateLimitStorage,
+        detail: str
+    ) -> None:
+        """Check the limit and record a hit if under limit. Raises 429 if exceeded."""
+        pass
+
+
+class SlidingWindowStrategy(RateLimitStrategy):
+    async def check(
+        self,
+        key: str,
+        limit: int,
+        window_sec: int,
+        storage: RateLimitStorage,
+        detail: str
+    ) -> None:
+        hits = await storage.get_hits(key, window_sec)
+        if len(hits) >= limit:
+            logger.warning(f"Rate limit exceeded (SlidingWindow) for key: {key} (limit={limit}, window={window_sec}s)")
+            raise HTTPException(status_code=429, detail=detail)
+        
+        await storage.record_hit(key, time.time(), window_sec)
+
+
+class FixedWindowStrategy(RateLimitStrategy):
+    async def check(
+        self,
+        key: str,
+        limit: int,
+        window_sec: int,
+        storage: RateLimitStorage,
+        detail: str
+    ) -> None:
+        now = time.time()
+        # Segment time into fixed windows
+        window_start = int(now // window_sec)
+        fixed_key = f"{key}:fixed:{window_start}"
+        
+        hits = await storage.get_hits(fixed_key, window_sec)
+        if len(hits) >= limit:
+            logger.warning(f"Rate limit exceeded (FixedWindow) for key: {key} (limit={limit}, window={window_sec}s)")
+            raise HTTPException(status_code=429, detail=detail)
+        
+        await storage.record_hit(fixed_key, now, window_sec)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Central Controller
+# ──────────────────────────────────────────────────────────────────────────────
+
+class RateLimiter:
+    def __init__(
+        self,
+        limit: int,
+        window_sec: int,
+        storage: RateLimitStorage,
+        strategy: RateLimitStrategy,
+        detail: str = "Rate limit exceeded. Please try again later."
+    ):
+        self.limit = limit
+        self.window_sec = window_sec
+        self.storage = storage
+        self.strategy = strategy
+        self.detail = detail
+
+    async def check(self, key: str) -> None:
+        await self.strategy.check(key, self.limit, self.window_sec, self.storage, self.detail)

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -5,6 +5,7 @@ Rate Limiting for ZizkaDB
 import time
 import logging
 import threading
+import uuid
 from abc import ABC, abstractmethod
 from fastapi import HTTPException
 from db.connection import get_redis
@@ -169,13 +170,21 @@ class RedisStorage(RateLimitStorage):
     async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
         """
         Record a hit timestamp in Redis using a sorted set (ZSET).
-        Appends the thread identifier to make each entry unique.
+        Appends a UUID to make each entry unique.
         """
         redis_client = get_redis()
         rkey = self._get_redis_key(key)
         
-        # Add hit (use stringified timestamp as value to avoid duplication in same microsecond)
-        val = f"{timestamp}:{threading.get_ident()}"
+        # Add hit. A UUID is used (not e.g. threading.get_ident()) because this
+        # is async code: every concurrent request on a given worker runs on the
+        # same event loop thread, so thread-identity is constant and does not
+        # disambiguate concurrent hits. Two concurrent calls with an identical
+        # `val` string would collide as the same ZSET member, and ZADD treats a
+        # repeated member as an update rather than a new entry -- silently
+        # undercounting real hits and weakening the rate limit under concurrent
+        # load (verified: 50 concurrent hits collapsed to 1 stored entry before
+        # this fix).
+        val = f"{timestamp}:{uuid.uuid4().hex}"
         await redis_client.zadd(rkey, {val: timestamp})
         
         # Set expiry to prevent memory leak

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 # ──────────────────────────────────────────────────────────────────────────────
 
 class RateLimitStorage(ABC):
+    """
+    Abstract base class representing the storage backend for rate limiting hits.
+    """
     @abstractmethod
     async def get_hits(self, key: str, window_sec: int) -> list[float]:
         """Retrieve all active hit timestamps for key within the window."""
@@ -33,6 +36,10 @@ class RateLimitStorage(ABC):
 
 
 class InMemoryStorage(RateLimitStorage):
+    """
+    An in-memory thread-safe storage implementation for tracking rate limit hits.
+    Supports lazy or periodic cleanup of expired timestamps to prevent memory leaks.
+    """
     def __init__(
         self,
         enable_cleanup: bool = False,
@@ -40,6 +47,15 @@ class InMemoryStorage(RateLimitStorage):
         default_ttl_sec: float = 3600.0,
         cleanup_interval_sec: float = 60.0
     ):
+        """
+        Initialize the in-memory storage.
+
+        Args:
+            enable_cleanup: Enable garbage collection of expired keys.
+            cleanup_method: 'lazy' to prune on retrieval, or 'periodic' to use a background thread.
+            default_ttl_sec: Maximum lifespan of keys in seconds.
+            cleanup_interval_sec: Interval in seconds for the periodic GC loop.
+        """
         self._data: dict[str, list[float]] = {}
         self._lock = threading.Lock()
         self.enable_cleanup = enable_cleanup
@@ -54,15 +70,18 @@ class InMemoryStorage(RateLimitStorage):
             self._start_gc_thread()
 
     def _start_gc_thread(self):
+        """Start the background thread for periodic garbage collection."""
         self._gc_thread = threading.Thread(target=self._gc_loop, daemon=True, name="InMemoryStorage-GC")
         self._gc_thread.start()
         logger.info("Started periodic background garbage collection thread for InMemoryStorage")
 
     def _gc_loop(self):
+        """Loop run by the GC thread, executing prune_expired_keys periodically."""
         while not self._stop_gc.wait(self.cleanup_interval_sec):
             self.prune_expired_keys()
 
     def prune_expired_keys(self):
+        """Prune keys from storage whose hit lists contain no active timestamps."""
         now = time.time()
         cutoff = now - self.default_ttl_sec
         pruned_count = 0
@@ -78,6 +97,10 @@ class InMemoryStorage(RateLimitStorage):
             logger.debug(f"InMemoryStorage GC pruned {pruned_count} keys")
 
     async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        """
+        Retrieve all active hit timestamps for a key within the specified window.
+        Optionally performs lazy pruning if cleanup is enabled.
+        """
         now = time.time()
         cutoff = now - window_sec
         with self._lock:
@@ -90,12 +113,14 @@ class InMemoryStorage(RateLimitStorage):
             return hits
 
     async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        """Record a hit timestamp for the given key in memory."""
         with self._lock:
             if key not in self._data:
                 self._data[key] = []
             self._data[key].append(timestamp)
 
     async def clear(self) -> None:
+        """Clear all rate limit entries from memory."""
         with self._lock:
             self._data.clear()
 
@@ -107,13 +132,28 @@ class InMemoryStorage(RateLimitStorage):
 
 
 class RedisStorage(RateLimitStorage):
+    """
+    A Redis-backed storage implementation for tracking rate limit hits.
+    Uses sorted sets (ZSET) to store hit timestamps and enforce expiry.
+    """
     def __init__(self, key_prefix: str = "ratelimit"):
+        """
+        Initialize the Redis storage.
+
+        Args:
+            key_prefix: Prefix prepended to all Redis keys to isolate rate limiting data.
+        """
         self.key_prefix = key_prefix
 
     def _get_redis_key(self, key: str) -> str:
+        """Generate a prefixed Redis key string."""
         return f"{self.key_prefix}:{key}"
 
     async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        """
+        Retrieve active hit timestamps from Redis for the key within the window.
+        Also automatically prunes expired timestamps from the sorted set.
+        """
         redis_client = get_redis()
         rkey = self._get_redis_key(key)
         now = time.time()
@@ -127,6 +167,10 @@ class RedisStorage(RateLimitStorage):
         return [score for _, score in results]
 
     async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        """
+        Record a hit timestamp in Redis using a sorted set (ZSET).
+        Appends the thread identifier to make each entry unique.
+        """
         redis_client = get_redis()
         rkey = self._get_redis_key(key)
         
@@ -138,6 +182,7 @@ class RedisStorage(RateLimitStorage):
         await redis_client.expire(rkey, window_sec)
 
     async def clear(self) -> None:
+        """Remove all rate limit keys matching the configured prefix from Redis."""
         redis_client = get_redis()
         # Find all keys matching key_prefix and delete them
         pattern = f"{self.key_prefix}:*"
@@ -151,6 +196,9 @@ class RedisStorage(RateLimitStorage):
 # ──────────────────────────────────────────────────────────────────────────────
 
 class RateLimitStrategy(ABC):
+    """
+    Abstract base class for rate limiting algorithms/strategies.
+    """
     @abstractmethod
     async def check(
         self,
@@ -165,6 +213,10 @@ class RateLimitStrategy(ABC):
 
 
 class SlidingWindowStrategy(RateLimitStrategy):
+    """
+    Sliding Window rate limiting strategy.
+    Measures requests dynamically over the preceding sliding time window.
+    """
     async def check(
         self,
         key: str,
@@ -173,6 +225,10 @@ class SlidingWindowStrategy(RateLimitStrategy):
         storage: RateLimitStorage,
         detail: str
     ) -> None:
+        """
+        Check the limit using a sliding window algorithm.
+        Raises HTTPException 429 if the request count exceeds the limit.
+        """
         hits = await storage.get_hits(key, window_sec)
         if len(hits) >= limit:
             logger.warning(f"Rate limit exceeded (SlidingWindow) for key: {key} (limit={limit}, window={window_sec}s)")
@@ -182,6 +238,10 @@ class SlidingWindowStrategy(RateLimitStrategy):
 
 
 class FixedWindowStrategy(RateLimitStrategy):
+    """
+    Fixed Window rate limiting strategy.
+    Divides time into fixed buckets (e.g., calendar hours) and limits requests per bucket.
+    """
     async def check(
         self,
         key: str,
@@ -190,6 +250,10 @@ class FixedWindowStrategy(RateLimitStrategy):
         storage: RateLimitStorage,
         detail: str
     ) -> None:
+        """
+        Check the limit using a fixed window algorithm.
+        Raises HTTPException 429 if the request count in the current window exceeds the limit.
+        """
         now = time.time()
         # Segment time into fixed windows
         window_start = int(now // window_sec)
@@ -208,6 +272,10 @@ class FixedWindowStrategy(RateLimitStrategy):
 # ──────────────────────────────────────────────────────────────────────────────
 
 class RateLimiter:
+    """
+    Central controller class that coordinates rate limiting checks.
+    Combines a specific limit, window duration, storage engine, and algorithm strategy.
+    """
     def __init__(
         self,
         limit: int,
@@ -216,6 +284,16 @@ class RateLimiter:
         strategy: RateLimitStrategy,
         detail: str = "Rate limit exceeded. Please try again later."
     ):
+        """
+        Initialize the rate limiter controller.
+
+        Args:
+            limit: Maximum allowed requests within the window.
+            window_sec: Length of the rate limiting window in seconds.
+            storage: Storage backend (e.g., InMemoryStorage, RedisStorage).
+            strategy: Limiting strategy (e.g., SlidingWindowStrategy, FixedWindowStrategy).
+            detail: Error message detail to raise on failure.
+        """
         self.limit = limit
         self.window_sec = window_sec
         self.storage = storage
@@ -223,4 +301,8 @@ class RateLimiter:
         self.detail = detail
 
     async def check(self, key: str) -> None:
+        """
+        Check if the key is within the rate limit.
+        Raises HTTPException 429 if the limit is exceeded.
+        """
         await self.strategy.check(key, self.limit, self.window_sec, self.storage, self.detail)

--- a/core/tests/test_auth_flow.py
+++ b/core/tests/test_auth_flow.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from main import app
-from api.auth import _otp_rate
+from api.auth import otp_limiter
 from services.auth import (
     _LOGIN_NO_ACCOUNT,
     _SIGNUP_ALREADY_REGISTERED,
@@ -24,7 +24,8 @@ TEST_OTP_ROW = {"otp_id": "otp-1", "otp_hash": TEST_OTP_HASH}
 
 class TestRequestOtpIntent:
     def setup_method(self):
-        _otp_rate.clear()
+        import asyncio
+        asyncio.run(otp_limiter.storage.clear())
 
     @patch("api.auth.request_otp", new_callable=AsyncMock)
     @patch("api.auth.email_exists", new_callable=AsyncMock)

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -4,8 +4,10 @@ Tests cover OTP request limits, Demo request limits, and Community board limits.
 """
 
 import asyncio
+import time
 from unittest.mock import patch, AsyncMock, MagicMock
 from datetime import datetime, timezone
+import fakeredis.aioredis
 from fastapi.testclient import TestClient
 from main import app
 from api.auth import otp_limiter, _OTP_RATE_MAX, _OTP_RATE_WINDOW_SEC
@@ -422,4 +424,42 @@ class TestRateLimiterFeatures:
         assert hits == [1000.0]
         mock_redis.zremrangebyscore.assert_called_once()
         mock_redis.zrange.assert_called_once()
+
+    @patch("services.rate_limiter.get_redis")
+    def test_redis_storage_concurrent_hits_not_collided(self, mock_get_redis):
+        """Regression test: RedisStorage.record_hit() must give each
+        concurrent call a genuinely unique ZSET member. Uses fakeredis
+        (a real ZADD implementation, not a MagicMock) because a plain mock
+        can't reproduce the collision this bug depended on -- it only
+        shows up when duplicate member strings actually collapse in a
+        real sorted set.
+
+        Regression coverage for a bug where record_hit() built the
+        member string from `threading.get_ident()`, which is constant
+        for every request on the same asyncio event loop thread. Two
+        concurrent hits at (nearly) the same timestamp therefore produced
+        an identical member string, and ZADD silently treated the second
+        call as an update to the first rather than a new entry --
+        undercounting real request volume and letting far more requests
+        through than the configured limit.
+        """
+        fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        mock_get_redis.return_value = fake_redis
+
+        storage = RedisStorage(key_prefix="ratelimit-concurrency-test")
+
+        async def fire_concurrent_hits(n: int, timestamp: float) -> int:
+            await asyncio.gather(*(
+                storage.record_hit("concurrent-key", timestamp, 60) for _ in range(n)
+            ))
+            hits = await storage.get_hits("concurrent-key", 60)
+            return len(hits)
+
+        n_requests = 50
+        recorded = asyncio.run(fire_concurrent_hits(n_requests, time.time()))
+        assert recorded == n_requests, (
+            f"expected all {n_requests} concurrent hits to be recorded distinctly, "
+            f"got {recorded} -- record_hit()'s member string is colliding under "
+            f"concurrency again"
+        )
 

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -3,14 +3,20 @@ Unit tests for ZizkaDB Core API rate limiters.
 Tests cover OTP request limits, Demo request limits, and Community board limits.
 """
 
+import asyncio
 from unittest.mock import patch, AsyncMock, MagicMock
 from datetime import datetime, timezone
 from fastapi.testclient import TestClient
-
 from main import app
-from api.auth import _otp_rate, _OTP_RATE_MAX, _OTP_RATE_WINDOW_SEC
-from api.demo_requests import _rate as demo_rate, RATE_MAX as DEMO_MAX, RATE_WINDOW_SEC as DEMO_WINDOW
-from api.community import _rate as community_rate, RATE_MAX_POSTS as COMM_MAX, RATE_WINDOW_SEC as COMM_WINDOW
+from api.auth import otp_limiter, _OTP_RATE_MAX, _OTP_RATE_WINDOW_SEC
+from api.demo_requests import demo_limiter, RATE_MAX as DEMO_MAX, RATE_WINDOW_SEC as DEMO_WINDOW
+from api.community import community_limiter, RATE_MAX_POSTS as COMM_MAX, RATE_WINDOW_SEC as COMM_WINDOW
+from services.rate_limiter import (
+    InMemoryStorage,
+    RedisStorage,
+    FixedWindowStrategy,
+    RateLimiter
+)
 
 client = TestClient(app)
 
@@ -21,8 +27,8 @@ client = TestClient(app)
 
 class TestOTPRateLimiting:
     def setup_method(self):
-        # Clear the in-memory rate dictionary before each test
-        _otp_rate.clear()
+        # Clear the centralized storage before each test
+        asyncio.run(otp_limiter.storage.clear())
 
     @patch("api.auth.email_exists", new_callable=AsyncMock)
     @patch("api.auth.request_otp", new_callable=AsyncMock)
@@ -109,7 +115,7 @@ class TestOTPRateLimiting:
 
 class TestDemoRequestsRateLimiting:
     def setup_method(self):
-        demo_rate.clear()
+        asyncio.run(demo_limiter.storage.clear())
 
     @patch("api.demo_requests.get_pool")
     def test_demo_requests_under_limit(self, mock_get_pool):
@@ -263,7 +269,7 @@ class TestDemoRequestsRateLimiting:
 
 class TestCommunityRateLimiting:
     def setup_method(self):
-        community_rate.clear()
+        asyncio.run(community_limiter.storage.clear())
 
     @patch("api.community.get_pool")
     def test_community_posts_under_limit(self, mock_get_pool):
@@ -348,3 +354,72 @@ class TestCommunityRateLimiting:
                 "body": "This is a detailed description of my question."
             })
             assert response.status_code == 201
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Centralized Rate Limiter Features Tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestRateLimiterFeatures:
+    def test_in_memory_lazy_cleanup(self):
+        storage = InMemoryStorage(enable_cleanup=True, cleanup_method="lazy")
+        asyncio.run(storage.record_hit("test-key", 1000.0, 60))
+        assert "test-key" in storage._data
+        
+        hits = asyncio.run(storage.get_hits("test-key", window_sec=0))
+        assert hits == []
+        assert "test-key" not in storage._data
+
+    def test_in_memory_periodic_cleanup(self):
+        import time
+        storage = InMemoryStorage(
+            enable_cleanup=True,
+            cleanup_method="periodic",
+            default_ttl_sec=0.01,
+            cleanup_interval_sec=0.01
+        )
+        asyncio.run(storage.record_hit("test-key", time.time(), 60))
+        assert "test-key" in storage._data
+        
+        time.sleep(0.08)
+        assert "test-key" not in storage._data
+        storage.close()
+
+    def test_fixed_window_strategy(self):
+        storage = InMemoryStorage()
+        limiter = RateLimiter(
+            limit=2,
+            window_sec=60,
+            storage=storage,
+            strategy=FixedWindowStrategy()
+        )
+        
+        asyncio.run(limiter.check("user-1"))
+        asyncio.run(limiter.check("user-1"))
+        
+        from fastapi import HTTPException
+        import pytest
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(limiter.check("user-1"))
+        assert exc.value.status_code == 429
+
+    @patch("services.rate_limiter.get_redis")
+    def test_redis_storage(self, mock_get_redis):
+        mock_redis = MagicMock()
+        mock_redis.zremrangebyscore = AsyncMock()
+        mock_redis.zrange = AsyncMock(return_value=[(b"1000.0:123", 1000.0)])
+        mock_redis.zadd = AsyncMock()
+        mock_redis.expire = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+        
+        storage = RedisStorage(key_prefix="ratelimit-test")
+        
+        asyncio.run(storage.record_hit("user-1", 1000.0, 60))
+        mock_redis.zadd.assert_called_once()
+        mock_redis.expire.assert_called_once()
+        
+        hits = asyncio.run(storage.get_hits("user-1", 60))
+        assert hits == [1000.0]
+        mock_redis.zremrangebyscore.assert_called_once()
+        mock_redis.zrange.assert_called_once()
+


### PR DESCRIPTION
### 1. What changed and why

Added a centralized, plug-and-play rate limiting strategy (`core/services/rate_limiter.py`) containing a unified `RateLimiter` controller, abstract storage and strategy interfaces, `InMemoryStorage` (supporting thread-safe locking and optional lazy or periodic background thread garbage collection), `RedisStorage` (utilizing Redis sorted sets and TTLs), `SlidingWindowStrategy`, and `FixedWindowStrategy`.
Integrated the centralized `RateLimiter` instances into the core FastAPI routes:
* OTP Login Rate Limiting (`/v1/auth/request-otp`)
* Demo Requests Rate Limiting (`/v1/demo-requests`)
* Community Post Rate Limiting (`/v1/community/posts`)
* Admin OTP Request Rate Limiting (`/v1/admin/request-otp`)
Updated the rate limiting test suite (`core/tests/test_rate_limiting.py`) to decouple testing assertions from internal endpoint dictionary attributes, clearing states via the unified `limiter.storage.clear()` interface instead.
Added 4 new test cases covering:
* `InMemoryStorage` lazy garbage collection eviction.
* `InMemoryStorage` periodic scanning thread eviction.
* `FixedWindowStrategy` boundary behavior.
* Mocked `RedisStorage` connectivity and operations.

### 2. How to test
Run pytest inside the virtual environment:
```bash
cd core
.venv/Scripts/pytest tests/test_rate_limiting.py
```

All 11 + 4 (extra) tests pass successfully.

### 3. Areas touched
* **API / Core Services** (core/services/rate_limiter.py)
* **API Routes** (core/api/auth.py, core/api/demo_requests.py, core/api/community.py, core/api/admin.py)
* **API Tests** (core/tests/test_rate_limiting.py)

### 4. Breaking changes
* None

### 5. Link to related issue(s)
* N/A
