### PR TITLE
Feat/api key plan limits

### DIFF
--- a/.cursor/rules/backend-dashboard-contract.mdc
+++ b/.cursor/rules/backend-dashboard-contract.mdc
@@ -1,0 +1,24 @@
+---
+description: Backend contract the ZizkaDB dashboard depends on — invariants to preserve and KB to keep in sync
+globs: core/api/**,core/services/**,core/db/**
+alwaysApply: false
+---
+
+# Backend ↔ Dashboard Contract
+
+The dashboard (`dashboard/`) is a client of this FastAPI backend. Before changing these files, check how the dashboard consumes them: `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` — endpoint map (§17.3), auth model (§17.2), backend state machine (§18), data model (§21).
+
+## Contracts the dashboard relies on (do not break silently)
+- **`verify-otp` response shape** (`core/api/auth.py`): `{access_token, token_type, requires_plan_selection, requires_checkout, has_access, plan}`. The login/signup funnel branches on these fields.
+- **`billing_status_payload` shape** (`core/services/billing.py`): `{enforced, has_access, requires_plan_selection, requires_checkout, subscription_status, trial_ends_at, plan, stripe_publishable_key?, trial_days?}`. Consumed by `SubscriptionGate`, `TenantPlanBanner`, checkout/success.
+- **Billing state machine** (`billing.py`): `ACCESS_STATUSES = {trialing, active}`; `pending_checkout` = no access until Stripe completes. Changing statuses/thresholds changes who can enter the dashboard.
+- **Auth resolution** (`core/api/deps.py::get_tenant`): JWT vs API key vs dev key; `assert_agent_allowed` (403) for agent-scoped keys; account routes are JWT-only (`require_dashboard_session`). `get_tenant` does NOT check subscription — access is a client-side gate.
+- **Event schema** (`core/api/events.py`, `event_write.py`): `POST /v1/events` is written by SDKs/MCP/integrations AND read back by the dashboard. Field renames affect both sides.
+- **Route paths/prefixes** (`core/main.py`): the dashboard calls fixed `/v1/...` paths via `dashboard/lib/api.ts`. Renaming a route breaks the client.
+- **API key plan limits** (`core/services/plan_limits.py` = single source of truth; `core/services/api_keys.py::assert_and_reserve_api_key_slot`): active keys per tenant capped by plan (Pro 3 / Team 10; else unlimited, incl. self-host since `billing_enforced()` is checked first). Guard runs in a per-tenant advisory-locked txn before insert on `create_api_key`, `create_agent_api_key`, `create_agent`; all three are now `require_dashboard_session` (JWT-only). Behind kill switch `API_KEY_LIMITS_ENFORCED` (default OFF). Usage: `GET /v1/auth/api-keys/usage` → `{plan, limit, used, unlimited, at_limit}`. Limit breach = `409 detail={msg, code, plan, limit, used}`. `count_active_api_keys` is the ONE counter for guard + usage — keep them using it to avoid drift.
+
+## Data model
+Schema in `core/db/schema.sql` + `migrations/002-006` + runtime DDL in `core/db/connection.py`. All billing state lives on `users`. Qdrant `agent_events` is 1536-dim COSINE; embeddings are dual-written to Postgres `events.embedding` + Qdrant. See §21.
+
+## Keep the KB in sync
+If you change any contract above, a route, the billing/auth logic, or the DB schema, update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` (§17.3, §18, §21) in the same change — and the matching `dashboard/lib/api.ts` types/callers if the response shape changed.

--- a/.cursor/rules/dashboard.mdc
+++ b/.cursor/rules/dashboard.mdc
@@ -1,0 +1,31 @@
+---
+description: ZizkaDB dashboard context, conventions, and gotchas for future work
+globs: dashboard/**
+alwaysApply: false
+---
+
+# ZizkaDB Dashboard — Agent Guide
+
+**Read first:** `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` is the source of truth (has a Table of Contents). Consult it before implementing features, fixing bugs, or reasoning about flows. Section map: architecture (§1-3), funnel (§5), business rules (§7), API layer (§8), touch points (§17), backend state machine (§18), per-screen behavior (§19), marketing/community/docs/admin surfaces (§20), data model / DB schema (§21), glossary (§22).
+
+## Conventions (match these)
+- Next.js 14 App Router. Interactive pages are Client Components (`'use client'`). TS `strict`, `@/*` alias. No Prettier — match surrounding style (2-space, single quotes, no semicolons).
+- **All API calls go through `lib/api.ts`** (`apiFetch` injects auth + normalizes errors). No React Query/SWR/Redux/Zustand/Context — local `useState`/`useEffect` only.
+- Guard every async effect with a `let cancelled = false` flag; check it before `setState` (see `SubscriptionGate`, `checkout`, `success`).
+- Redirect guards: render the page's `*Fallback` loader while a redirect is pending; never render real UI before guard checks resolve (see the `checked` gate in `signup/page.tsx`).
+- Wrap `useSearchParams` pages in `<Suspense>` (Next CSR bailout).
+- Errors: `apiFetch` throws a normalized `Error`; catch and render into a local `error` string.
+
+## Critical gotchas (do not break)
+- **Billing is a client-side UX gate, not a security boundary.** `get_tenant` (backend) does NOT check subscription; a `pending_checkout` JWT can still hit `/v1/agents` and `/v1/events`. Access is enforced by `SubscriptionGate` + `has_access` only. Account routes are the exception (JWT-only).
+- **Auth split:** middleware reads the access-token cookie; client code reads `localStorage`. The refresh token is an HttpOnly cookie (backend). Keep both cookie + localStorage in sync via `setToken`/`clearToken`.
+- **Funnel state** lives in `sessionStorage` (`signup_plan`, `signup_consent_gdpr`, `signup_consent_marketing`); cleared after OTP verify.
+- Routing helpers `postAuthRedirect` / `billingGateRedirect` (`lib/api.ts`) are the single source for gated redirects — reuse them.
+- Self-host `NEXT_PUBLIC_DEV_MODE=true` bypasses the billing gate, hides the plan banner, and enables dev-token login.
+- **API key limits (§7):** active keys per tenant are capped by plan (Pro 3 / Team 10; else unlimited) and count ALL keys (tenant-wide + agent-scoped), so each agent consumes a slot on Pro/Team. UI reads `useApiKeyQuota` (`GET /v1/auth/api-keys/usage`) — never hardcode limits; render `<ApiKeyUsage>` and disable create at `at_limit`. Refresh the quota after every create/delete (including agent create/delete). Backend is the real guard; enforcement is behind `API_KEY_LIMITS_ENFORCED` (default OFF).
+
+## Testing / safety
+- There are **no frontend tests** and `apiFetch` is untyped. Prefer adding tests for pure helpers (`postAuthRedirect`, `billingGateRedirect`, funnel guards) when touching them, and type new `apiFetch` responses.
+
+## Keep the KB in sync
+If you change billing/auth/the signup funnel, `lib/api.ts`, routes, a backend endpoint the dashboard calls, or the DB schema, **update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md`** (esp. §7, §8, §17.3, §18, §19-21) in the same change. Line numbers there are best-effort — verify the cited file, prefer symbol names over line numbers.

--- a/core/api/account.py
+++ b/core/api/account.py
@@ -4,35 +4,17 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException, Security, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi import APIRouter, Depends, HTTPException
 
-from api.deps import resolve_api_key_tenant
-from services.auth import decode_access_token
+from api.deps import dashboard_session_dependency
 from services.account import account_options, delete_managed_account, grant_retention_trial
 
 router = APIRouter()
 log = logging.getLogger(__name__)
-bearer = HTTPBearer()
 
-
-async def require_dashboard_session(
-    credentials: HTTPAuthorizationCredentials = Security(bearer),
-) -> dict:
-    token = credentials.credentials
-    if await resolve_api_key_tenant(token):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Sign in to the dashboard to manage your account",
-        )
-    try:
-        payload = decode_access_token(token)
-        return {
-            "tenant_id": payload["tenant_id"],
-            "user_id": payload["sub"],
-        }
-    except Exception:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+require_dashboard_session = dashboard_session_dependency(
+    "Sign in to the dashboard to manage your account"
+)
 
 
 @router.get("/options")

--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -4,9 +4,10 @@ import re
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from api.deps import get_tenant
+from api.deps import get_tenant, require_dashboard_session
 from db.connection import get_pool
 from services.api_keys import (
+    assert_and_reserve_api_key_slot,
     create_api_key_record,
     list_api_keys_for_agent,
     revoke_api_key_record,
@@ -74,35 +75,44 @@ async def list_agents(tenant: dict = Depends(get_tenant)):
 @router.post("", status_code=201)
 async def create_agent(
     body: CreateAgentBody,
-    tenant: dict = Depends(get_tenant),
+    session: dict = Depends(require_dashboard_session),
 ):
-    """Create an agent and its first API key (shown once)."""
+    """Create an agent and its first API key (shown once).
+
+    Agent + first key are created in one transaction so a plan-limit rejection
+    (the auto-created key counts against the quota) rolls back the agent instead
+    of leaving an agent with no key.
+    """
     agent_id = _validate_agent_id(body.agent_id)
     pool = get_pool()
-    tenant_id = tenant["tenant_id"]
+    tenant_id = session["tenant_id"]
 
-    existing = await pool.fetchrow(
-        "SELECT 1 FROM agents WHERE tenant_id = $1 AND agent_id = $2",
-        tenant_id, agent_id,
-    )
-    if existing:
-        raise HTTPException(status_code=409, detail="Agent already exists")
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            existing = await conn.fetchrow(
+                "SELECT 1 FROM agents WHERE tenant_id = $1 AND agent_id = $2",
+                tenant_id, agent_id,
+            )
+            if existing:
+                raise HTTPException(status_code=409, detail="Agent already exists")
 
-    await pool.execute(
-        """
-        INSERT INTO agents (agent_id, tenant_id, metadata)
-        VALUES ($1, $2, $3::jsonb)
-        """,
-        agent_id, tenant_id, json.dumps(body.metadata or {}),
-    )
+            await assert_and_reserve_api_key_slot(conn, tenant_id=tenant_id)
 
-    key_name = body.key_name or f"{agent_id} production"
-    api_key = await create_api_key_record(
-        pool,
-        tenant_id=tenant_id,
-        name=key_name,
-        agent_id=agent_id,
-    )
+            await conn.execute(
+                """
+                INSERT INTO agents (agent_id, tenant_id, metadata)
+                VALUES ($1, $2, $3::jsonb)
+                """,
+                agent_id, tenant_id, json.dumps(body.metadata or {}),
+            )
+
+            key_name = body.key_name or f"{agent_id} production"
+            api_key = await create_api_key_record(
+                conn,
+                tenant_id=tenant_id,
+                name=key_name,
+                agent_id=agent_id,
+            )
 
     return {
         "agent": agent_id,
@@ -200,25 +210,29 @@ async def list_agent_api_keys(
 async def create_agent_api_key(
     agent_id: str,
     body: CreateAgentKeyBody,
-    tenant: dict = Depends(get_tenant),
+    session: dict = Depends(require_dashboard_session),
 ):
     agent_id = _validate_agent_id(agent_id)
     pool = get_pool()
-    tenant_id = tenant["tenant_id"]
+    tenant_id = session["tenant_id"]
 
-    exists = await pool.fetchrow(
-        "SELECT 1 FROM agents WHERE tenant_id = $1 AND agent_id = $2",
-        tenant_id, agent_id,
-    )
-    if not exists:
-        raise HTTPException(status_code=404, detail="Agent not found")
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            exists = await conn.fetchrow(
+                "SELECT 1 FROM agents WHERE tenant_id = $1 AND agent_id = $2",
+                tenant_id, agent_id,
+            )
+            if not exists:
+                raise HTTPException(status_code=404, detail="Agent not found")
 
-    return await create_api_key_record(
-        pool,
-        tenant_id=tenant_id,
-        name=body.name or f"{agent_id} key",
-        agent_id=agent_id,
-    )
+            await assert_and_reserve_api_key_slot(conn, tenant_id=tenant_id)
+
+            return await create_api_key_record(
+                conn,
+                tenant_id=tenant_id,
+                name=body.name or f"{agent_id} key",
+                agent_id=agent_id,
+            )
 
 
 @router.delete("/{agent_id}/api-keys/{key_id}")

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -6,8 +6,13 @@ from typing import Literal
 from fastapi import APIRouter, HTTPException, Response
 from pydantic import BaseModel, EmailStr
 from services.auth import request_otp, verify_otp, _issue_tokens, email_exists
-from services.api_keys import create_api_key_record, revoke_api_key_record
-from api.deps import get_tenant
+from services.api_keys import (
+    assert_and_reserve_api_key_slot,
+    count_active_api_keys,
+    create_api_key_record,
+    revoke_api_key_record,
+)
+from api.deps import get_tenant, require_dashboard_session
 from fastapi import Depends
 from db.connection import get_pool
 from services.event_write import write_event
@@ -124,16 +129,54 @@ async def verify_otp_route(body: VerifyOTPBody, response: Response):
 @router.post("/api-keys")
 async def create_api_key(
     body: CreateAPIKeyBody,
-    tenant: dict = Depends(get_tenant),
+    session: dict = Depends(require_dashboard_session),
 ):
     """Tenant-wide key (no agent scope). Use for multi-agent apps. Per-agent keys: POST /v1/agents/{id}/api-keys."""
     pool = get_pool()
-    return await create_api_key_record(
-        pool,
-        tenant_id=tenant["tenant_id"],
-        name=body.name,
-        agent_id=None,
-    )
+    tenant_id = session["tenant_id"]
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await assert_and_reserve_api_key_slot(conn, tenant_id=tenant_id)
+            return await create_api_key_record(
+                conn,
+                tenant_id=tenant_id,
+                name=body.name,
+                agent_id=None,
+            )
+
+
+@router.get("/api-keys/usage")
+async def api_keys_usage(session: dict = Depends(require_dashboard_session)):
+    """Account-wide API key quota for the current plan.
+
+    Returns unlimited whenever enforcement is off or the plan is uncapped, so the
+    dashboard UI stays consistent with the backend guard. Fail-open on lookup error.
+    """
+    from services.billing import billing_enforced, fetch_tenant_plan
+    from services.plan_limits import api_key_limit_for_plan, limits_enforced
+
+    pool = get_pool()
+    tenant_id = session["tenant_id"]
+    used = await count_active_api_keys(pool, tenant_id)
+
+    plan: str | None = None
+    limit: int | None = None
+    if limits_enforced():
+        try:
+            plan = await fetch_tenant_plan(pool, tenant_id)
+            limit = api_key_limit_for_plan(plan, billing_enforced=billing_enforced())
+        except Exception as e:
+            log.warning("api-key usage: plan lookup failed for tenant %s: %s", tenant_id, e)
+            limit = None
+
+    unlimited = limit is None
+    return {
+        "plan": plan,
+        "limit": limit,
+        "used": used,
+        "unlimited": unlimited,
+        "at_limit": (not unlimited) and used >= limit,
+    }
 
 
 @router.delete("/api-keys/{key_id}")

--- a/core/api/deps.py
+++ b/core/api/deps.py
@@ -67,6 +67,48 @@ def _dev_key_accepted(token: str) -> bool:
     return token in _KNOWN_DEV_KEYS
 
 
+def dashboard_session_dependency(forbid_detail: str):
+    """Build a JWT-only FastAPI dependency for dashboard-managed actions.
+
+    Rejects API-key auth so a scoped agent key cannot perform dashboard-only
+    actions (e.g. minting new keys), and guarantees a ``user_id``/plan context.
+    ``forbid_detail`` is the 403 message shown when an API key is used instead of
+    a dashboard session. Returns a dependency that yields ``{tenant_id, user_id}``.
+
+    Single implementation reused by every JWT-only router (auth, agents, account,
+    settings) so the auth logic can never drift between them.
+    """
+
+    async def _require_dashboard_session(
+        credentials: HTTPAuthorizationCredentials = Security(bearer),
+    ) -> dict:
+        token = credentials.credentials
+        if await resolve_api_key_tenant(token):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=forbid_detail,
+            )
+        try:
+            payload = decode_access_token(token)
+            return {
+                "tenant_id": payload["tenant_id"],
+                "user_id": payload["sub"],
+            }
+        except Exception:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid token",
+            )
+
+    return _require_dashboard_session
+
+
+# Default dependency for API-key management routes (auth, agents).
+require_dashboard_session = dashboard_session_dependency(
+    "Sign in to the dashboard to manage API keys"
+)
+
+
 async def get_tenant(
     credentials: HTTPAuthorizationCredentials = Security(bearer),
 ) -> dict:

--- a/core/api/settings.py
+++ b/core/api/settings.py
@@ -1,11 +1,9 @@
 """Dashboard settings — embedding provider/model (managed cloud)."""
 
-from fastapi import APIRouter, Depends, HTTPException, Security, status
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from api.deps import get_tenant, resolve_api_key_tenant
-from services.auth import decode_access_token
+from api.deps import dashboard_session_dependency, get_tenant
 from services.embedding_config import (
     embedding_config_for_response,
     get_tenant_embedding_config,
@@ -14,27 +12,11 @@ from services.embedding_config import (
 )
 
 router = APIRouter()
-bearer = HTTPBearer()
 
-
-async def require_dashboard_session(
-    credentials: HTTPAuthorizationCredentials = Security(bearer),
-) -> dict:
-    """JWT only — API keys cannot change tenant embedding settings."""
-    token = credentials.credentials
-    if await resolve_api_key_tenant(token):
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
-            detail="Sign in to the dashboard to manage embedding settings",
-        )
-    try:
-        payload = decode_access_token(token)
-        return {
-            "tenant_id": payload["tenant_id"],
-            "user_id": payload["sub"],
-        }
-    except Exception:
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+# JWT only — API keys cannot change tenant embedding settings.
+require_dashboard_session = dashboard_session_dependency(
+    "Sign in to the dashboard to manage embedding settings"
+)
 
 
 class UpdateEmbeddingsBody(BaseModel):

--- a/core/services/api_keys.py
+++ b/core/services/api_keys.py
@@ -2,7 +2,80 @@
 
 from __future__ import annotations
 
+import logging
+
+from fastapi import HTTPException
+
 from services.auth import generate_api_key
+from services.billing import billing_enforced, fetch_tenant_plan
+from services.plan_limits import api_key_limit_for_plan, limits_enforced
+
+log = logging.getLogger(__name__)
+
+
+async def count_active_api_keys(conn, tenant_id: str) -> int:
+    """Count non-revoked keys for a tenant (tenant-wide + agent-scoped).
+
+    The ONE counter used by both the create guard and the usage endpoint so the
+    enforced limit and the displayed usage can never drift apart.
+    """
+    return int(
+        await conn.fetchval(
+            "SELECT COUNT(*) FROM api_keys WHERE tenant_id = $1 AND revoked = FALSE",
+            tenant_id,
+        )
+    )
+
+
+async def assert_and_reserve_api_key_slot(conn, *, tenant_id: str) -> None:
+    """Raise 409 if creating another active key would exceed the plan limit.
+
+    MUST be called inside a transaction on ``conn`` and immediately before the
+    insert. A per-tenant advisory lock serializes concurrent creates so the
+    count-then-insert cannot race (rapid double-clicks, multiple tabs).
+
+    Fail-open: if the plan lookup errors, creation is allowed — this is a
+    plan-limit UX guard, not a security boundary, so a billing hiccup must never
+    block a legitimate user.
+    """
+    if not limits_enforced():
+        return
+
+    # Serialize creates for this tenant within the surrounding transaction.
+    await conn.execute("SELECT pg_advisory_xact_lock(hashtext($1))", tenant_id)
+
+    try:
+        # Read plan on the guard's own connection so it stays inside the
+        # advisory lock and never contends for a second pooled connection.
+        plan = await fetch_tenant_plan(conn, tenant_id)
+    except Exception as e:  # fail-open
+        log.warning(
+            "api-key limit: plan lookup failed for tenant %s, allowing create: %s",
+            tenant_id,
+            e,
+        )
+        return
+
+    limit = api_key_limit_for_plan(plan, billing_enforced=billing_enforced())
+    if limit is None:
+        return
+
+    used = await count_active_api_keys(conn, tenant_id)
+    if used >= limit:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "msg": (
+                    "You've reached the maximum number of API keys allowed on your "
+                    f"current plan ({used}/{limit}). Delete an existing API key or "
+                    "upgrade your plan to create more."
+                ),
+                "code": "api_key_limit_reached",
+                "plan": plan,
+                "limit": limit,
+                "used": used,
+            },
+        )
 
 
 def _key_row(row) -> dict:
@@ -17,14 +90,15 @@ def _key_row(row) -> dict:
 
 
 async def create_api_key_record(
-    pool,
+    db,
     *,
     tenant_id: str,
     name: str | None,
     agent_id: str | None = None,
 ) -> dict:
+    """``db`` is a pool or a transaction connection (used by the create guard)."""
     raw_key, key_hash, prefix = generate_api_key()
-    row = await pool.fetchrow(
+    row = await db.fetchrow(
         """
         INSERT INTO api_keys (tenant_id, key_hash, key_prefix, name, agent_id)
         VALUES ($1, $2, $3, $4, $5)

--- a/core/services/billing.py
+++ b/core/services/billing.py
@@ -132,6 +132,29 @@ async def fetch_user_billing(*, user_id: str | None = None, email: str | None = 
     return dict(row)
 
 
+async def fetch_tenant_plan(executor, tenant_id: str) -> str | None:
+    """Resolve the owning user's plan for a tenant.
+
+    Signup creates one tenant per user (see ``services.auth.verify_otp``), so a
+    tenant maps to a single owner. If a tenant ever has multiple users, the
+    earliest-created (owner) row wins. Returns ``None`` when no user row exists.
+
+    ``executor`` is any asyncpg pool or connection. Pass the guard's own
+    transaction connection so the read stays inside its advisory lock; pass the
+    pool for read-only callers (e.g. the usage endpoint).
+    """
+    return await executor.fetchval(
+        """
+        SELECT plan
+        FROM users
+        WHERE tenant_id = $1::uuid
+        ORDER BY created_at ASC
+        LIMIT 1
+        """,
+        tenant_id,
+    )
+
+
 async def update_user_billing(
     *,
     user_id: str | None = None,

--- a/core/services/plan_limits.py
+++ b/core/services/plan_limits.py
@@ -1,0 +1,49 @@
+"""Single source of truth for per-plan API key limits.
+
+Only the plans listed in ``API_KEY_LIMITS`` are capped. Anything else
+(self-host, free, unknown, ``pending_checkout``) is treated as unlimited.
+
+Adding a new plan (e.g. ``"enterprise"``) is a one-line change here — no
+business logic elsewhere needs to change.
+"""
+
+from __future__ import annotations
+
+import os
+
+# ``None`` means "no cap". Used for self-host and any plan not listed below.
+UNLIMITED: int | None = None
+
+# The only plans with an API key cap. Extend this dict to add plans.
+API_KEY_LIMITS: dict[str, int] = {
+    "pro": 3,
+    "team": 10,
+}
+
+
+def api_key_limit_for_plan(plan: str | None, *, billing_enforced: bool) -> int | None:
+    """Return the active-API-key cap for ``plan``, or ``None`` for unlimited.
+
+    ``billing_enforced=False`` (self-host / local dev) is always unlimited,
+    regardless of any stored plan value — self-host users are backfilled as
+    ``'pro'`` (see ``core/db/connection.py``), so plan alone must never gate them.
+    """
+    if not billing_enforced:
+        return UNLIMITED
+    if not plan:
+        return UNLIMITED
+    return API_KEY_LIMITS.get(plan.strip().lower(), UNLIMITED)
+
+
+def limits_enforced() -> bool:
+    """Master kill switch for API key limit enforcement.
+
+    Defaults OFF so the feature can ship dormant and be enabled per environment
+    after measuring how many existing tenants already exceed their plan limit.
+    """
+    return os.getenv("API_KEY_LIMITS_ENFORCED", "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )

--- a/core/tests/test_plan_limits.py
+++ b/core/tests/test_plan_limits.py
@@ -1,0 +1,153 @@
+"""Unit tests for the API-key plan-limit config and enforcement guard.
+
+Infrastructure-free: the config logic is pure, and the advisory-locked guard is
+exercised against a fake asyncpg connection so no database is required.
+"""
+
+import pytest
+from fastapi import HTTPException
+
+from services import api_keys
+from services.plan_limits import (
+    API_KEY_LIMITS,
+    api_key_limit_for_plan,
+    limits_enforced,
+)
+
+
+# ─────────────────────────────────────────
+# api_key_limit_for_plan (single source of truth)
+# ─────────────────────────────────────────
+
+class TestApiKeyLimitForPlan:
+    def test_pro_plan_capped_at_three(self):
+        assert api_key_limit_for_plan("pro", billing_enforced=True) == 3
+
+    def test_team_plan_capped_at_ten(self):
+        assert api_key_limit_for_plan("team", billing_enforced=True) == 10
+
+    def test_config_dict_matches_expected(self):
+        assert API_KEY_LIMITS == {"pro": 3, "team": 10}
+
+    def test_plan_is_case_and_whitespace_insensitive(self):
+        assert api_key_limit_for_plan("  TEAM  ", billing_enforced=True) == 10
+        assert api_key_limit_for_plan("Pro", billing_enforced=True) == 3
+
+    def test_unknown_plan_is_unlimited(self):
+        assert api_key_limit_for_plan("enterprise", billing_enforced=True) is None
+        assert api_key_limit_for_plan("free", billing_enforced=True) is None
+        assert api_key_limit_for_plan("pending_checkout", billing_enforced=True) is None
+
+    def test_none_plan_is_unlimited(self):
+        assert api_key_limit_for_plan(None, billing_enforced=True) is None
+
+    def test_billing_not_enforced_is_always_unlimited(self):
+        # Self-host / local dev: never gate, even for a capped plan value.
+        assert api_key_limit_for_plan("pro", billing_enforced=False) is None
+        assert api_key_limit_for_plan("team", billing_enforced=False) is None
+
+
+# ─────────────────────────────────────────
+# limits_enforced (kill switch)
+# ─────────────────────────────────────────
+
+class TestLimitsEnforced:
+    def test_defaults_off(self, monkeypatch):
+        monkeypatch.delenv("API_KEY_LIMITS_ENFORCED", raising=False)
+        assert limits_enforced() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", "yes", "on", " On "])
+    def test_truthy_values_enable(self, monkeypatch, value):
+        monkeypatch.setenv("API_KEY_LIMITS_ENFORCED", value)
+        assert limits_enforced() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_falsy_values_disable(self, monkeypatch, value):
+        monkeypatch.setenv("API_KEY_LIMITS_ENFORCED", value)
+        assert limits_enforced() is False
+
+
+# ─────────────────────────────────────────
+# assert_and_reserve_api_key_slot (enforcement guard)
+# ─────────────────────────────────────────
+
+class FakeConn:
+    """Minimal asyncpg-connection stand-in for the guard.
+
+    ``fetchval`` routes by SQL: the COUNT query returns the active-key count,
+    everything else (the plan lookup) returns the configured plan.
+    """
+
+    def __init__(self, plan: str | None, count: int):
+        self._plan = plan
+        self._count = count
+        self.executed: list[tuple] = []
+
+    async def execute(self, query, *args):
+        self.executed.append((query, args))
+        return "SELECT 1"
+
+    async def fetchval(self, query, *args):
+        if "COUNT(" in query:
+            return self._count
+        return self._plan
+
+
+class ExplodingConn(FakeConn):
+    async def fetchval(self, query, *args):
+        if "COUNT(" in query:
+            return self._count
+        raise RuntimeError("simulated plan lookup failure")
+
+
+@pytest.fixture
+def enforce(monkeypatch):
+    """Turn enforcement ON with billing enforced for the guard under test."""
+    monkeypatch.setattr(api_keys, "limits_enforced", lambda: True)
+    monkeypatch.setattr(api_keys, "billing_enforced", lambda: True)
+
+
+async def test_guard_no_op_when_enforcement_off(monkeypatch):
+    monkeypatch.setattr(api_keys, "limits_enforced", lambda: False)
+    conn = FakeConn(plan="pro", count=99)
+    # Even wildly over limit, disabled enforcement must never raise or lock.
+    await api_keys.assert_and_reserve_api_key_slot(conn, tenant_id="t1")
+    assert conn.executed == []
+
+
+async def test_guard_allows_under_limit(enforce):
+    conn = FakeConn(plan="pro", count=2)  # limit 3
+    await api_keys.assert_and_reserve_api_key_slot(conn, tenant_id="t1")
+    # Advisory lock must be taken before the count check.
+    assert any("pg_advisory_xact_lock" in q for q, _ in conn.executed)
+
+
+async def test_guard_blocks_at_limit(enforce):
+    conn = FakeConn(plan="pro", count=3)  # limit 3, already full
+    with pytest.raises(HTTPException) as exc:
+        await api_keys.assert_and_reserve_api_key_slot(conn, tenant_id="t1")
+    assert exc.value.status_code == 409
+    assert exc.value.detail["code"] == "api_key_limit_reached"
+    assert exc.value.detail["limit"] == 3
+    assert exc.value.detail["used"] == 3
+
+
+async def test_guard_team_limit_is_ten(enforce):
+    conn_ok = FakeConn(plan="team", count=9)  # under new limit of 10
+    await api_keys.assert_and_reserve_api_key_slot(conn_ok, tenant_id="t1")
+
+    conn_full = FakeConn(plan="team", count=10)
+    with pytest.raises(HTTPException) as exc:
+        await api_keys.assert_and_reserve_api_key_slot(conn_full, tenant_id="t1")
+    assert exc.value.detail["limit"] == 10
+
+
+async def test_guard_unlimited_plan_never_blocks(enforce):
+    conn = FakeConn(plan="enterprise", count=500)
+    await api_keys.assert_and_reserve_api_key_slot(conn, tenant_id="t1")
+
+
+async def test_guard_fails_open_on_plan_lookup_error(enforce):
+    conn = ExplodingConn(plan="pro", count=99)
+    # Plan lookup blows up → allow the create (UX guard, not a security boundary).
+    await api_keys.assert_and_reserve_api_key_slot(conn, tenant_id="t1")

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -2,7 +2,37 @@
 
 > Single source of truth for the Dashboard module. Reverse-engineered directly from the codebase.
 >
+> **Last verified:** 2026-07-02 · **Maintenance:** when you change billing/auth/the signup funnel, `lib/api.ts`, routes, or a backend endpoint the dashboard calls, update the affected section here (esp. §7, §8, §17.3, §18, §19) in the same change. Line numbers are best-effort snapshots — verify the cited file and prefer symbol names. This doc is auto-surfaced to the agent via `.cursor/rules/dashboard.mdc`.
+>
 > **Important finding:** There is **no "Pricing Modal"** in this codebase. Pricing is a static section on the landing page (`app/page.tsx`, `#pricing`). The only actual modal is the **Calendly "Book demo" modal** (`components/marketing/CalendlyBookModal.tsx`).
+>
+> **Scope:** covers the entire `dashboard/` Next.js app — tenant product (`/dashboard/*`), signup funnel, login, marketing/community/docs/trust, and the operator admin console — plus the backend touch points it depends on (`core/`). SDKs (`sdk/*`), MCP (`mcp/`), and integrations (`integrations/*`) are the event *producers*; they are pointers only here (see §17.4), not fully documented.
+
+## Table of Contents
+
+1. [Dashboard Architecture](#1-dashboard-architecture)
+2. [Folder Structure](#2-folder-structure)
+3. [Component Hierarchy](#3-component-hierarchy)
+4. [Navigation Diagram](#4-navigation-diagram)
+5. [Free Trial Flow](#5-free-trial-flow-highest-priority)
+6. [Pricing "Modal" Flow](#6-pricing-modal-flow)
+7. [Business Logic / Rules](#7-business-logic--rules)
+8. [API Layer](#8-api-layer)
+9. [State Management](#9-state-management)
+10. [User Journey](#10-user-journey-end-to-end-with-variations)
+11. [Edge Cases](#11-edge-cases-found-in-code)
+12. [Technical Notes](#12-technical-notes) · [12.5 Coding Conventions](#125-coding-conventions--practices)
+13. [Areas for Improvement](#13-areas-for-improvement-documented-not-changed)
+14. [Potential Risks](#14-potential-risks)
+15. [Local Development, Build & Environment](#15-local-development-build--environment)
+16. [Admin Surface, Component Catalog & Key Types](#16-admin-surface-component-catalog--key-types)
+17. [Full-Stack Touch Points](#17-full-stack-touch-points-dashboard--backend--ecosystem)
+18. [Backend Business Logic & State Machines](#18-backend-business-logic--state-machines)
+19. [Per-Screen Functional Reference](#19-per-screen-functional-reference)
+20. [Marketing, Public & Admin Surfaces](#20-marketing-public--admin-surfaces)
+21. [Data Model (backend)](#21-data-model-backend)
+22. [Glossary](#22-glossary)
+- [Reference: Key Files](#reference-key-files)
 
 ---
 
@@ -249,11 +279,22 @@ There is a **separate** lead-capture path (`lib/demo.ts` → `submitDemoRequest`
 
 **Trial rules:** 30-day free trial (`trial_days` from `getBillingConfig`, shown in `TenantPlanBanner` as "Free trial until <date>" when `subscription_status==='trialing'`). Card is collected at Stripe checkout. **Copy inconsistency:** landing pricing says "card required"; `/signup/plan` and `/signup` say "No credit card required" (see Risks).
 
+**Managed vs self-host trial activation (backend, `core/services/`):** on first OTP verify, **managed cloud** users get `subscription_status='pending_checkout'` (no access until Stripe checkout completes → `trialing`), whereas **self-host** (`billing_enforced()==false`) users are auto-set to `plan=pro`, `trialing`, `trial_ends_at=+30d` and have immediate access. Full state machine in §18.1.
+
+**Auth gate vs access gate (important gotcha):** `get_tenant` (`core/api/deps.py`) validates the token but does **not** check subscription status — a JWT in `pending_checkout` can still call `/v1/agents` and `/v1/events`. Dashboard access is enforced **client-side** by `SubscriptionGate` + `has_access`, not by the API. Account routes are the exception (JWT-only, `require_dashboard_session`).
+
 **Retention trial:** managed-cloud users get a one-time "X more days free" offer in the delete-account modal (`grantRetentionTrial` → `/v1/account/retention-trial`), gated by `accountOpts.retention_trial_available`.
 
 **Plan selection persistence:** `selectBillingPlan` called twice in the happy path — best-effort after OTP (`signup/page.tsx:99`) and again in checkout if `!status.plan` (`checkout/page.tsx:83`).
 
 **Feature gating:** Self-host (`DEV_MODE`) bypasses billing; pricing is UI-only (plans not enforced client-side beyond gate redirects).
+
+**API key plan limits:** the number of **active** (`revoked = FALSE`) API keys per tenant is capped by plan — Pro 3, Team 10; every other case (self-host, no/unknown plan, `pending_checkout`) is **unlimited**. The limit counts **all** keys (tenant-wide + agent-scoped), and because creating an agent auto-creates a key (`create_agent`), each agent consumes one slot on Pro/Team.
+- **Single source of truth:** `core/services/plan_limits.py` (`API_KEY_LIMITS`, `api_key_limit_for_plan(plan, *, billing_enforced)`). Adding a plan is a one-line change.
+- **Enforcement (backend, real guard):** `assert_and_reserve_api_key_slot` in `core/services/api_keys.py` runs inside a per-tenant advisory-locked transaction (race-safe) before every insert; wired into `create_api_key`, `create_agent_api_key`, and `create_agent`. Fail-open on plan-lookup error. Behind kill switch `API_KEY_LIMITS_ENFORCED` (defaults OFF; ships dormant for staged rollout). `billing_enforced()` is checked first so self-host is never capped despite the `plan='pro'` backfill.
+- **Creation is JWT-only:** all three creation routes use `require_dashboard_session` (a scoped API key can no longer mint keys). List/revoke unchanged.
+- **Usage:** `GET /v1/auth/api-keys/usage` → `{plan, limit, used, unlimited, at_limit}` (unlimited whenever enforcement is off / uncapped). Frontend hook `useApiKeyQuota` + `ApiKeyUsage` component; the UI reads limits from this endpoint (never hardcodes them) and disables create at the limit. Deleting a key **or an agent** (cascade via `fk_api_keys_agent ON DELETE CASCADE`) frees a slot.
+- **Error shape:** limit breach returns `409` with `detail={msg, code:"api_key_limit_reached", plan, limit, used}` (the `msg` key renders through `formatApiError`).
 
 ---
 
@@ -323,6 +364,7 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 - **Empty states:** agents → `GettingStartedChecklist`; no API keys → prompt to create agent.
 - **Direct URL access:** `/dashboard*` guarded at edge; `/signup/checkout` & `/success` re-check token client-side and redirect to `/signup`.
 - **`getEvents` response shape:** handles both array and `{events:[]}` (`api.ts:91`).
+- **Signup screen flicker (fixed):** `/signup` gates its email/OTP form behind a `checked` state so it no longer flashes before a redirect to `/signup/plan` or `/signup/start` resolves. Pattern: run checks in `useEffect`, `return` early on a redirect, call `setChecked(true)` only on the valid path, and render `SignupFallback` until then (`signup/page.tsx`).
 
 ---
 
@@ -336,6 +378,20 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 
 ---
 
+## 12.5 Coding Conventions & Practices
+
+- **TypeScript:** `strict: true`, `isolatedModules`, `skipLibCheck`, `noEmit` (`tsconfig.json`). Import via the `@/*` alias (root-relative). Prefer explicit return types on `lib/` functions; `apiFetch` currently returns untyped JSON — annotate new endpoints.
+- **Linting/formatting:** ESLint `next` + `next/core-web-vitals` only (`package.json`). **No Prettier** — match surrounding style manually (2-space indent, single quotes, no semicolons in TS files).
+- **Components:** all interactive pages are Client Components (`'use client'`). PascalCase component files; route files are `page.tsx`; shared logic lives in `lib/`.
+- **Data fetching:** always via `lib/api.ts` (`apiFetch` injects auth + normalizes errors). No React Query/SWR — manual `useEffect` + `useState`.
+- **Async safety:** guard every async effect with a `let cancelled = false` flag and check it before `setState` (see `SubscriptionGate`, `checkout`, `success`). Standard pattern — reuse it.
+- **Redirect guards:** always render the page's `*Fallback` loader while a redirect is pending; never render real UI before guard checks resolve (see the `checked` gate in `signup/page.tsx`).
+- **Errors:** `apiFetch` throws a normalized `Error`; catch in the component and render into a local `error` state string.
+- **Env flags:** client-exposed values must be prefixed `NEXT_PUBLIC_*`.
+- **Styling:** dashboard uses Tailwind (`className`); marketing/signup use inline styles + a raw `<style>` block for breakpoints. Match the surface you're editing.
+
+---
+
 ## 13. Areas for Improvement (documented, not changed)
 
 1. **Duplicate plan definitions** (landing, `/signup/plan`, backend `getBillingConfig`) → drift risk; consolidate on `getBillingConfig`.
@@ -345,18 +401,500 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 5. **No analytics/telemetry** on funnel steps → hard to measure drop-off.
 6. **No React Query/SWR** → manual polling + no dedupe/caching; billing status fetched 2–3× per dashboard load (`SubscriptionGate` + `TenantPlanBanner`).
 7. **Inconsistent styling systems** (Tailwind vs inline).
+8. **No frontend tests** — no `*.test.tsx`, no test runner, no `test` script (`package.json`); CI only runs `lint` + `build`. Highest-value first tests: the pure `postAuthRedirect` / `billingGateRedirect` helpers, then the signup funnel guards.
+9. **`apiFetch` is effectively untyped** (returns `any` from `res.json()`), so agents/events endpoints lose type safety despite `strict: true` → add response interfaces + a generic `apiFetch<T>()`.
 
 ---
 
 ## 14. Potential Risks
 
 1. **Copy contradiction on credit card:** `/signup/plan` and `/signup` say "No credit card required," but the flow forces Stripe checkout and landing says "card required." User-trust/legal risk. (`plan/page.tsx:57`, `signup/page.tsx:180` vs `page.tsx:190,196`.)
-2. **Token in `localStorage`** is XSS-exposed; the mirrored non-`HttpOnly` cookie is also JS-readable. Middleware trusts the cookie only.
-3. **Auth source mismatch:** middleware reads cookie, app reads localStorage. If one is cleared (e.g., cookie expiry vs localStorage), user can pass the edge guard but fail client calls, or vice-versa.
+2. **Access token is XSS-exposed:** the **access** JWT lives in `localStorage` + a non-`HttpOnly` (JS-readable) cookie. (The **refresh** token is a proper `HttpOnly` cookie set by the backend — `core/api/auth.py:104-112` — so it is not JS-readable.) A structural fix would move the access token to an `HttpOnly` server-set cookie too. Middleware trusts the access cookie only.
+3. **Auth source mismatch:** middleware reads the access cookie, app code reads localStorage. If one is cleared (cookie expiry vs localStorage), a user can pass the edge guard but fail client calls, or vice-versa.
 4. **`selectBillingPlan` best-effort swallow** (`signup/page.tsx:99` `catch {}`) — a failure here silently defers plan to checkout; acceptable but undocumented.
 5. **Retention-trial / delete** are destructive and rely on client `accountOpts.managed_cloud`; ensure backend re-validates.
 6. **Calendly `postMessage`**: origin is validated (good), but booked-state cannot be forged into app state beyond a UI success screen (low risk).
 7. **No client-side rate-limit/backoff on OTP request** (relies on backend).
+8. **Billing gate fails open:** if `getBillingStatus` throws, `SubscriptionGate` calls `setReady(true)` and lets the user into the dashboard (`SubscriptionGate.tsx:42-44`). Better UX when the billing API is down, but a potential revenue-leak / access risk — verify it's intentional.
+9. **No request timeouts:** only `adminRequestOtp` passes an `AbortSignal` (`api.ts:157`); other fetches (incl. 10s agents poll, 30s `/health` poll) can hang/stack. Consider an `AbortController` + timeout in `apiFetch`.
+10. **API does not enforce subscription:** `get_tenant` validates the token but not `subscription_status`; a `pending_checkout` JWT can still hit `/v1/agents` and `/v1/events`. Access is gated client-side only (see §7). Treat billing as a UX gate, not a security boundary, for non-account endpoints.
+
+---
+
+## 15. Local Development, Build & Environment
+
+**Scripts (`package.json`):** `dev` (`next dev`), `build` (`next build`), `start` (`next start`), `lint` (`next lint`). **No `test` script — there are no tests.**
+
+**Build output:** `output: 'standalone'` (`next.config.mjs`) for containerized deploy.
+
+**Environment variables:**
+
+| Var | Where read | Default | Purpose |
+|-----|-----------|---------|---------|
+| `NEXT_PUBLIC_API_URL` | client (`lib/api.ts`, `lib/demo.ts`, `lib/community.ts`, `ConnectionStatus`, `login`) | `''` (same-origin; `login` falls back to `http://localhost:8000`) | API base URL |
+| `NEXT_PUBLIC_DEV_MODE` | client (`SubscriptionGate`, `TenantPlanBanner`, `ConnectionStatus`, `login`) | unset | `'true'` = self-host: skips billing gate, enables dev-token login, changes onboarding copy |
+| `API_REWRITE_TARGET` | build/server (`next.config.mjs`) | `http://127.0.0.1:8000` | upstream host for the `/swagger` + `/openapi.json` rewrites |
+
+**Rewrites / redirects (`next.config.mjs`):**
+- Redirect: `/api-explorer` and `/api-explorer/*` → `/swagger` (temporary).
+- Rewrite: `/swagger`, `/swagger/*`, `/openapi.json` → `${API_REWRITE_TARGET}/...`.
+
+There is **no `.env.example`** in the repo — env vars are documented only here.
+
+---
+
+## 16. Admin Surface, Component Catalog & Key Types
+
+**Admin (`app/admin/`):** `layout.tsx` + `page.tsx` only. Separate auth via the `zizkadb_admin_token` cookie/localStorage (`lib/auth.ts` admin helpers; `adminRequestOtp`/`adminVerifyOtp` in `lib/api.ts`). Middleware permits the bare `/admin` (OTP login UI) but redirects `/admin/*` subpaths to `/admin` without a token. Backend locks admin to a single founder email.
+
+**Reusable components (`components/`, 15 total):**
+
+| Component | Role |
+|-----------|------|
+| `DashboardShell` | sidebar / mobile nav / sign-out frame |
+| `SubscriptionGate` | billing redirect guard (fails open on fetch error) |
+| `TenantPlanBanner` | plan pill + trial / active / past_due state |
+| `ConnectionStatus` (+ `GettingStartedChecklist`) | `/health` poll + empty-state onboarding |
+| `AgentApiKeys` | key create / reveal-once / revoke |
+| `SiteNav`, `BrandLogo`, `brand.ts` | marketing nav + branding tokens |
+| `marketing/*` | `CalendlyBookModal`, `CompetitorCompare`, `ConversationCompare`, `ThreeWaysConnectSection`, `TrustBar`, `IntegrationStrip`, `ProductPreview`, `SessionReplayDemo` |
+
+**Key types (`lib/api.ts`) — the funnel branches on these:**
+- `BillingStatus` — `enforced`, `has_access`, `requires_plan_selection`, `requires_checkout`, `subscription_status`, `trial_ends_at`, `plan`, `stripe_publishable_key?`, `trial_days?`.
+- `BillingPlan` — `id: 'pro'|'team'`, `name`, `price`, `price_sub`, `highlight`, `features[]`.
+- `AccountOptions` — `managed_cloud`, `retention_trial_available?`, `retention_trial_days?`, `trial_ends_at?`, `email?`.
+- `verifyOtp` response — `access_token`, `token_type`, plus optional `requires_plan_selection`, `requires_checkout`, `has_access`, `plan`.
+
+---
+
+## 17. Full-Stack Touch Points (Dashboard ↔ Backend ↔ Ecosystem)
+
+The dashboard is a **client** of the FastAPI backend in `core/`. It never touches the DB directly — every interaction is an HTTP call to `/v1/*` (or `/health`).
+
+### 17.1 System topology (`infra/nginx.conf`)
+
+Single host `db.zizka.ai` behind nginx:
+
+| Path | Proxied to | Serves |
+|------|-----------|--------|
+| `/v1/*`, `/health` | `127.0.0.1:8000` | FastAPI (`core/main.py`) |
+| `/swagger`, `/openapi.json`, `/api-explorer` | `127.0.0.1:8000` | API docs |
+| `/api/*`, `/api/v1/*` | `127.0.0.1:8000` (rewritten → `/v1/*`) | legacy SDK base URLs (<0.2.1) |
+| `/` (everything else) | `127.0.0.1:3001` | Next.js dashboard |
+
+With `NEXT_PUBLIC_API_URL=''` the dashboard's relative `/v1/...` calls hit nginx, which routes them to FastAPI. Dashboard runs under PM2 (`dashboard/ecosystem.config.js`) or Docker (`dashboard/Dockerfile`, `infra/docker-compose*.yml`).
+
+### 17.2 Auth model (`core/api/deps.py::get_tenant`, lines 70-102)
+
+One bearer-token entry point resolves **three** credential types, in order:
+1. **Dev key bypass** (non-production only, `deps.py:57-68,76-78`): `DEV_API_KEY` env or known keys `zizkadb_dev_local` / `agdb_dev_local` → fixed dev tenant.
+2. **API key** (`deps.py:80-83`): SHA-256 hash lookup via `verify_api_key`; returns `{tenant_id, key_id, agent_id?}`. Prefix-agnostic (legacy `agdb_live_*` still work).
+3. **JWT** (`deps.py:85-102`): three dot-separated segments → `decode_access_token` → `{tenant_id, user_id}`.
+
+- **Agent-scoped keys** (`assert_agent_allowed`, `deps.py:43-54`): if the key is bound to an agent, a request for a different `agent_id` → **403**.
+- **Account routes are JWT-only** (`require_dashboard_session`, `account.py:19-35`): API keys are rejected with 403 "Sign in to the dashboard".
+- The dashboard obtains its JWT from `verifyOtp`/`dev-token` and sends `Authorization: Bearer <jwt>` on every `apiFetch` call.
+
+### 17.3 Endpoint map — every dashboard call → backend implementation
+
+Router prefixes are mounted in `core/main.py:66-79`.
+
+**Auth (`core/api/auth.py`, prefix `/v1/auth`):**
+| Dashboard fn (`lib/api.ts`) | Method · Path | Backend |
+|---|---|---|
+| `requestOtp` | POST `/v1/auth/request-otp` | `auth.py:58` |
+| `verifyOtp` | POST `/v1/auth/verify-otp` | `auth.py:80` |
+| dev-token (`login/page.tsx`) | POST `/v1/auth/dev-token` | `auth.py:151` |
+| `sendTestEvent` | POST `/v1/auth/test-event` | `auth.py:187` |
+| `getApiKeys` | GET `/v1/auth/api-keys` | `auth.py:205` |
+| `createApiKey` | POST `/v1/auth/api-keys` | `auth.py:124` |
+| `revokeApiKey` | DELETE `/v1/auth/api-keys/{id}` | `auth.py:139` |
+
+**Agents (`core/api/agents.py`, prefix `/v1/agents`):**
+| Dashboard fn | Method · Path | Backend |
+|---|---|---|
+| `getAgents` | GET `/v1/agents` | `agents.py:41` |
+| `createAgent` | POST `/v1/agents` | `agents.py:74` |
+| `deleteAgent` | DELETE `/v1/agents/{id}` | `agents.py:114` |
+| `sendAgentTestEvent` | POST `/v1/agents/{id}/test-event` | `agents.py:150` |
+| `getAgentApiKeys` | GET `/v1/agents/{id}/api-keys` | `agents.py:180` |
+| `createAgentApiKey` | POST `/v1/agents/{id}/api-keys` | `agents.py:199` |
+| `revokeAgentApiKey` | DELETE `/v1/agents/{id}/api-keys/{keyId}` | `agents.py:224` |
+| `getAgentStats` | GET `/v1/agents/{id}/stats` | `agents.py:239` |
+| `getAgentSessions` | GET `/v1/agents/{id}/sessions` | `agents.py:280` |
+| `getAgentBaseline` | GET `/v1/agents/{id}/baseline` | `agents.py:453` |
+
+**Events / Search / Memory (dashboard read side):**
+| Dashboard fn | Method · Path | Backend |
+|---|---|---|
+| `getEvents` | GET `/v1/events` | `events.py:64` |
+| `getWhyChain` | GET `/v1/events/{id}/why` | `events.py:123` |
+| `timeTravel` | GET `/v1/events/at` | `events.py:173` |
+| `searchEvents` | POST `/v1/search` | `search.py:18` |
+| `getMemoryDiff` | GET `/v1/memory/diff/{sessionId}` | `memory.py:190` |
+
+**Billing (`core/api/billing_checkout.py`, prefix `/v1/billing`):**
+| Dashboard fn | Method · Path | Backend |
+|---|---|---|
+| `getBillingConfig` | GET `/v1/billing/config` | `billing_checkout.py:56` |
+| `getBillingStatus` | GET `/v1/billing/status` | `billing_checkout.py:68` |
+| `selectBillingPlan` | POST `/v1/billing/select-plan` | `billing_checkout.py:74` |
+| `createCheckoutSession` | POST `/v1/billing/checkout-session` | `billing_checkout.py:87` |
+| `confirmCheckout` | POST `/v1/billing/confirm-checkout` | `billing_checkout.py:115` |
+| _(Stripe → backend webhook)_ | POST `/v1/webhooks/stripe` | `billing.py:22` |
+
+**Settings / Account:**
+| Dashboard fn | Method · Path | Backend |
+|---|---|---|
+| `getEmbeddingCatalog` | GET `/v1/settings/embeddings/catalog` | `settings.py:47` |
+| `getEmbeddingSettings` | GET `/v1/settings/embeddings` | `settings.py:53` |
+| `updateEmbeddingSettings` | PUT `/v1/settings/embeddings` | `settings.py:59` |
+| `getAccountOptions` | GET `/v1/account/options` | `account.py:38` |
+| `grantRetentionTrial` | POST `/v1/account/retention-trial` | `account.py:43` |
+| `deleteManagedAccount` | DELETE `/v1/account` | `account.py:54` |
+
+**Admin (`core/api/admin.py`, prefix `/v1/admin`, `include_in_schema=False`):** `adminRequestOtp` `:90` · `adminVerifyOtp` `:103` · `adminOverview` `:120` · `adminTelemetrySummary` `:157` · `adminTelemetryRecent` `:200` · `adminManagedOverview` `:235` · `adminManagedSubscribers` `:262` · `adminManagedUsers` `:329` · `adminManagedUsage` `:447` · `adminDemoRequests` `:497`.
+
+**Community (`lib/community.ts` → `core/api/community.py`, prefix `/v1/community`):** `listCommunityPosts`/`getCommunityPost` (GET `/posts`, `/posts/{id}` — `:78`,`:119`) · `createCommunityPost` (POST `/posts` `:169`) · `createCommunityReply` (POST `/posts/{id}/replies` `:198`) · `uploadCommunityImage` (POST `/upload` `:238`) · `mediaUrl` (GET `/media/{file}` `:261`). Unauthenticated; uses a honeypot field (`website`) for spam control.
+
+**Demo (`lib/demo.ts`):** `submitDemoRequest` → POST `/v1/demo-requests` → `demo_requests.py:48` (unauthenticated, honeypot `botcheck`).
+
+**Health:** `ConnectionStatus` → GET `/health` → `main.py:82`.
+
+### 17.4 Data producers vs the dashboard (consumer)
+
+The dashboard **reads and visualizes** data that the **rest of the ecosystem writes** using API keys created in the dashboard:
+- **SDKs** (`sdk/python`, `sdk/typescript`), **integrations** (`integrations/langchain`, `integrations/crewai`), and **MCP** (`mcp/`) call **POST `/v1/events`** (`events.py:43`), `POST /v1/memory/context` (`memory.py:46`), `POST /v1/telemetry` (`telemetry.py:27`).
+- The dashboard's Agents / Sessions / Search / Memory-diff / Baseline views read those rows back through the GET endpoints above.
+
+**Implication:** an event-schema or agent-scoping change in `core/api/events.py` or `deps.py` affects **both** the write path (SDKs) and the dashboard read views — keep field names in sync across `lib/api.ts` types and SDK payloads.
+
+### 17.5 Service layer behind the routers (`core/services/`)
+
+`auth.py` (JWT + API-key hashing, OTP), `billing.py` (Stripe, plans, trials, state machine), `account.py` (retention/delete), `embeddings.py` + `embedding_config.py`, `api_keys.py`, `event_write.py`. Routers are thin; business logic lives here — the first place to look when a dashboard call returns unexpected data.
+
+### 17.6 External integrations
+
+- **Stripe** — checkout session created server-side (`billing_checkout.py`), dashboard redirects to `session.url`; completion confirmed via `confirmCheckout` + webhook `/v1/webhooks/stripe`.
+- **Calendly** — client-only embed in `CalendlyBookModal` (no backend); lead capture is the separate `submitDemoRequest` path.
+
+---
+
+## 18. Backend Business Logic & State Machines
+
+The logic that drives every dashboard gate and funnel branch. Routers are thin; the rules below live in `core/services/`.
+
+### 18.1 Billing / trial / subscription state machine (`core/services/billing.py`)
+
+**When billing is enforced** (`billing_enforced()`, `billing.py:58-62`): `ENV=production` **and** `STRIPE_SECRET_KEY`, `STRIPE_PRO_PRICE_ID`, `STRIPE_TEAM_PRICE_ID` all set. Otherwise (self-host / dev) billing is off and everyone has access.
+
+**Plans & prices** (`PLAN_CATALOG`, `billing.py:26-43`): `pro` = €39/mo, `team` = €99/mo. A plan is *valid* only if it is in `VALID_PLANS` **and** its Stripe price ID is configured (`_valid_plan`, `billing.py:54-55`). Trial length = `STRIPE_TRIAL_DAYS` (default **30**, `billing.py:19`).
+
+**Access gate** (`billing.py:23-24, 74-82`): `ACCESS_STATUSES = {trialing, active}`. `has_dashboard_access` returns `true` if billing not enforced, else `subscription_status ∈ ACCESS_STATUSES`.
+
+**Decision tree (managed cloud):**
+
+```
+billing_enforced?
+  NO  → has_access=true, requires_plan_selection=false, requires_checkout=false
+  YES → has_access            = status ∈ {trialing, active}
+        requires_plan_selection = !has_access && !valid_plan            (billing.py:84-90)
+        requires_checkout       = !has_access && valid_plan &&
+                                  status ∈ {pending_checkout, null, "",
+                                            past_due, canceled, unpaid,
+                                            incomplete, incomplete_expired}  (billing.py:93-105)
+```
+
+**State transitions:**
+
+| Trigger | From | To | Side effects | Ref |
+|---------|------|----|-------------|-----|
+| New user OTP verify (managed) | anything ∉ {active,trialing} & no Stripe sub | `pending_checkout` | — | `auth.py` verify branch |
+| New user OTP verify (self-host) | plan+status both NULL | `plan=pro`, `trialing`, `trial_ends_at=+30d` | — | `services/auth.py` |
+| `select_plan` | any (no Stripe sub) | plan saved, `status=COALESCE(status,'pending_checkout')` | blocked if already active/trialing when enforced | `billing.py:247-267` |
+| Stripe checkout complete | `pending_checkout` | `trialing` (or Stripe status) | links customer/sub IDs, sets `trial_ends_at` | `sync_checkout_session` `billing.py:381-442` |
+| Retention trial | any | `trialing`, `retention_trial_used=true`, extended trial | Stripe `Subscription.modify(trial_end=…)` if sub exists | `account.py` service 39-88 |
+| Webhook `subscription.deleted` | * | `canceled` | — | `core/api/billing.py` |
+| Webhook `invoice.payment_failed` | * | `past_due` | — | `core/api/billing.py` |
+
+**`billing_status_payload` shape** (`billing.py:445-466`) — the object the dashboard branches on:
+
+```json
+{
+  "enforced": bool, "has_access": bool,
+  "requires_plan_selection": bool, "requires_checkout": bool,
+  "subscription_status": "trialing|active|pending_checkout|past_due|…|null",
+  "trial_ends_at": "ISO8601|null", "plan": "pro|team|null",
+  "stripe_publishable_key": "str|null",  // only when enforced
+  "trial_days": "int|null"                // only when enforced
+}
+```
+
+**Checkout** (`create_checkout_session`, `billing.py:270-307`): Stripe Hosted Checkout, `mode=subscription`, card required, `trial_period_days=STRIPE_TRIAL_DAYS`, metadata `{user_id, plan}`; success → `{DASHBOARD_URL}/signup/success?session_id={CHECKOUT_SESSION_ID}`, cancel → `/signup/plan?canceled=1`. `confirm-checkout` soft-fails to current status on Stripe errors (`billing_checkout.py:127-130`).
+
+### 18.2 Auth internals (`core/services/auth.py`)
+
+- **JWT** (`auth.py:17-43`): access token 7 days, refresh 30 days; `JWT_SECRET`/`JWT_REFRESH_SECRET` **required** in production (else `dev-secret`). Payload `{sub: user_id, email, tenant_id, exp, iat}`.
+- **API keys** (`auth.py:50-89`): format `zizkadb_live_{32 url-safe}`; stored as SHA-256 hash + 16-char prefix; legacy `agdb_live_*` still resolve by hash; valid use bumps `last_used`.
+- **OTP** (`auth.py:96-295`): 6-digit, bcrypt-hashed, 15-min expiry; prior unused OTPs invalidated; sent via SMTP or printed to console when no SMTP config.
+- **request-otp** (`core/api/auth.py:58-77`): rate-limited 10/15min; `intent="signup"` + existing email → **409** "already registered".
+- **verify-otp** (`core/api/auth.py:80-121`): new users **must** pass `gdpr_consent=true` (else 401 ValueError); sets a **HttpOnly, Secure, SameSite=Lax refresh-token cookie** (30-day, `auth.py:104-112`); returns access token + billing routing flags. Consent fields persisted.
+- **dev-token** (`core/api/auth.py:151-164`): development only (403 in prod).
+
+### 18.3 Account (`core/api/account.py` + `core/services/account.py`) — JWT only
+
+- **`account_options`**: non-production → `{managed_cloud:false}`; production → `{managed_cloud:true, retention_trial_available, retention_trial_days, trial_ends_at, plan, email}`; `retention_trial_available = !retention_trial_used`.
+- **Retention trial** (one-time): production only; 400 if `retention_trial_used`; extends trial by `RETENTION_TRIAL_DAYS` (default 30), modifies Stripe sub `trial_end` if present, sets `retention_trial_used=TRUE`.
+- **Delete account**: production only; tenant must match JWT (403 otherwise); cancels Stripe sub, purges Qdrant vectors, deletes user + auth_otps + tenant in a transaction.
+
+### 18.4 Events & memory
+
+- **`write_event`** (`core/services/event_write.py:16-109`): upsert agent + bump `event_count`; insert event with SHA-256 checksum of sorted JSON; best-effort embedding + Qdrant upsert to `agent_events`; increment `usage_daily.events_written`; returns `{event_id, timestamp, sequence_no, checksum}`.
+- **Events API** (`core/api/events.py`): `POST /` and `GET /` enforce agent scope (`assert_agent_allowed`); `GET /{id}/why` walks the parent chain (`depth≤50`); `GET /at` reconstructs state at a timestamp via `STATE_SET`/`STATE_DELETE` reduction — note **`/at` does NOT enforce agent scope**.
+- **Memory** (`core/api/memory.py`): `POST /context` (recent + semantic search merged into a char-budgeted prompt block), `GET /diff/{session_id}` (session summary + new event types vs prior), `DELETE /forget` (deletes events by exact JSONB match + purges Qdrant).
+
+### 18.5 Agents & baseline (`core/api/agents.py`)
+
+- `agent_id` must match `^[a-zA-Z0-9][a-zA-Z0-9._-]{0,254}$` (`agents.py:18-28`); `POST /` returns a one-time API key (`{agent, api_key:{key,key_id,prefix}, message}`).
+- **Baseline / drift** (`agents.py:453-544`): splits sessions into recent N (default 50) vs older; computes event distribution, parent→child transitions, session shape, error rate; `drift_score = 0.5·L1(event_dist) + 0.5·L1(transitions)`; verdicts `stable | minor_drift | noticeable_drift | significant_drift`; status can be `insufficient_data`, `warming_up`, or `ok`.
+
+### 18.6 Admin (`core/api/admin.py`)
+
+Single allow-listed email (`ADMIN_EMAIL`, default `founder@zizka.ai`). Non-admin requests get **404** (not 403) to hide the panel's existence. Admin JWT is issued with `is_admin:true` and no tenant. Endpoints return telemetry (SDK installs) + managed-cloud analytics (subscribers, users, usage, demo requests).
+
+### 18.7 End-to-end signup state machine
+
+```mermaid
+flowchart TD
+    A["POST /auth/request-otp (intent=signup)"] --> B["POST /auth/verify-otp (gdpr_consent=true)"]
+    B --> C{billing_enforced?}
+    C -->|No| D["Self-host: status=trialing, plan=pro, +30d"]
+    C -->|Yes| E["status=pending_checkout"]
+    E --> F{requires_plan_selection?}
+    F -->|Yes| G["POST /billing/select-plan"]
+    F -->|No| H["POST /billing/checkout-session"]
+    G --> H
+    H --> I["Stripe Hosted Checkout"]
+    I --> J["POST /billing/confirm-checkout (session_id)"]
+    J --> K["status=trialing, has_access=true"]
+    D --> L["Dashboard unlocked"]
+    K --> L
+```
+
+---
+
+## 19. Per-Screen Functional Reference
+
+Exhaustive behavior per file (state, effects, API order, branches, edge cases, navigation). Line numbers reflect the state at time of writing; re-confirm before relying on exact positions.
+
+### 19.1 Agents home — `app/dashboard/page.tsx`
+
+- **State (`:21-31`):** `agents`, `loading`, `error`, `lastSync`, `newAgentId`, `creating`, `createErr`, `deletingAgent`, `newAgentKey`, `newAgentName`, `copied`.
+- **Effect (`:33-72`):** on mount + `[router]`; no token → `router.replace('/login')` (`:34-37`); `loadAgents(true)` then **10s `setInterval`** `loadAgents(false)` (`:66`); cleanup sets `cancelled` + `clearInterval`.
+- **API:** `getAgents` initial (`:44`) + poll (`:66`); `createAgent` (`:82`) → optional one-time key display (`:84-87`) → `getAgents` refresh; `deleteAgent` (`:105`).
+- **Branches:** `loading`→Skeleton (`:114`); `error`→error + "Sign in again" (`:116-133`); `newAgentKey`→one-time key banner (`:159-197`); `agents.length===0`→`GettingStartedChecklist` else grid (`:223-237`); `AgentCard` green dot if `last_seen` < 5 min (`:254`).
+- **Rules/edge:** 401 / "invalid token" → `/login` (`:54-56`); poll errors silent (only initial-load errors surface, `:58`); empty trimmed id blocks create (`:77`); `window.confirm` before delete (`:99-100`); non-array response → `[]` (`:47`); copy resets after 2s (`:176`, no cleanup).
+- **Nav:** card → `router.push('/dashboard/agents/{encoded}')` (`:233`).
+
+### 19.2 Agent detail — `app/dashboard/agents/[id]/page.tsx`
+
+- **Route:** `id` from `useParams` → `decodeURIComponent` → `agentId` (`:100-101`). `PAGE=50` (`:95`).
+- **State:** tabs (`tab` default `'events'`, `:104`), stats/loading/refreshing/lastSync/deleting (`:105-109`); events cluster (`:127-139`); sessions cluster (`:142-147`); time-travel (`:150-153`); behavior/baseline (`:156-157`).
+- **Effects:** initial `Promise.all([loadStats, loadEvents(1)])` (`:182-186`); **10s tab-aware poll** (`:189-214`, skips while `loading`; deps include `tab`, `filterSession`, `filterType`, `searchResults`, `agentId`). Note: comment says 30s but interval is `10_000` (`:208`).
+- **API:** `getEvents` (`:167,197,233,242,298`), `getAgentStats` (`:177,195,224`), `searchEvents` (`:252`), `getWhyChain` (`:273`), `getAgentSessions` (`:203,285`), `getMemoryDiff` (`.catch(()=>null)`, `:299`), `timeTravel` (`:328`), `getAgentBaseline` (`:200,313`), `deleteAgent` (`:118`).
+- **Branches/rules:** `displayEvents = searchResults ?? events` (`:341`); filter pills only if `stats.top_events.length>0 && !searchResults` (`:427`); re-click event deselects (`:259`); cached why-chain / sessions / baseline skip refetch (`:267,280,308`); `hasMore = evs.length===PAGE` (`:169`); Behavior tab renders `insufficient_data` / `warming_up` / full drift (`:904-981`).
+- **Edge:** search shape `res.results ?? res` (`:253`); events auth failure → `/login` (`:170`); stats errors swallowed (`:179`). **Nav:** delete → `/dashboard` (`:119`); back → `/dashboard` (`:1265`). Renders `<AgentApiKeys agentId onTestSuccess={refresh} />` (`:345`).
+
+### 19.3 Search — `app/dashboard/search/page.tsx`
+
+- **State (`:19-22`):** `query`, `results`, `loading`, `searched`. **No effect** — form-driven.
+- **API:** submit → `requireAuth()` (`:30`) → `searchEvents(token, query)` **tenant-wide, no agentId** (`:31`); catch → `results=[]` (`:33-34`); assumes `res.results` (`:32`).
+- **Branches:** submit disabled if `loading || !query.trim()` (`:65`); empty-after-search state (`:74-78`); score badge if `event.score !== undefined` (`:103-107`); example queries when `!searched` (`:115-138`, buttons only set `query`).
+- **Rules:** empty query no-ops (`:26`); no page-load auth redirect (relies on layout gate + `requireAuth` on submit).
+
+### 19.4 Settings — `app/dashboard/settings/page.tsx`
+
+- **State (`:20-46`):** 20+ vars — API keys, embedding UI (provider/model/platform/custom-key/ready/err), test event, tenant key, delete-account modal.
+- **Effect (`:48-67`):** once on mount; `requireAuth()` catch → silent return (no redirect). Parallel: `getApiKeys` → `keys` (`:51`), `getEmbeddingCatalog` (`:56`, errors ignored), `getEmbeddingSettings` (`:60`, errors → `embErr`), `getAccountOptions` (`:66`, errors ignored).
+- **API:** `updateEmbeddingSettings` (`:116-121`, platform key → `api_key:undefined`), `sendTestEvent` (agent `dashboard-connection-test`, `:202`), `createApiKey` (`:255`, optimistic append w/ placeholder key_id `:258-264`), `revokeApiKey` (`:77`), `grantRetentionTrial` (`:412`), `deleteManagedAccount` (`:452`).
+- **Branches/rules:** delete section + modal only if `accountOpts?.managed_cloud` (`:345,375`); retention offer if `retention_trial_available` (`:395-432`); delete button enabled only when `deleteConfirm === 'DELETE'` (`:446`); confirm before revoke (`:71-72`); copy resets after 2s (`:242`).
+- **Nav:** after delete → `clearToken()` → `router.replace('/login?deleted=1')` (`:454`).
+
+### 19.5 Dashboard layout — `app/dashboard/layout.tsx`
+
+Server component; `metadata.robots` = noindex/nofollow (`:5-7`); wraps children in `DashboardShell` → `SubscriptionGate` (`:9-14`). No API, no branching of its own.
+
+### 19.6 Login — `app/login/page.tsx`
+
+- **Consts:** `IS_DEV_MODE` (`:9`), `API_URL` (`:10`). Suspense wrapper (`:12-17`).
+- **State (`:34-39`):** `email`, `otp`, `step` (`'email'|'otp'`), `loading`, `devLoading`, `error`.
+- **`safeNext` (`:41-45`):** uses `next` param **only** if it starts with `/dashboard` and not `//` (open-redirect guard); else `/dashboard`.
+- **Effect (`:47-53`):** existing token → `setToken` + `router.replace(safeNext)`.
+- **API:** dev-token `fetch POST ${API_URL}/v1/auth/dev-token` (`:59-62`); `requestOtp(email)` (`:76`); `verifyOtp(email, otp)` (`:90`) → `postAuthRedirect(data)` (`:92`).
+- **Branches:** dev banner + bypass if `IS_DEV_MODE` (`:112-139`); OTP input digits-only max 6 (`:215`); signup link hidden in dev mode (`:255-262`). Dev-login failure shows docker hint (`:65`).
+
+### 19.7 Plan selection — `app/signup/plan/page.tsx`
+
+- `PLANS` const (`:9-26`), `selected` default `'pro'` (`:30`), no effect.
+- On continue: `sessionStorage.setItem('signup_plan', selected)` (`:33-35`) → `router.push('/signup/start?plan={selected}')` (`:36`). Copy: "30-day free trial… No credit card required" (`:57`) — see credit-card copy risk (§14.1).
+
+### 19.8 Checkout success — `app/signup/success/page.tsx`
+
+- **State (`:31-35`):** `sessionId` from query, `error`. **Effect (`:37-119`)** deps `[router, sessionId]`.
+- **Retry loop (max 5):** `confirmCheckout` → if no access `getBillingStatus` → on catch retry `getBillingStatus`. `isPendingStripeConfirmation` (`:51-60`) retries while status null / `pending_checkout` / `incomplete` / `incomplete_expired` and still requires checkout; waits 2000ms between pending attempts (`:81-83`), 1500ms on error path (`:101,108`); `has_access` → `/dashboard` immediately (`:69-78,96-98`).
+- **Edge/nav:** no token → `/signup` (`:39-41`); missing `session_id` → error, no API (`:43-45`); timeout after 5 → error message (`:86-89`); error UI offers full reload (`:131`) + link to `/signup/plan` (`:145`); `cancelled` on unmount (`:118`).
+
+### 19.9 Components
+
+- **`DashboardShell.tsx`** — no state; `usePathname`/`useRouter`. Nav items Agents/Search/Settings (`:11-15`); active = exact/prefix match (`:40`); sign out `clearToken()` → `router.push('/login')` (`:21-24`). Renders `TenantPlanBanner` (`:84`) + `ConnectionStatus` (`:85`) + children.
+- **`TenantPlanBanner.tsx`** — state `status` (`:27`); effect once, **early-exits if `IS_DEV_MODE`** (`:30`), no token → return, `getBillingStatus` with `cancelled` cleanup (`:29-39`, errors swallowed). Returns `null` if dev mode or `!status?.plan` (`:41`); shows trial end date if `trialing` (`:66-70`), "Active" (`:71-73`), or "Payment failed" if `past_due` (`:74-76`). Informational only.
+- **`ConnectionStatus.tsx`** — state `health: 'checking'|'ok'|'error'` (`:11`); effect mount + **30s `/health` poll** (`:14-30`, `cache:'no-store'`, `cancelled`+`clearInterval` cleanup). Empty `API` → label "same-origin (nginx)" (`:12`); dev label + setup hint on error. Also exports `GettingStartedChecklist` (static; Python snippet + step 1 copy differ by `IS_DEV`).
+- **`AgentApiKeys.tsx`** — state keys/loading/creating/revokingId/newKey/copied/err/testBusy/testMsg (`:24-32`); `load` useCallback → `getAgentApiKeys` (normalizes to array, `:34-44`); effect re-loads when `agentId` changes (`:46-48`). `createAgentApiKey` (`:55`) → reload; `revokeAgentApiKey` (`:72`, confirm first `:66-67`); `sendAgentTestEvent` (`:110`) → `onTestSuccess?.()` (`:112`). One-time key display; copy resets 2s (`:84`).
+
+### 19.10 Cross-cutting quick reference
+
+| Concern | Behavior |
+|---------|----------|
+| `getToken()` | read-only, no redirect |
+| `requireAuth()` | no token → `window.location.href='/login'`, throws |
+| Agents home | explicit `router.replace('/login')` on missing/invalid token |
+| Layout gate | `SubscriptionGate` redirects unauthenticated + billing-blocked (skips if `IS_DEV_MODE`) |
+| Polling | agents home 10s, agent detail 10s (tab-aware), `ConnectionStatus` 30s |
+| `NEXT_PUBLIC_DEV_MODE=true` | dev login bypass; hides plan banner; skips subscription gate; dev onboarding copy |
+
+### 19.11 Signup email/OTP — `app/signup/page.tsx`
+
+- **Step 3 of the funnel** (account creation). Suspense-wrapped (`useSearchParams`); `SignupForm` inner.
+- **State:** `email`, `otp`, `step` (`'email'|'otp'`), `loading`, `error`, `alreadyRegistered`, and `checked` (the render gate).
+- **Guard effect (deps `[searchParams, router]`):** resets step/otp/error; persists `?plan=` to `sessionStorage.signup_plan`; if plan not `pro|team` → `router.replace('/signup/plan')` and return; if `sessionStorage.signup_consent_gdpr !== '1'` → `router.replace('/signup/start?plan=<plan>')` and return; else `setChecked(true)`. **Renders `SignupFallback` until `checked`** (this is the flicker fix — see §11).
+- **API:** `handleRequestOtp` → `requestOtp(email, 'signup')` → `step='otp'`; on "already registered" sets `alreadyRegistered` (shows "Sign in →" link). `handleVerifyOtp` → `verifyOtp(email, otp, {gdpr, marketing})` → `setToken` → clear consent keys → best-effort `selectBillingPlan(token, plan)` (`catch {}`) → clear `signup_plan` → `router.replace(postAuthRedirect(data))`.
+- **Edge:** OTP input digits-only max 6; buttons disabled while `loading` or empty/short input.
+
+### 19.12 Before-you-begin / consent — `app/signup/start/page.tsx`
+
+- **Step 2 of the funnel.** Suspense-wrapped; `plan` resolved from `?plan=` or `sessionStorage.signup_plan` (`pro|team`), else effect `router.replace('/signup/plan')`. Renders `StartFallback` until `plan` set.
+- **State:** `plan`, `gdprConsent`, `marketingConsent`. **No API calls.**
+- **`handleContinue`:** requires `gdprConsent`; writes `sessionStorage.signup_consent_gdpr='1'` and `signup_consent_marketing` (`'1'|'0'`) → `router.push('/signup?plan=<plan>')`.
+- **UI:** 3 static guideline cards; GDPR checkbox required (Continue disabled until checked); "← Change plan" → `/signup/plan`.
+
+### 19.13 Checkout — `app/signup/checkout/page.tsx`
+
+- **Step 4 of the funnel.** Suspense-wrapped; `plan` from `?plan=` (`pro|team|null`). Renders `CheckoutFallback` ("Redirecting to Stripe…") by default.
+- **Effect (deps `[router, plan]`):** no token → `/signup`; no plan → `/signup/plan`. `startCheckout` (guarded by `cancelled`): `getBillingStatus` → `has_access` → `/dashboard`; `billingGateRedirect==='/signup/plan'` → `/signup/plan`; if `status.plan && status.plan !== plan` → redirect to `/signup/checkout?plan=<status.plan>`; if `!status.plan` → `selectBillingPlan(token, plan)`; then `createCheckoutSession(token, plan)` → `window.location.href = session.url` (or error if no url).
+- **Edge/nav:** on error shows message + "← Back to plan selection" (`/signup/plan`); `cancelled` guards all `setState`.
+
+---
+
+## 20. Marketing, Public & Admin Surfaces
+
+These live in the same Next app but are separate from the tenant `/dashboard/*` product. None use `NEXT_PUBLIC_DEV_MODE` (except docs *content* text).
+
+### 20.1 Landing — `app/page.tsx`
+
+- **Client Component**, static marketing. Sections: `SiteNav` → Hero (+ `CalendlyBookModal`, `IntegrationStrip`) → `ThreeWaysConnectSection` → `ConversationCompare` → engineering cards → `TrustBar` → **Pricing grid** (Self-Hosted / Pro / Team) → `CompetitorCompare` → final CTA → footer.
+- **State:** `copied` (which copy button, 2s reset) and `demoOpen` (Calendly modal). **No `useEffect`, no API calls.**
+- **CTAs / nav:** `/signup` (hero, cards, final, footer), `/signup?plan=pro`, `/signup?plan=team`, `/docs`, `/trust`, `/login`, `#pricing`, GitHub. "Book demo" opens `CalendlyBookModal` (`demoOpen`); "Copy MCP config" copies `MCP_CONFIG` JSON.
+- **Rules:** `plan.highlight` → "POPULAR" badge; footer external `http` links → `<a>`, internal → `<Link>`. Responsive via inline `<style>`. No honeypot here (demo capture is the Calendly modal).
+
+### 20.2 Community — `app/community/page.tsx` + `app/community/[id]/page.tsx`
+
+- **Public, unauthenticated.** Uses `lib/community.ts` raw `fetch` (NOT `apiFetch`, no JWT).
+- **List (`community/page.tsx`):** state `filter`, `posts`, `loading`, `showForm`, `err`; `load` depends on `[filter]`, effect re-runs on filter change → `listCommunityPosts(filter)`. Cards show category badge, author, relative time, reply count, excerpt (truncated ~280 chars), up to 3 image thumbnails. After a successful post: `window.location.href = /community/{id}` (full navigation).
+- **`NewPostForm`:** fields name/email/category/title/body/images + **honeypot `website`** (`if (website) return`). Client validation: name required, `title.length ≥ 3`, `body.length ≥ 10`. Image upload via `uploadCommunityImage` (accept png/jpeg/webp/gif, **max 4 per pick, 6 total**, sequential). Categories `question | experience | showcase`.
+- **Detail (`community/[id]/page.tsx`):** state `post`, `loading`, `err`, reply fields + honeypot `website`; `load` depends on `[id]` → `getCommunityPost(id)`. Reply → `createCommunityReply(id, {author_name, body})` → `load()` refresh; reply disabled unless name + `body.length ≥ 2`. Body rendered `white-space: pre-wrap`.
+- **Note:** no `cancelled` guard on the async loads (differs from dashboard convention).
+
+### 20.3 Docs — `app/docs/page.tsx` + `docs/sections.tsx`
+
+- **Client SPA shell.** State `section` (default `'overview'`); `navigate(id)` validates against an 8-item whitelist (`overview, frameworks, python, typescript, rest, mcp, selfhost, concepts`) and scrolls to top. **No API, no hash routing → section resets to overview on refresh.**
+- `sections.tsx` holds all static content + shared `Code`/`Callout`/`Step` components (`Code` has its own 2s copy state). Links out to `/signup`, `/dashboard`, `/trust#…`, `/swagger`, PyPI/npm/GitHub. Documents `NEXT_PUBLIC_DEV_MODE=false` for self-host prod and `ZIZKADB_TELEMETRY=false` opt-out.
+
+### 20.4 Trust — `app/trust/page.tsx`
+
+- **Server Component** (static, SEO `metadata` set). 17 anchor sections (overview, architecture, data model, integrity, performance, security, API, deployment, comparison, licensing, limits, FAQ, contact, …). Desktop-only sticky sidebar (`@media min-width: 900px`). Links to `/docs`, `/swagger`, `/signup`, GitHub, `mailto:founder@zizka.ai`. No state/API.
+
+### 20.5 Admin console — `app/admin/page.tsx` (+ `layout.tsx`)
+
+- **Separate auth** via `zizkadb_admin_token` (localStorage + cookie; `setAdminToken`/`clearAdminToken`). `layout.tsx` sets `robots: noindex/nofollow`. Middleware allows bare `/admin` (login UI) but redirects `/admin/*` without the cookie.
+- **Three tiers:** `AdminPage` boot gate (reads `getAdminToken()`, shows Loading → Login → Dashboard) → `Login` (founder-only `ADMIN_EMAIL = 'founder@zizka.ai'`, OTP via `adminRequestOtp` with 30s `AbortSignal` + `adminVerifyOtp`) → `Dashboard`.
+- **Dashboard:** `OverviewRow` stats + 4 tabs — `subscribers` (`SubscribersSection`), `managed` (`ManagedSection`), `telemetry` (`TelemetrySection`), `demo_requests` (`DemoRequestsSection`). `adminOverview` polls every **10s**; **401/"Not Found" → auto `onLogout()`**.
+- **Data calls** (all admin JWT via `apiFetch`): `adminOverview`, `adminTelemetrySummary` + `adminTelemetryRecent(100)`, `adminManagedOverview`, `adminManagedSubscribers`, `adminManagedUsers`, `adminManagedUsage`, `adminDemoRequests({limit:200})`. Subscriber/managed/demo tabs also poll 10s.
+- **Behaviors:** most tab fetches `.catch(()=>…)` **silently**; **search reloads only on Enter/Refresh** (search text is not in effect deps); subscriber filters `trialing|active|past_due`; managed filters `all|active|keys|no_keys` (→ `has_keys`/`active_7d` query params); Stripe customer links to `dashboard.stripe.com`; empty subscribers message references migration `002_user_billing.sql`. No `NEXT_PUBLIC_DEV_MODE` bypass.
+
+---
+
+## 21. Data Model (backend)
+
+Schema sources: `core/db/schema.sql` (base DDL, Docker init) + `core/db/migrations/002-006` + **runtime idempotent DDL** in `core/db/connection.py` (production relies primarily on this). Extensions: `vector`, `uuid-ossp`. There is no migration `001`.
+
+### 21.1 Postgres tables (key columns)
+
+| Table | Key columns | Purpose |
+|-------|-------------|---------|
+| `tenants` | `tenant_id` (PK), `name`, `embedding_provider`, `embedding_model`, `embedding_use_platform_key`, `embedding_api_key_encrypted` | Root of multi-tenant isolation; per-tenant embedding config (Fernet-encrypted BYOK key) |
+| `agents` | `(agent_id, tenant_id)` (PK), `first_seen`, `last_seen`, `event_count`, `metadata` | Registered agent identities; upserted on every event write |
+| `api_keys` | `key_id` (PK), `tenant_id`, `agent_id` (NULL = tenant-wide, set = agent-scoped), `key_hash` (SHA-256, unique), `key_prefix`, `revoked`, `last_used` | API-key auth; hashed only, prefix for display |
+| `users` | `user_id` (PK), `email` (unique), `tenant_id`, **billing cols** (see §21.2), `gdpr_consent_at`, `marketing_consent`, `last_login` | Dashboard users (passwordless OTP). **All billing state lives here.** |
+| `auth_otps` | `otp_id` (PK), `email`, `otp_hash`, `expires_at`, `used` | Passwordless login OTPs (15-min expiry) |
+| `events` | `event_id` (PK), `tenant_id`, `agent_id`, `timestamp`, `event_type`, `data` (JSONB), `embedding vector(1536)`, `parent_event_id` (causal link), `session_id`, `sequence_no` (BIGSERIAL), `checksum` (SHA-256) | Append-only event log — source of truth. HNSW index on `embedding` (cosine) |
+| `usage_daily` | `(tenant_id, date)` (PK), `events_written`, `queries_run`, `searches_run` | Daily metering (only `events_written` is incremented today) |
+| `community_posts` | `post_id` (PK), `author_name`, `category`, `title`, `body`, `image_urls` (JSONB), `reply_count` | Public community board |
+| `community_replies` | `reply_id` (PK), `post_id` (FK cascade), `author_name`, `body` | Replies; bumps parent `reply_count` |
+| `demo_requests` | `request_id` (PK), `first_name`, `last_name`, `email`, `company_name`, `website`, `ip_address` | Landing "Book demo" submissions |
+| `sdk_telemetry` | `install_id` (PK), `sdk`, `sdk_version`, `runtime`, `os`, `mode` (`cloud`/`self-hosted`), `ping_count` | Anonymous SDK install pings (runtime-only table, not in `schema.sql`) |
+
+**Cascade:** `agents`, `api_keys`, `events`, `usage_daily` cascade from `tenants`. Account deletion explicitly deletes `users`, `auth_otps`, `tenants` and purges Qdrant vectors.
+
+### 21.2 Billing storage (all on `users`)
+
+`plan` (`pro|team`), `subscription_status`, `trial_ends_at`, `stripe_customer_id` (unique), `stripe_subscription_id` (unique), `retention_trial_used` (one-time flag). No separate subscriptions table. `subscription_status` values and transitions are documented in §18.1. Startup backfill: users with NULL plan/status get `plan='pro'`, `subscription_status='trialing'`, `trial_ends_at = created_at + 30d` (`connection.py`, `002_user_billing.sql`).
+
+### 21.3 Qdrant (vector search)
+
+Single collection **`agent_events`**, **1536-dim, COSINE**, point id = `event_id`. Payload is only `{tenant_id, agent_id, event_type, timestamp}` — the full `data` stays in Postgres and is re-fetched after vector search (`search.py`, `memory.py`). **Dual-write:** embeddings go to both Postgres `events.embedding` (HNSW) and Qdrant. Embedding text = `event_type` + flattened `data`; skipped if dim ≠ 1536. Redis caches embeddings 24h.
+
+### 21.4 Connections (`core/db/connection.py`)
+
+`asyncpg` pool (`DATABASE_URL`, min 2 / max 20, `get_pool()`); Redis (`REDIS_URL`, embedding cache, `get_redis()`); Qdrant (`QDRANT_URL`, `get_qdrant()`, collection auto-created). `init_db()` applies idempotent DDL on startup.
+
+### 21.5 Entity relationships
+
+```mermaid
+erDiagram
+    tenants ||--o{ agents : has
+    tenants ||--o{ api_keys : has
+    tenants ||--o{ events : has
+    tenants ||--o{ usage_daily : meters
+    tenants ||--o| users : owns
+    agents ||--o{ events : emits
+    agents ||--o{ api_keys : scoped_to
+    events ||--o| events : parent_event_id
+    community_posts ||--o{ community_replies : has
+    users ||--o{ auth_otps : email_match
+```
+
+---
+
+## 22. Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Tenant** | Isolation root — one per project/customer (`tenants` table). Every event, agent, key, and user belongs to a tenant. |
+| **Agent** | A named AI agent identity within a tenant (`agents`), e.g. `support-bot`. Created in the dashboard; events are logged against it. |
+| **Event** | An append-only record of one agent step (`events`): `event_type` + `data` JSONB, optional `parent_event_id` (causal link) and `session_id`. Source of truth. |
+| **Session** | A grouping of events sharing a `session_id` (one conversation/run). |
+| **Why-chain** | The recursive parent-event lineage for an event (`GET /v1/events/{id}/why`) — "why did this happen?". |
+| **Time-travel** | Reconstructing agent state at a past timestamp by replaying events (`GET /v1/events/at`, `STATE_SET`/`STATE_DELETE` reduction). |
+| **Memory diff** | Per-session summary of new event types / behavior vs prior (`GET /v1/memory/diff/{session_id}`). |
+| **Baseline / drift** | Behavioral comparison of recent vs older sessions; `drift_score` + verdicts `stable/minor/noticeable/significant` (`GET /v1/agents/{id}/baseline`). |
+| **API key** | Credential used by SDKs/MCP to write events (`zizkadb_live_*`, stored hashed). Tenant-wide or **agent-scoped** (bound to one agent). |
+| **JWT (session)** | Dashboard user's access token from OTP login; distinct from API keys. Resolved by `get_tenant`. |
+| **OTP** | One-time 6-digit code for passwordless email login/signup (`auth_otps`, 15-min expiry). |
+| **Billing enforced** | `true` only on managed cloud (`ENV=production` + Stripe keys). When false (self-host), everyone has access. |
+| **pending_checkout** | New managed-cloud user status before Stripe checkout completes — no dashboard access until it becomes `trialing`. |
+| **Retention trial** | One-time extra free month offered in the delete-account modal (`retention_trial_used`). |
+| **Honeypot** | Hidden `website`/`botcheck` form field; if a bot fills it, the submission is silently dropped (community + demo forms). |
+| **Self-host / DEV_MODE** | `NEXT_PUBLIC_DEV_MODE=true` (frontend) / non-production backend — bypasses billing, enables dev-token login. |
 
 ---
 
@@ -374,3 +912,22 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 | Agents home | `app/dashboard/page.tsx` |
 | Settings (keys/embeddings/account) | `app/dashboard/settings/page.tsx` |
 | Book-demo modal | `components/marketing/CalendlyBookModal.tsx` |
+| Operator admin | `app/admin/{layout,page}.tsx` |
+| Build config / rewrites / env | `next.config.mjs` |
+
+### Backend & infra (touch points)
+
+| Concern | File |
+|---------|------|
+| FastAPI app + router mounts | `core/main.py` |
+| Auth resolution (JWT / API key / dev) | `core/api/deps.py` |
+| Auth service (JWT, OTP, API keys) | `core/services/auth.py`, `core/api/auth.py` |
+| Billing state machine + Stripe | `core/services/billing.py`, `core/api/billing_checkout.py`, `core/api/billing.py` (webhook) |
+| Account (retention trial, delete) | `core/api/account.py`, `core/services/account.py` |
+| Event write pipeline | `core/services/event_write.py`, `core/api/events.py` |
+| Memory (context/diff/forget) | `core/api/memory.py` |
+| Agents + baseline/drift | `core/api/agents.py` |
+| Embeddings config (BYOK) | `core/services/embedding_config.py`, `core/api/settings.py` |
+| Admin analytics/telemetry | `core/api/admin.py` |
+| Reverse proxy / routing | `infra/nginx.conf` |
+| Event producers | `sdk/python`, `sdk/typescript`, `integrations/*`, `mcp/` |

--- a/dashboard/app/dashboard/page.tsx
+++ b/dashboard/app/dashboard/page.tsx
@@ -1,14 +1,14 @@
 'use client'
 
-import { useEffect, useState } from 'react'
-import { useRouter } from 'next/navigation'
-import { getAgents, createAgent, deleteAgent } from '@/lib/api'
-import { getToken, requireAuth } from '@/lib/auth'
-import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
 import { ApiKeyUsage } from '@/components/ApiKeyUsage'
-import { formatDistanceToNow } from 'date-fns'
-import { Zap, Plus, Trash2, Copy, Check } from 'lucide-react'
 import { GettingStartedChecklist } from '@/components/ConnectionStatus'
+import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
+import { createAgent, deleteAgent, getAgents } from '@/lib/api'
+import { getToken, requireAuth } from '@/lib/auth'
+import { formatDistanceToNow } from 'date-fns'
+import { Check, Copy, Plus, Trash2, Zap } from 'lucide-react'
+import { useRouter } from 'next/navigation'
+import { useEffect, useState } from 'react'
 
 interface Agent {
   agent: string

--- a/dashboard/app/dashboard/page.tsx
+++ b/dashboard/app/dashboard/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { getAgents, createAgent, deleteAgent } from '@/lib/api'
 import { getToken, requireAuth } from '@/lib/auth'
+import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
+import { ApiKeyUsage } from '@/components/ApiKeyUsage'
 import { formatDistanceToNow } from 'date-fns'
 import { Zap, Plus, Trash2, Copy, Check } from 'lucide-react'
 import { GettingStartedChecklist } from '@/components/ConnectionStatus'
@@ -29,6 +31,7 @@ export default function DashboardPage() {
   const [newAgentKey, setNewAgentKey] = useState<string | null>(null)
   const [newAgentName, setNewAgentName] = useState<string | null>(null)
   const [copied, setCopied] = useState(false)
+  const quota = useApiKeyQuota()
 
   useEffect(() => {
     const token = getToken()
@@ -88,6 +91,7 @@ export default function DashboardPage() {
       const data = await getAgents(token)
       setAgents(Array.isArray(data) ? data : [])
       setLastSync(new Date())
+      await quota.refresh()
     } catch (err) {
       setCreateErr(err instanceof Error ? err.message : 'Failed to create agent')
     } finally {
@@ -104,6 +108,7 @@ export default function DashboardPage() {
       const token = requireAuth()
       await deleteAgent(token, agentId)
       setAgents(prev => prev.filter(a => a.agent !== agentId))
+      await quota.refresh()
     } catch (err) {
       alert(err instanceof Error ? err.message : 'Failed to delete agent')
     } finally {
@@ -195,6 +200,7 @@ export default function DashboardPage() {
             </button>
           </div>
         )}
+        {!quota.unlimited && <ApiKeyUsage quota={quota} className="mb-3" />}
         <form onSubmit={handleCreateAgent} className="flex gap-3">
           <input
             value={newAgentId}
@@ -207,14 +213,20 @@ export default function DashboardPage() {
           />
           <button
             type="submit"
-            disabled={creating || !newAgentId.trim()}
-            className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-black disabled:opacity-40"
+            disabled={creating || !newAgentId.trim() || quota.at_limit}
+            title={quota.at_limit ? 'API key limit reached — each agent includes a key' : undefined}
+            className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-black disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ background: '#22c55e' }}
           >
             <Plus size={14} />
             {creating ? 'Creating…' : 'Create'}
           </button>
         </form>
+        {quota.at_limit && (
+          <p className="text-xs mt-2" style={{ color: '#f87171' }}>
+            You&apos;ve reached your plan&apos;s API key limit. Delete an API key or upgrade to add more agents.
+          </p>
+        )}
         {createErr && (
           <p className="text-xs mt-2" style={{ color: '#f87171' }}>{createErr}</p>
         )}

--- a/dashboard/app/dashboard/settings/page.tsx
+++ b/dashboard/app/dashboard/settings/page.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { ApiKeyUsage } from '@/components/ApiKeyUsage'
+import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
+import { createApiKey, deleteManagedAccount, getAccountOptions, getApiKeys, getEmbeddingCatalog, getEmbeddingSettings, grantRetentionTrial, revokeApiKey, sendTestEvent, updateEmbeddingSettings, type AccountOptions } from '@/lib/api'
+import { clearToken, requireAuth } from '@/lib/auth'
+import { AlertTriangle, Check, Copy, Key, Plus, Trash2, X } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
-import { getApiKeys, createApiKey, revokeApiKey, getEmbeddingCatalog, getEmbeddingSettings, updateEmbeddingSettings, sendTestEvent, getAccountOptions, grantRetentionTrial, deleteManagedAccount, type AccountOptions } from '@/lib/api'
-import { requireAuth, clearToken } from '@/lib/auth'
-import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
-import { ApiKeyUsage } from '@/components/ApiKeyUsage'
-import { Key, Trash2, Plus, Copy, Check, AlertTriangle, X } from 'lucide-react'
+import { useEffect, useState } from 'react'
 
 interface ApiKey {
   key_id: string

--- a/dashboard/app/dashboard/settings/page.tsx
+++ b/dashboard/app/dashboard/settings/page.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { getApiKeys, createApiKey, revokeApiKey, getEmbeddingCatalog, getEmbeddingSettings, updateEmbeddingSettings, sendTestEvent, getAccountOptions, grantRetentionTrial, deleteManagedAccount, type AccountOptions } from '@/lib/api'
 import { requireAuth, clearToken } from '@/lib/auth'
+import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
+import { ApiKeyUsage } from '@/components/ApiKeyUsage'
 import { Key, Trash2, Plus, Copy, Check, AlertTriangle, X } from 'lucide-react'
 
 interface ApiKey {
@@ -44,6 +46,7 @@ export default function SettingsPage() {
   const [accountBusy, setAccountBusy] = useState(false)
   const [accountMsg, setAccountMsg] = useState('')
   const [accountErr, setAccountErr] = useState('')
+  const quota = useApiKeyQuota()
 
   useEffect(() => {
     let token: string
@@ -76,6 +79,7 @@ export default function SettingsPage() {
       const token = requireAuth()
       await revokeApiKey(token, key.key_id)
       setKeys(prev => prev.filter(k => k.key_id !== key.key_id))
+      await quota.refresh()
     } catch (e) {
       alert(e instanceof Error ? e.message : 'Failed to revoke key')
     } finally {
@@ -229,6 +233,7 @@ export default function SettingsPage() {
           Most users should create per-agent keys on the{' '}
           <Link href="/dashboard" className="underline" style={{ color: '#22c55e' }}>Agents</Link> page instead.
         </p>
+        {!quota.unlimited && <ApiKeyUsage quota={quota} className="mb-3" />}
         {tenantNewKey && (
           <div className="rounded-lg p-3 mb-3" style={{ background: '#0d2010', border: '1px solid #22c55e40' }}>
             <p className="text-xs mb-2" style={{ color: '#22c55e' }}>Tenant-wide key — copy now</p>
@@ -263,6 +268,7 @@ export default function SettingsPage() {
                 last_used: null,
               }, ...prev])
               setTenantKeyName('')
+              await quota.refresh()
             } catch (err) {
               alert(err instanceof Error ? err.message : 'Failed to create key')
             } finally {
@@ -277,7 +283,7 @@ export default function SettingsPage() {
             className="flex-1 rounded-lg px-3 py-2 text-sm text-white outline-none"
             style={{ background: '#1a1a1a', border: '1px solid #2a2a2a' }}
           />
-          <button type="submit" disabled={tenantKeyCreating} className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-black disabled:opacity-40" style={{ background: '#22c55e' }}>
+          <button type="submit" disabled={tenantKeyCreating || quota.at_limit} title={quota.at_limit ? 'API key limit reached for your plan' : undefined} className="flex items-center gap-1.5 px-4 py-2 rounded-lg text-sm font-medium text-black disabled:opacity-40 disabled:cursor-not-allowed" style={{ background: '#22c55e' }}>
             <Plus size={14} />
             {tenantKeyCreating ? 'Creating…' : 'Create'}
           </button>

--- a/dashboard/components/AgentApiKeys.tsx
+++ b/dashboard/components/AgentApiKeys.tsx
@@ -1,11 +1,11 @@
 'use client'
 
-import { useCallback, useEffect, useState } from 'react'
+import { ApiKeyUsage } from '@/components/ApiKeyUsage'
+import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
 import { createAgentApiKey, getAgentApiKeys, revokeAgentApiKey, sendAgentTestEvent } from '@/lib/api'
 import { requireAuth } from '@/lib/auth'
-import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
-import { ApiKeyUsage } from '@/components/ApiKeyUsage'
-import { Key, Plus, Copy, Check, Trash2, Zap } from 'lucide-react'
+import { Check, Copy, Key, Plus, Trash2, Zap } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
 
 export interface AgentApiKey {
   key_id: string

--- a/dashboard/components/AgentApiKeys.tsx
+++ b/dashboard/components/AgentApiKeys.tsx
@@ -3,6 +3,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import { createAgentApiKey, getAgentApiKeys, revokeAgentApiKey, sendAgentTestEvent } from '@/lib/api'
 import { requireAuth } from '@/lib/auth'
+import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
+import { ApiKeyUsage } from '@/components/ApiKeyUsage'
 import { Key, Plus, Copy, Check, Trash2, Zap } from 'lucide-react'
 
 export interface AgentApiKey {
@@ -30,6 +32,7 @@ export function AgentApiKeys({
   const [err, setErr] = useState('')
   const [testBusy, setTestBusy] = useState(false)
   const [testMsg, setTestMsg] = useState('')
+  const quota = useApiKeyQuota()
 
   const load = useCallback(async () => {
     try {
@@ -55,6 +58,7 @@ export function AgentApiKeys({
       const res = await createAgentApiKey(token, agentId)
       setNewKey(res.key)
       await load()
+      await quota.refresh()
     } catch (e) {
       setErr(e instanceof Error ? e.message : 'Failed to create key')
     } finally {
@@ -71,6 +75,7 @@ export function AgentApiKeys({
       const token = requireAuth()
       await revokeAgentApiKey(token, agentId, key.key_id)
       setKeys(prev => prev.filter(k => k.key_id !== key.key_id))
+      await quota.refresh()
     } catch (e) {
       alert(e instanceof Error ? e.message : 'Failed to revoke key')
     } finally {
@@ -124,9 +129,10 @@ export function AgentApiKeys({
           </button>
           <button
             type="button"
-            disabled={creating}
+            disabled={creating || quota.at_limit}
             onClick={handleCreate}
-            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-black disabled:opacity-40"
+            title={quota.at_limit ? 'API key limit reached for your plan' : undefined}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-black disabled:opacity-40 disabled:cursor-not-allowed"
             style={{ background: '#22c55e' }}
           >
             <Plus size={13} />
@@ -134,6 +140,11 @@ export function AgentApiKeys({
           </button>
         </div>
       </div>
+      {!quota.unlimited && (
+        <div className="px-5 py-3" style={{ background: '#111', borderBottom: '1px solid #1f1f1f' }}>
+          <ApiKeyUsage quota={quota} />
+        </div>
+      )}
       {testMsg && (
         <p className="px-5 py-2 text-xs" style={{ color: '#22c55e', background: '#111', borderBottom: '1px solid #1f1f1f' }}>
           {testMsg}

--- a/dashboard/components/ApiKeyUsage.tsx
+++ b/dashboard/components/ApiKeyUsage.tsx
@@ -1,0 +1,49 @@
+'use client'
+
+import type { ApiKeyQuota } from '@/hooks/useApiKeyQuota'
+
+/**
+ * Account-wide API key usage indicator. Renders nothing when the plan is
+ * unlimited (self-host, enforcement off, or an uncapped plan) so it adds zero
+ * friction for those users. The label is explicitly account-wide because the
+ * count is tenant-total even on a single agent's page.
+ */
+export function ApiKeyUsage({
+  quota,
+  className,
+}: {
+  quota: ApiKeyQuota
+  className?: string
+}) {
+  if (quota.loading || quota.unlimited || quota.limit === null) return null
+
+  const { used, limit, at_limit } = quota
+  const pct = Math.min(100, Math.round((used / limit) * 100))
+  const accent = at_limit ? '#f87171' : '#22c55e'
+
+  return (
+    <div className={className} aria-live="polite">
+      <div className="flex items-center justify-between text-xs mb-1">
+        <span style={{ color: '#e5e5e5' }}>Account API keys</span>
+        <span style={{ color: at_limit ? '#f87171' : '#e5e5e5' }}>
+          {used} / {limit} used
+        </span>
+      </div>
+      <div
+        className="h-1.5 rounded-full overflow-hidden"
+        style={{ background: '#1a1a1a' }}
+        role="progressbar"
+        aria-valuenow={used}
+        aria-valuemin={0}
+        aria-valuemax={limit}
+      >
+        <div className="h-full rounded-full" style={{ width: `${pct}%`, background: accent }} />
+      </div>
+      {at_limit && (
+        <p className="text-xs mt-1.5" style={{ color: '#f87171' }}>
+          Delete an API key or upgrade your plan to create more.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/dashboard/hooks/useApiKeyQuota.ts
+++ b/dashboard/hooks/useApiKeyQuota.ts
@@ -1,0 +1,63 @@
+'use client'
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { getApiKeyUsage, type ApiKeyUsage } from '@/lib/api'
+import { getToken } from '@/lib/auth'
+
+export interface ApiKeyQuota extends ApiKeyUsage {
+  loading: boolean
+  /** Re-fetch account-wide usage. Call after any create/delete. */
+  refresh: () => Promise<void>
+}
+
+const UNLIMITED_DEFAULT: ApiKeyUsage = {
+  plan: null,
+  limit: null,
+  used: 0,
+  unlimited: true,
+  at_limit: false,
+}
+
+/**
+ * Account-wide API key quota. Single source for every screen that creates keys.
+ *
+ * Fail-open by design: if the usage fetch fails, the quota stays "unlimited" so
+ * the UI never blocks a create — the backend guard remains the real enforcement.
+ * Refreshes on mount and on window focus (plan/keys may change in another tab).
+ */
+export function useApiKeyQuota(): ApiKeyQuota {
+  const [usage, setUsage] = useState<ApiKeyUsage>(UNLIMITED_DEFAULT)
+  const [loading, setLoading] = useState(true)
+  const mounted = useRef(true)
+
+  const refresh = useCallback(async () => {
+    const token = getToken()
+    if (!token) {
+      // No session: nothing to fetch, but stop showing the loading state so
+      // callers relying on `loading` don't hang indefinitely.
+      if (mounted.current) setLoading(false)
+      return
+    }
+    try {
+      const next = await getApiKeyUsage(token)
+      if (mounted.current) setUsage(next)
+    } catch {
+      // Fail-open: keep the unlimited default; never block the UI on a usage error.
+    } finally {
+      if (mounted.current) setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    mounted.current = true
+    refresh()
+    const onFocus = () => refresh()
+    window.addEventListener('focus', onFocus)
+    return () => {
+      mounted.current = false
+      window.removeEventListener('focus', onFocus)
+    }
+  }, [refresh])
+
+  return { ...usage, loading, refresh }
+}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -248,6 +248,20 @@ export async function revokeApiKey(token: string, keyId: string) {
   })
 }
 
+export interface ApiKeyUsage {
+  plan: string | null
+  limit: number | null
+  used: number
+  unlimited: boolean
+  at_limit: boolean
+}
+
+// Account-wide API key quota for the current plan. The backend is the source of
+// truth for the limit, so the UI never hardcodes plan limits.
+export async function getApiKeyUsage(token: string): Promise<ApiKeyUsage> {
+  return apiFetch('/v1/auth/api-keys/usage', token)
+}
+
 export async function requestOtp(email: string, intent?: 'signup' | 'login') {
   const res = await fetch(`${API}/v1/auth/request-otp`, {
     method: 'POST',

--- a/docs/DEVELOPER_TECHNICAL_BRIEF.md
+++ b/docs/DEVELOPER_TECHNICAL_BRIEF.md
@@ -218,7 +218,7 @@ Base URL: `https://db.zizka.ai` (self-host: your host, port **8000**).
 | Agents | GET | `/v1/agents/{id}/sessions` | Sessions |
 | Auth | POST | `/v1/auth/request-otp` | Email OTP |
 | Auth | POST | `/v1/auth/verify-otp` | Get JWT |
-| Auth | POST | `/v1/auth/api-keys` | Create API key |
+| Auth | POST | `/v1/auth/api-keys` | Create API key (dashboard JWT only; plan-limited) |
 | Health | GET | `/health` | Status check |
 | Stats | GET | `/v1/stats` | Public install counters (homepage) |
 

--- a/docs/DEVELOPER_TECHNICAL_BRIEF.md
+++ b/docs/DEVELOPER_TECHNICAL_BRIEF.md
@@ -1,12 +1,12 @@
 # ZizkaDB — Developer Technical Brief
 
-**Audience:** Marketing / sales talking to software engineers, ML engineers, and agent builders.  
-**Purpose:** Answer technical questions accurately without overstating the product.  
-**Last updated:** May 2026  
-**Product URL:** https://db.zizka.ai  
-**Docs:** https://db.zizka.ai/docs  
-**API explorer:** https://db.zizka.ai/swagger  
-**GitHub:** https://github.com/Zizka-ai/ZizkaDB  
+**Audience:** Marketing / sales talking to software engineers, ML engineers, and agent builders.
+**Purpose:** Answer technical questions accurately without overstating the product.
+**Last updated:** May 2026
+**Product URL:** https://db.zizka.ai
+**Docs:** https://db.zizka.ai/docs
+**API explorer:** https://db.zizka.ai/swagger
+**GitHub:** https://github.com/Zizka-ai/ZizkaDB
 
 ---
 
@@ -107,9 +107,9 @@ context = await db.context_for(agent="support-bot", task="user asking about bill
 
 After enough sessions (with `session_id` on logs), ZizkaDB compares **recent** behavior vs **historical baseline**:
 
-- Event-type distribution  
-- Parent→child transition patterns  
-- Session length, error rate  
+- Event-type distribution
+- Parent→child transition patterns
+- Session length, error rate
 
 Returns a **drift score** (0 = identical, 1 = totally different) and verdict: `stable`, `minor_drift`, `noticeable_drift`, `significant_drift`.
 
@@ -123,7 +123,7 @@ baseline = await db.baseline(agent="support-bot", recent_window=50)
 
 ### 4.7 Session diff & GDPR forget
 
-- **`memory_diff(session_id)`** — what changed in a session (API: `GET /v1/memory/diff/{session_id}`).  
+- **`memory_diff(session_id)`** — what changed in a session (API: `GET /v1/memory/diff/{session_id}`).
 - **`forget(filter_key, filter_value)`** — delete all events matching metadata (e.g. `user_id`, `email`) for GDPR erasure (API: `DELETE /v1/memory/forget`).
 
 ### 4.8 Audit trail
@@ -200,7 +200,7 @@ Base URL: `https://db.zizka.ai` (self-host: your host, port **8000**).
 **Auth:** `Authorization: Bearer <token>`
 
 - Production API keys: prefix **`zizkadb_live_`**
-- Dashboard login uses JWT (OTP email)  
+- Dashboard login uses JWT (OTP email)
 - Self-host dev: optional `DEV_API_KEY` in `.env` (never in production)
 
 | Area | Method | Path | Purpose |
@@ -249,12 +249,12 @@ Python 3.10+, TypeScript works on Node/Deno/Bun/edge.
 
 **Managed production (db.zizka.ai):**
 
-- **Dashboard:** Next.js 14 (PM2 on port 3001 behind nginx)  
-- **API:** FastAPI (Python), Docker, port 8000  
-- **Postgres** + **pgvector** — events, tenants, embeddings  
-- **Qdrant** — vector search  
-- **Redis** — caching/sessions  
-- **Nginx** — TLS, routes `/` → frontend, `/v1/` → API  
+- **Dashboard:** Next.js 14 (PM2 on port 3001 behind nginx)
+- **API:** FastAPI (Python), Docker, port 8000
+- **Postgres** + **pgvector** — events, tenants, embeddings
+- **Qdrant** — vector search
+- **Redis** — caching/sessions
+- **Nginx** — TLS, routes `/` → frontend, `/v1/` → API
 
 **Self-host (Docker Compose):**
 
@@ -274,9 +274,9 @@ Stack: postgres (pgvector), qdrant, redis, api. Dashboard optional (`npm run dev
 
 ## 10. Authentication & onboarding flow
 
-1. Sign up at **https://db.zizka.ai/signup** — email OTP, no password.  
-2. Dashboard → **Settings** → **Create API key** (`zizkadb_live_...`).  
-3. Paste key into SDK, MCP env, or `Authorization: Bearer` header.  
+1. Sign up at **https://db.zizka.ai/signup** — email OTP, no password.
+2. Dashboard → **Settings** → **Create API key** (`zizkadb_live_...`).
+3. Paste key into SDK, MCP env, or `Authorization: Bearer` header.
 4. Start logging from agent code or MCP.
 
 **Multi-tenant:** API keys are scoped to a tenant/project; events are isolated per tenant.
@@ -334,31 +334,31 @@ Use the comparison on the homepage; verify competitors’ docs before live debat
 
 ## 14. FAQ — hard questions from developers
 
-**Q: How is this different from LangSmith?**  
+**Q: How is this different from LangSmith?**
 A: LangSmith is excellent for LangChain-centric tracing and evals. ZizkaDB is a **standalone operational DB** with causal trees, time travel, cross-agent queries, and behavioral baselines — works with any stack.
 
-**Q: How is this different from Mem0?**  
+**Q: How is this different from Mem0?**
 A: Mem0 focuses on long-term memory retrieval for prompts. ZizkaDB adds **causal lineage, session replay, drift baselines, and audit-oriented event storage**.
 
-**Q: Do we need to replace Pinecone?**  
+**Q: Do we need to replace Pinecone?**
 A: No. Pinecone is for RAG document search. ZizkaDB is for **agent decision history**. Many teams use both.
 
-**Q: Does it wrap our LLM calls?**  
+**Q: Does it wrap our LLM calls?**
 A: No. You add `db.log()` (or MCP `log_event`) where you already handle messages/tools. One line for causal link: `parent_id=...`.
 
-**Q: Latency impact?**  
+**Q: Latency impact?**
 A: Logging is async HTTP; embedding generation is non-blocking on the hot path. Typical integration is fire-and-forget `await db.log(...)`.
 
-**Q: What if OpenAI is down / we don’t use OpenAI?**  
+**Q: What if OpenAI is down / we don’t use OpenAI?**
 A: Logging and causal features work without embeddings. Semantic search and `context_for` need embeddings (today: OpenAI). Other embedding providers = roadmap; say “check with team” unless confirmed shipped.
 
-**Q: PII / GDPR?**  
+**Q: PII / GDPR?**
 A: You control what goes in `data` and `metadata`. `forget()` deletes by metadata filter. Self-host keeps data on your infra.
 
-**Q: Can we use it in regulated environments?**  
+**Q: Can we use it in regulated environments?**
 A: Self-host + your VPC is the usual answer. Managed cloud: discuss DPA, retention, and region with founders — don’t invent certifications.
 
-**Q: PyPI package confusion?**  
+**Q: PyPI package confusion?**
 A: Install **`zizkadb-sdk`** (not the unrelated `agentdb` package on PyPI). Import: `from zizkadb import ZizkaDB`.
 
 ---
@@ -394,11 +394,11 @@ curl -X POST https://db.zizka.ai/v1/events \
 
 ## 16. What marketing should **not** claim (yet)
 
-- “Real-time alerts” everywhere — baseline exists; **alerting product** may be partial/roadmap (homepage mentions “Alerts coming” for session 50 narrative).  
-- “Replaces your observability stack” — it complements APM/logs; different layer.  
-- “Detects hallucinations” — drift is **behavioral statistics**, not truth verification.  
-- “SOC2 / HIPAA certified” — unless explicitly launched.  
-- “Works offline” — needs API reachability (or self-host on localhost).  
+- “Real-time alerts” everywhere — baseline exists; **alerting product** may be partial/roadmap (homepage mentions “Alerts coming” for session 50 narrative).
+- “Replaces your observability stack” — it complements APM/logs; different layer.
+- “Detects hallucinations” — drift is **behavioral statistics**, not truth verification.
+- “SOC2 / HIPAA certified” — unless explicitly launched.
+- “Works offline” — needs API reachability (or self-host on localhost).
 
 When unsure: **“Let me connect you to engineering”** or point to **docs + GitHub**.
 

--- a/wiki/REST-API.md
+++ b/wiki/REST-API.md
@@ -57,11 +57,11 @@ GET /v1/events/{event_id}/why?depth=10
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/v1/agents` | List agents |
-| POST | `/v1/agents` | Create agent + first key |
+| POST | `/v1/agents` | Create agent + first key (dashboard JWT only) |
 | DELETE | `/v1/agents/{id}` | Delete agent + events + keys |
 | POST | `/v1/agents/{id}/test-event` | Dashboard test (JWT) |
 | GET | `/v1/agents/{id}/api-keys` | List keys |
-| POST | `/v1/agents/{id}/api-keys` | Create key |
+| POST | `/v1/agents/{id}/api-keys` | Create key (dashboard JWT only) |
 | DELETE | `/v1/agents/{id}/api-keys/{key_id}` | Revoke key |
 
 ## Auth / keys
@@ -70,9 +70,12 @@ GET /v1/events/{event_id}/why?depth=10
 |--------|------|-------------|
 | POST | `/v1/auth/request-otp` | Login OTP |
 | POST | `/v1/auth/verify-otp` | Get JWT |
-| POST | `/v1/auth/api-keys` | Tenant-wide key |
+| POST | `/v1/auth/api-keys` | Tenant-wide key (dashboard JWT only) |
 | GET | `/v1/auth/api-keys` | List all keys |
+| GET | `/v1/auth/api-keys/usage` | Plan key quota `{plan, limit, used, unlimited, at_limit}` |
 | DELETE | `/v1/auth/api-keys/{id}` | Revoke key |
+
+**API key creation** requires a dashboard login session (JWT), not an API key. Active keys per tenant are limited by plan (Pro 3, Team 10; self-host/other unlimited); exceeding the limit returns `409` with `{detail:{code:"api_key_limit_reached", plan, limit, used}}`. Enforcement is gated by the `API_KEY_LIMITS_ENFORCED` server flag.
 
 ## Health
 


### PR DESCRIPTION
## Summary

Adds subscription-plan-based limits on the number of **active API keys** a tenant can have — **Pro: 3**, **Team: 10**, everything else (self-host, free, unknown plan) **unlimited**. The limit counts *all* active keys, both account-wide and agent-scoped, so each agent (which auto-creates a key) consumes one slot on Pro/Team.

Enforcement ships **dormant behind a kill switch** (`API_KEY_LIMITS_ENFORCED`, default OFF) so it can be reviewed and merged safely, then enabled per-environment after measuring existing tenants. Existing over-limit keys are never revoked — only *new* creates are blocked at the limit.

## What's included

**Backend**
- `core/services/plan_limits.py` — single source of truth for per-plan caps + the `API_KEY_LIMITS_ENFORCED` kill switch. Adding/changing a limit is a one-line change here.
- `assert_and_reserve_api_key_slot` — an advisory-locked, **fail-open** guard that runs inside a transaction before every key/agent create, so concurrent double-clicks/tabs can't race past the cap. Any plan-lookup error allows the create (it's a UX guard, not a security boundary).
- Key creation is restricted to **dashboard JWT sessions** (a scoped API key can no longer mint keys).
- Unified `fetch_tenant_plan(executor)` resolver (works with a pool or a txn connection) and a new `GET /v1/auth/api-keys/usage` endpoint returning `{plan, limit, used, unlimited, at_limit}`.
- `dashboard_session_dependency` factory dedupes the JWT-only auth logic previously copy-pasted across `auth`, `agents`, `account`, and `settings`.

**Frontend**
- `useApiKeyQuota` hook + `<ApiKeyUsage>` component — reads limits from the backend (no hardcoded numbers), shows used/limit + progress bar, fail-open on fetch error.
- Create buttons disable at the limit and the quota refreshes after every create/delete across **settings**, **agent detail**, and **agents home**.

**Docs & tests**
- Updated `DASHBOARD_KNOWLEDGE_BASE.md`, Cursor rules, and `wiki/REST-API.md`.
- New `core/tests/test_plan_limits.py` — 25 infrastructure-free tests covering the config logic, kill switch, and the enforcement guard (under/at/over limit, unlimited plans, disabled enforcement, fail-open on error).

## Rollout

Feature is inert until enabled. To activate in an environment (e.g. AWS):
1. **First** run an over-limit audit so no existing Pro/Team customer is retroactively blocked from managing keys.
2. Set `API_KEY_LIMITS_ENFORCED=true` on the API service and restart. No code deploy or DB migration needed to toggle.

```sql
-- Over-limit audit (run before enabling in prod)
SELECT u.plan, k.tenant_id, COUNT(*) AS active_keys
FROM api_keys k
JOIN users u ON u.tenant_id = k.tenant_id
WHERE k.revoked = FALSE
GROUP BY k.tenant_id, u.plan
HAVING (u.plan = 'pro'  AND COUNT(*) > 3)
    OR (u.plan = 'team' AND COUNT(*) > 10);