### PR TITLE
fix: intent-based OTP auth for login vs signup

### DIFF
--- a/core/api/admin.py
+++ b/core/api/admin.py
@@ -108,7 +108,7 @@ async def admin_verify_otp(body: AdminOTPVerify):
         # We reuse verify_otp() to validate + consume the OTP record.
         # We discard its returned tokens; admin gets a separately minted
         # token with is_admin=true and no tenant context.
-        await verify_otp(ADMIN_EMAIL, body.otp)
+        await verify_otp(ADMIN_EMAIL, body.otp, intent="login")
     except ValueError as e:
         raise HTTPException(status_code=401, detail=str(e))
 

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -46,12 +46,13 @@ _DEV_EMAIL     = "dev@localhost"
 
 class RequestOTPBody(BaseModel):
     email: EmailStr
-    intent: Literal["signup", "login"] | None = None
+    intent: Literal["signup", "login"] = "login"
 
 
 class VerifyOTPBody(BaseModel):
     email: EmailStr
     otp: str
+    intent: Literal["signup", "login"] = "login"
     gdpr_consent: bool | None = None
     marketing_consent: bool | None = None
 
@@ -74,6 +75,12 @@ async def request_otp_route(body: RequestOTPBody):
             detail="This email is already registered. Please sign in instead.",
         )
 
+    if body.intent == "login" and not await email_exists(email):
+        raise HTTPException(
+            status_code=404,
+            detail="No account found for this email. Create an account to get started.",
+        )
+
     try:
         await request_otp(email)
         return {"message": "Code sent"}
@@ -89,6 +96,7 @@ async def verify_otp_route(body: VerifyOTPBody, response: Response):
         tokens = await verify_otp(
             email,
             body.otp,
+            intent=body.intent,
             gdpr_consent=body.gdpr_consent,
             marketing_consent=body.marketing_consent,
         )
@@ -103,8 +111,12 @@ async def verify_otp_route(body: VerifyOTPBody, response: Response):
 
     from services.billing import billing_status_payload, fetch_user_billing
 
-    billing_row = await fetch_user_billing(email=email)
-    billing = billing_status_payload(billing_row)
+    billing = billing_status_payload(None)
+    try:
+        billing_row = await fetch_user_billing(email=email)
+        billing = billing_status_payload(billing_row)
+    except Exception as e:
+        log.warning("billing status lookup failed after verify for %s: %s", email, e)
 
     response.set_cookie(
         key="refresh_token",

--- a/core/services/auth.py
+++ b/core/services/auth.py
@@ -7,6 +7,7 @@ import jwt
 import bcrypt
 import random
 import smtplib
+from typing import Literal
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 from datetime import datetime, timedelta, timezone
@@ -170,17 +171,27 @@ async def _save_signup_consent(
     )
 
 
+AuthIntent = Literal["login", "signup"]
+
+_LOGIN_NO_ACCOUNT = (
+    "No account found for this email. Create an account to get started."
+)
+_SIGNUP_ALREADY_REGISTERED = (
+    "This email is already registered. Please sign in instead."
+)
+_SIGNUP_GDPR_REQUIRED = "GDPR consent is required to create an account."
+
+
 async def verify_otp(
     email: str,
     otp: str,
     *,
+    intent: AuthIntent = "login",
     gdpr_consent: bool | None = None,
     marketing_consent: bool | None = None,
 ) -> dict:
     email = email.lower().strip()
     pool = get_pool()
-
-    is_new_user = not await email_exists(email)
 
     row = await pool.fetchrow(
         """
@@ -198,39 +209,77 @@ async def verify_otp(
     if not valid:
         raise ValueError("Invalid OTP")
 
-    await pool.execute(
-        "UPDATE auth_otps SET used = TRUE WHERE otp_id = $1",
-        row["otp_id"],
-    )
+    user_exists = await email_exists(email)
+
+    if intent == "login":
+        if not user_exists:
+            raise ValueError(_LOGIN_NO_ACCOUNT)
+    elif intent == "signup":
+        if user_exists:
+            raise ValueError(_SIGNUP_ALREADY_REGISTERED)
+        if not gdpr_consent:
+            raise ValueError(_SIGNUP_GDPR_REQUIRED)
+    else:
+        raise ValueError("Invalid authentication intent")
 
     async with pool.acquire() as conn:
         async with conn.transaction():
-            # Upsert user + tenant — explicit ::text casts avoid asyncpg type ambiguity
-            user = await conn.fetchrow(
-                """
-                WITH ins_tenant AS (
-                    INSERT INTO tenants (name)
-                    SELECT $1::text
-                    WHERE NOT EXISTS (SELECT 1 FROM users WHERE email = $1::text)
-                    RETURNING tenant_id
-                ),
-                ins_user AS (
-                    INSERT INTO users (email, tenant_id, last_login)
-                    VALUES (
-                        $1::text,
-                        (SELECT tenant_id FROM ins_tenant),
-                        NOW()
-                    )
-                    ON CONFLICT (email) DO UPDATE SET last_login = NOW()
-                    RETURNING user_id, email, tenant_id
+            if intent == "login":
+                user = await conn.fetchrow(
+                    """
+                    SELECT user_id, email, tenant_id
+                    FROM users WHERE email = $1
+                    """,
+                    email,
                 )
-                SELECT * FROM ins_user
-                """,
-                email,
-            )
+                if not user:
+                    raise ValueError(_LOGIN_NO_ACCOUNT)
 
-            user_id = str(user["user_id"])
-            tenant_id = user["tenant_id"]
+                await conn.execute(
+                    "UPDATE users SET last_login = NOW() WHERE user_id = $1::uuid",
+                    user["user_id"],
+                )
+                user_id = str(user["user_id"])
+                tenant_id = user["tenant_id"]
+            else:
+                tenant_id = await conn.fetchval(
+                    "INSERT INTO tenants (name) VALUES ($1) RETURNING tenant_id",
+                    email,
+                )
+                user = await conn.fetchrow(
+                    """
+                    INSERT INTO users (email, tenant_id, last_login)
+                    VALUES ($1, $2, NOW())
+                    RETURNING user_id, email, tenant_id
+                    """,
+                    email,
+                    tenant_id,
+                )
+                user_id = str(user["user_id"])
+                consent_at = datetime.now(timezone.utc)
+                try:
+                    await _save_signup_consent(
+                        db=conn,
+                        user_id=user_id,
+                        consent_at=consent_at,
+                        marketing_consent=bool(marketing_consent),
+                    )
+                except Exception as e:
+                    log.warning(
+                        "consent persistence skipped for user %s: %s", user_id, e
+                    )
+                await conn.execute(
+                    """
+                    UPDATE users
+                    SET plan = COALESCE(plan, 'pro'),
+                        subscription_status = COALESCE(subscription_status, 'trialing'),
+                        trial_ends_at = COALESCE(
+                            trial_ends_at, NOW() + INTERVAL '30 days'
+                        )
+                    WHERE user_id = $1::uuid
+                    """,
+                    user_id,
+                )
 
             # Legacy rows: user without tenant breaks /v1/agents (JWT has no valid tenant_id)
             if not tenant_id:
@@ -246,34 +295,16 @@ async def verify_otp(
 
             tenant_id = str(tenant_id)
 
-            if is_new_user:
-                if not gdpr_consent:
-                    raise ValueError("GDPR consent is required to create an account")
-                consent_at = datetime.now(timezone.utc)
-                try:
-                    await _save_signup_consent(
-                        db=conn,
-                        user_id=user_id,
-                        consent_at=consent_at,
-                        marketing_consent=bool(marketing_consent),
-                    )
-                except Exception as e:
-                    # Do not block account creation if consent persistence fails unexpectedly.
-                    # We still enforce that consent was checked in the signup UI/API payload.
-                    log.warning("consent persistence skipped for user %s: %s", user_id, e)
-
-            await conn.execute(
+            burned = await conn.fetchval(
                 """
-                UPDATE users
-                SET plan = COALESCE(plan, 'pro'),
-                    subscription_status = COALESCE(subscription_status, 'trialing'),
-                    trial_ends_at = COALESCE(trial_ends_at, NOW() + INTERVAL '30 days')
-                WHERE user_id = $1::uuid
-                  AND (plan IS NULL OR subscription_status IS NULL
-                       OR subscription_status = 'pending_checkout')
+                UPDATE auth_otps SET used = TRUE
+                WHERE otp_id = $1 AND used = FALSE
+                RETURNING otp_id
                 """,
-                user_id,
+                row["otp_id"],
             )
+            if not burned:
+                raise ValueError("OTP already used")
 
     return _issue_tokens(user_id, email, tenant_id)
 

--- a/core/tests/test_auth_flow.py
+++ b/core/tests/test_auth_flow.py
@@ -1,0 +1,229 @@
+"""Auth flow tests — login vs signup intent, account existence checks."""
+
+import bcrypt
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from api.auth import _otp_rate
+from services.auth import (
+    _LOGIN_NO_ACCOUNT,
+    _SIGNUP_ALREADY_REGISTERED,
+    _SIGNUP_GDPR_REQUIRED,
+    verify_otp,
+)
+
+client = TestClient(app)
+
+TEST_OTP = "123456"
+TEST_OTP_HASH = bcrypt.hashpw(TEST_OTP.encode(), bcrypt.gensalt()).decode()
+TEST_OTP_ROW = {"otp_id": "otp-1", "otp_hash": TEST_OTP_HASH}
+
+
+class TestRequestOtpIntent:
+    def setup_method(self):
+        _otp_rate.clear()
+
+    @patch("api.auth.request_otp", new_callable=AsyncMock)
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
+    def test_login_rejects_unknown_email(self, mock_exists, mock_request):
+        mock_exists.return_value = False
+        res = client.post(
+            "/v1/auth/request-otp",
+            json={"email": "gone@example.com", "intent": "login"},
+        )
+        assert res.status_code == 404
+        assert "No account found" in res.json()["detail"]
+        mock_request.assert_not_called()
+
+    @patch("api.auth.request_otp", new_callable=AsyncMock)
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
+    def test_login_sends_code_for_existing_user(self, mock_exists, mock_request):
+        mock_exists.return_value = True
+        res = client.post(
+            "/v1/auth/request-otp",
+            json={"email": "user@example.com", "intent": "login"},
+        )
+        assert res.status_code == 200
+        mock_request.assert_called_once()
+
+    @patch("api.auth.request_otp", new_callable=AsyncMock)
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
+    def test_signup_rejects_existing_email(self, mock_exists, mock_request):
+        mock_exists.return_value = True
+        res = client.post(
+            "/v1/auth/request-otp",
+            json={"email": "user@example.com", "intent": "signup"},
+        )
+        assert res.status_code == 409
+        assert "already registered" in res.json()["detail"]
+        mock_request.assert_not_called()
+
+    @patch("api.auth.request_otp", new_callable=AsyncMock)
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
+    def test_signup_sends_code_for_new_email(self, mock_exists, mock_request):
+        mock_exists.return_value = False
+        res = client.post(
+            "/v1/auth/request-otp",
+            json={"email": "new@example.com", "intent": "signup"},
+        )
+        assert res.status_code == 200
+        mock_request.assert_called_once()
+
+
+    @patch("api.auth.request_otp", new_callable=AsyncMock)
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
+    def test_request_otp_defaults_to_login(self, mock_exists, mock_request):
+        mock_exists.return_value = True
+        res = client.post(
+            "/v1/auth/request-otp",
+            json={"email": "user@example.com"},
+        )
+        assert res.status_code == 200
+        mock_request.assert_called_once()
+
+
+class TestVerifyOtpIntent:
+    @pytest.mark.asyncio
+    @patch("services.auth.email_exists", new_callable=AsyncMock)
+    @patch("services.auth.get_pool")
+    async def test_login_rejects_unknown_email_before_otp_burn(self, mock_pool_fn, mock_exists):
+        mock_exists.return_value = False
+        pool = MagicMock()
+        pool.fetchrow = AsyncMock(return_value=TEST_OTP_ROW)
+        pool.execute = AsyncMock()
+        mock_pool_fn.return_value = pool
+
+        with pytest.raises(ValueError, match=_LOGIN_NO_ACCOUNT):
+            await verify_otp("deleted@example.com", TEST_OTP, intent="login")
+
+        pool.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("services.auth.email_exists", new_callable=AsyncMock)
+    @patch("services.auth.get_pool")
+    async def test_signup_requires_gdpr_for_new_user(self, mock_pool_fn, mock_exists):
+        mock_exists.return_value = False
+        pool = MagicMock()
+        pool.fetchrow = AsyncMock(return_value=TEST_OTP_ROW)
+        pool.execute = AsyncMock()
+        mock_pool_fn.return_value = pool
+
+        with pytest.raises(ValueError, match=_SIGNUP_GDPR_REQUIRED):
+            await verify_otp("new@example.com", TEST_OTP, intent="signup")
+
+        pool.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("services.auth.email_exists", new_callable=AsyncMock)
+    @patch("services.auth.get_pool")
+    async def test_signup_rejects_existing_email(self, mock_pool_fn, mock_exists):
+        mock_exists.return_value = True
+        pool = MagicMock()
+        pool.fetchrow = AsyncMock(return_value=TEST_OTP_ROW)
+        pool.execute = AsyncMock()
+        mock_pool_fn.return_value = pool
+
+        with pytest.raises(ValueError, match=_SIGNUP_ALREADY_REGISTERED):
+            await verify_otp(
+                "user@example.com",
+                TEST_OTP,
+                intent="signup",
+                gdpr_consent=True,
+            )
+
+        pool.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("services.auth.email_exists", new_callable=AsyncMock)
+    @patch("services.auth.get_pool")
+    async def test_invalid_otp_does_not_burn(self, mock_pool_fn, mock_exists):
+        pool = MagicMock()
+        pool.fetchrow = AsyncMock(return_value=TEST_OTP_ROW)
+        pool.acquire = MagicMock()
+        mock_pool_fn.return_value = pool
+
+        with pytest.raises(ValueError, match="Invalid OTP"):
+            await verify_otp("user@example.com", "000000", intent="login")
+
+        pool.acquire.assert_not_called()
+        mock_exists.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("services.auth.email_exists", new_callable=AsyncMock)
+    @patch("services.auth.get_pool")
+    async def test_otp_already_used_when_burn_fails(self, mock_pool_fn, mock_exists):
+        mock_exists.return_value = True
+        pool = MagicMock()
+        pool.fetchrow = AsyncMock(return_value=TEST_OTP_ROW)
+
+        conn = MagicMock()
+        conn.fetchrow = AsyncMock(return_value={
+            "user_id": "uid-1",
+            "email": "user@example.com",
+            "tenant_id": "tid-1",
+        })
+        conn.execute = AsyncMock()
+        conn.fetchval = AsyncMock(side_effect=[None])  # burn UPDATE returns nothing
+
+        tx = MagicMock()
+        tx.__aenter__ = AsyncMock(return_value=None)
+        tx.__aexit__ = AsyncMock(return_value=None)
+        conn.transaction = MagicMock(return_value=tx)
+
+        acquire_cm = MagicMock()
+        acquire_cm.__aenter__ = AsyncMock(return_value=conn)
+        acquire_cm.__aexit__ = AsyncMock(return_value=None)
+        pool.acquire = MagicMock(return_value=acquire_cm)
+
+        mock_pool_fn.return_value = pool
+
+        with pytest.raises(ValueError, match="OTP already used"):
+            await verify_otp("user@example.com", TEST_OTP, intent="login")
+
+
+class TestVerifyOtpRoute:
+    @patch("api.auth.verify_otp", new_callable=AsyncMock)
+    @patch("services.billing.fetch_user_billing", new_callable=AsyncMock)
+    def test_verify_passes_intent_to_service(self, mock_billing, mock_verify):
+        mock_verify.return_value = {
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "token_type": "bearer",
+        }
+        mock_billing.return_value = {"plan": "pro", "subscription_status": "trialing"}
+
+        res = client.post(
+            "/v1/auth/verify-otp",
+            json={
+                "email": "user@example.com",
+                "otp": "123456",
+                "intent": "signup",
+                "gdpr_consent": True,
+            },
+        )
+        assert res.status_code == 200
+        assert res.json()["access_token"] == "tok"
+        mock_verify.assert_called_once()
+        call_kwargs = mock_verify.call_args.kwargs
+        assert call_kwargs["intent"] == "signup"
+        assert call_kwargs["gdpr_consent"] is True
+
+    @patch("api.auth.verify_otp", new_callable=AsyncMock)
+    @patch("services.billing.fetch_user_billing", new_callable=AsyncMock)
+    def test_verify_returns_tokens_when_billing_lookup_fails(self, mock_billing, mock_verify):
+        mock_verify.return_value = {
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "token_type": "bearer",
+        }
+        mock_billing.side_effect = RuntimeError("db down")
+
+        res = client.post(
+            "/v1/auth/verify-otp",
+            json={"email": "user@example.com", "otp": "123456", "intent": "login"},
+        )
+        assert res.status_code == 200
+        assert res.json()["access_token"] == "tok"

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -24,8 +24,10 @@ class TestOTPRateLimiting:
         # Clear the in-memory rate dictionary before each test
         _otp_rate.clear()
 
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
     @patch("api.auth.request_otp", new_callable=AsyncMock)
-    def test_otp_requests_under_limit(self, mock_request_otp):
+    def test_otp_requests_under_limit(self, mock_request_otp, mock_exists):
+        mock_exists.return_value = True
         # Set up a fixed time
         start_time = 1000000.0
         with patch("time.time", return_value=start_time):
@@ -37,8 +39,10 @@ class TestOTPRateLimiting:
             
             assert mock_request_otp.call_count == _OTP_RATE_MAX
 
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
     @patch("api.auth.request_otp", new_callable=AsyncMock)
-    def test_otp_requests_exceed_limit(self, mock_request_otp):
+    def test_otp_requests_exceed_limit(self, mock_request_otp, mock_exists):
+        mock_exists.return_value = True
         start_time = 1000000.0
         with patch("time.time", return_value=start_time):
             # Send up to the limit
@@ -51,8 +55,10 @@ class TestOTPRateLimiting:
             assert response.status_code == 429
             assert "Too many code requests" in response.json()["detail"]
 
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
     @patch("api.auth.request_otp", new_callable=AsyncMock)
-    def test_otp_requests_partitioned_by_email(self, mock_request_otp):
+    def test_otp_requests_partitioned_by_email(self, mock_request_otp, mock_exists):
+        mock_exists.return_value = True
         start_time = 1000000.0
         with patch("time.time", return_value=start_time):
             # Send up to the limit for user1
@@ -68,8 +74,10 @@ class TestOTPRateLimiting:
             response = client.post("/v1/auth/request-otp", json={"email": "user2@example.com"})
             assert response.status_code == 200
 
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
     @patch("api.auth.request_otp", new_callable=AsyncMock)
-    def test_otp_requests_window_expiry(self, mock_request_otp):
+    def test_otp_requests_window_expiry(self, mock_request_otp, mock_exists):
+        mock_exists.return_value = True
         start_time = 1000000.0
         
         # We use a mutable container to simulate advancing time

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -255,7 +255,7 @@ There is a **separate** lead-capture path (`lib/demo.ts` → `submitDemoRequest`
 
 **Auth model:** passwordless email OTP for managed cloud; `POST /v1/auth/request-otp` then `/verify-otp` returns a JWT (`access_token`, 7-day TTL per `TOKEN_MAX_AGE_SEC`). Self-host DEV_MODE offers `POST /v1/auth/dev-token`.
 
-**Signup vs login:** `requestOtp(email, intent)` — signup passes `intent='signup'`; if backend says "already registered", signup surfaces a "Sign in →" link (`signup/page.tsx:72-73`).
+**Signup vs login:** Both flows use `intent` on `requestOtp` / `verifyOtp` (`login` | `signup`, default `login`). Login request-otp returns **404** when no account exists; signup returns **409** when the email is already registered. Login verify only succeeds for existing users; signup requires `gdpr_consent=true` and creates a new tenant/user. OTP is consumed atomically inside the verify transaction (invalid OTP or pre-check failures do not burn the code). After success, auth uses `window.location.assign` (hard redirect) to avoid stuck OTP screens. Helpers: `lib/auth-errors.ts`, `lib/signup-funnel.ts`, `hooks/useResendCooldown.ts` (60s resend cooldown on login and signup).
 
 **Billing / trial (no payment provider):** signup OTP verify sets `plan=pro` (if unset), `subscription_status=trialing`, `trial_ends_at=+30d` (also converts legacy `pending_checkout` rows). `postAuthRedirect()` always returns `/dashboard`. `getBillingStatus` / `billing_status_payload` always return `has_access: true`, `enforced: false`, `requires_checkout: false` — informational only for `TenantPlanBanner`.
 
@@ -323,11 +323,13 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 
 **Variations:**
 - **Generic CTA (no plan):** inserts `/signup/plan` first.
-- **Existing account tries signup:** "already registered" → link to `/login`.
-- **Returning login:** `/login` → OTP → `/dashboard` (`postAuthRedirect` always `/dashboard`).
+- **Existing account tries signup:** request-otp **409** → "Sign in →" link with `?email=` prefill.
+- **Deleted account re-register:** after delete, `/login?deleted=1` banner → `/signup/plan`; signup path sends `intent=signup` + GDPR consent (not login verify).
+- **Login with unknown email:** request-otp **404** → "Create account" CTA to `/signup/plan`.
+- **Returning login:** `/login` → OTP (auto-submit at 6 digits, resend cooldown) → hard redirect `/dashboard`.
 - **Self-host (DEV_MODE):** `/login` → "Open my dashboard" (dev-token) → `/dashboard`.
 - **Trial expiry / past_due:** `TenantPlanBanner` shows plan + trial end; no checkout redirect (billing not enforced).
-- **Account deletion:** Settings → delete modal → optional retention trial → confirm "DELETE" → `/login?deleted=1`.
+- **Account deletion:** Settings → delete modal → optional retention trial → confirm "DELETE" → `clearSignupSession()` → `/login?deleted=1`.
 - **Legacy URLs:** `/signup/checkout` → `/signup/plan`; `/signup/success` → `/dashboard`.
 
 ---
@@ -344,7 +346,8 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 - **Empty states:** agents → `GettingStartedChecklist`; no API keys → prompt to create agent.
 - **Direct URL access:** `/dashboard*` guarded at edge; legacy `/signup/checkout` & `/success` redirect away.
 - **`getEvents` response shape:** handles both array and `{events:[]}` (`api.ts:91`).
-- **Signup screen flicker (fixed):** `/signup` gates its email/OTP form behind a `checked` state so it no longer flashes before a redirect to `/signup/plan` or `/signup/start` resolves. Pattern: run checks in `useEffect`, `return` early on a redirect, call `setChecked(true)` only on the valid path, and render `SignupFallback` until then (`signup/page.tsx`).
+- **Signup screen flicker (fixed):** `/signup` gates its email/OTP form behind a `checked` state so it no longer flashes before a redirect to `/signup/plan` or `/signup/start` resolves.
+- **Signup funnel keys:** centralized in `lib/signup-funnel.ts` (`SIGNUP_PLAN_KEY`, consent keys, `clearSignupSession()`).
 
 ---
 
@@ -673,17 +676,17 @@ Server component; `metadata.robots` = noindex/nofollow (`:5-7`); wraps children 
 
 ### 19.6 Login — `app/login/page.tsx`
 
-- **Consts:** `IS_DEV_MODE` (`:9`), `API_URL` (`:10`). Suspense wrapper (`:12-17`).
-- **State (`:34-39`):** `email`, `otp`, `step` (`'email'|'otp'`), `loading`, `devLoading`, `error`.
-- **`safeNext` (`:41-45`):** uses `next` param **only** if it starts with `/dashboard` and not `//` (open-redirect guard); else `/dashboard`.
-- **Effect (`:47-53`):** existing token → `setToken` + `router.replace(safeNext)`.
-- **API:** dev-token `fetch POST ${API_URL}/v1/auth/dev-token` (`:59-62`); `requestOtp(email)` (`:76`); `verifyOtp(email, otp)` (`:90`) → `postAuthRedirect(data)` (`:92`).
-- **Branches:** dev banner + bypass if `IS_DEV_MODE` (`:112-139`); OTP input digits-only max 6 (`:215`); signup link hidden in dev mode (`:255-262`). Dev-login failure shows docker hint (`:65`).
+- **Consts:** `IS_DEV_MODE`, `API_URL`. Suspense wrapper.
+- **State:** `email`, `otp`, `step`, `loading`, `devLoading`, `navigating`, `error`, `noAccount`; `verifyLock` ref prevents double verify; `useResendCooldown` (60s).
+- **`safeNext`:** uses `next` param only if it starts with `/dashboard` and not `//`; else `/dashboard`. `?email=` pre-fills email; `?deleted=1` shows re-register banner.
+- **Effect:** existing token → hard redirect `safeNext`. OTP auto-submits at 6 digits via `verifyFormRef.requestSubmit()`.
+- **API:** `requestOtp(email, 'login')`; `verifyOtp(email, otp, { intent: 'login' })` → `setToken` → `window.location.assign(safeNext)`.
+- **Errors:** `authErrorMessage` / `isNoAccountError` (404) → inline "Create account" CTA. Resend with cooldown. Dev-token bypass when `IS_DEV_MODE`.
 
 ### 19.7 Plan selection — `app/signup/plan/page.tsx`
 
 - `PLANS` const (`:9-26`), `selected` default `'pro'` (`:30`), no effect.
-- On continue: `sessionStorage.setItem('signup_plan', selected)` (`:33-35`) → `router.push('/signup/start?plan={selected}')` (`:36`). Copy: "30-day free trial… No credit card required" (`:57`) — see credit-card copy risk (§14.1).
+- On continue: `sessionStorage.setItem(SIGNUP_PLAN_KEY, selected)` (`lib/signup-funnel.ts`) → `router.push('/signup/start?plan={selected}')`.
 
 ### 19.8 Checkout success — `app/signup/success/page.tsx`
 
@@ -711,9 +714,9 @@ Server component; `metadata.robots` = noindex/nofollow (`:5-7`); wraps children 
 
 - **Step 3 of the funnel** (account creation). Suspense-wrapped (`useSearchParams`); `SignupForm` inner.
 - **State:** `email`, `otp`, `step` (`'email'|'otp'`), `loading`, `error`, `alreadyRegistered`, and `checked` (the render gate).
-- **Guard effect (deps `[searchParams, router]`):** resets step/otp/error; persists `?plan=` to `sessionStorage.signup_plan`; if plan not `pro|team` → `router.replace('/signup/plan')` and return; if `sessionStorage.signup_consent_gdpr !== '1'` → `router.replace('/signup/start?plan=<plan>')` and return; else `setChecked(true)`. **Renders `SignupFallback` until `checked`** (this is the flicker fix — see §11).
-- **API:** `handleRequestOtp` → `requestOtp(email, 'signup')` → `step='otp'`; on "already registered" sets `alreadyRegistered` (shows "Sign in →" link). `handleVerifyOtp` → `verifyOtp(email, otp, {gdpr, marketing})` → `setToken` → clear consent keys → best-effort `selectBillingPlan(token, plan)` (`catch {}`) → clear `signup_plan` → `router.replace(postAuthRedirect(data))`.
-- **Edge:** OTP input digits-only max 6; buttons disabled while `loading` or empty/short input.
+- **Guard effect:** resets step/otp/error; persists `?plan=` via `SIGNUP_PLAN_KEY`; missing plan → `/signup/plan`; missing consent → `/signup/start`; else `setChecked(true)`. Renders `SignupFallback` until `checked`.
+- **API:** `requestOtp(email, 'signup')`; `verifyOtp(..., { intent: 'signup', gdprConsent, marketingConsent })` → `setToken` → `clearSignupSession()` → best-effort `selectBillingPlan` → `window.location.assign('/dashboard')`.
+- **UX:** OTP auto-submit at 6 digits; resend with 60s cooldown; `auth-errors` helpers for 409/GDPR; "already registered" links to `/login?email=`.
 
 ### 19.12 Before-you-begin / consent — `app/signup/start/page.tsx`
 

--- a/dashboard/app/dashboard/settings/page.tsx
+++ b/dashboard/app/dashboard/settings/page.tsx
@@ -4,6 +4,7 @@ import { ApiKeyUsage } from '@/components/ApiKeyUsage'
 import { useApiKeyQuota } from '@/hooks/useApiKeyQuota'
 import { createApiKey, deleteManagedAccount, getAccountOptions, getApiKeys, getEmbeddingCatalog, getEmbeddingSettings, grantRetentionTrial, revokeApiKey, sendTestEvent, updateEmbeddingSettings, type AccountOptions } from '@/lib/api'
 import { clearToken, requireAuth } from '@/lib/auth'
+import { clearSignupSession } from '@/lib/signup-funnel'
 import { AlertTriangle, Check, Copy, Key, Plus, Trash2, X } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
@@ -457,6 +458,7 @@ export default function SettingsPage() {
                   const token = requireAuth()
                   await deleteManagedAccount(token)
                   clearToken()
+                  clearSignupSession()
                   router.replace('/login?deleted=1')
                 } catch (e) {
                   setAccountErr(e instanceof Error ? e.message : 'Could not delete account')

--- a/dashboard/app/login/page.tsx
+++ b/dashboard/app/login/page.tsx
@@ -1,13 +1,20 @@
 'use client'
 
-import { useState, useEffect, Suspense } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
-import { requestOtp, verifyOtp, postAuthRedirect } from '@/lib/api'
+import { useState, useEffect, useRef, Suspense } from 'react'
+import { useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { requestOtp, verifyOtp } from '@/lib/api'
+import { authErrorMessage, isNoAccountError } from '@/lib/auth-errors'
 import { getToken, setToken } from '@/lib/auth'
+import { useResendCooldown } from '@/hooks/useResendCooldown'
 import { BrandLogo } from '@/components/BrandLogo'
 
 const IS_DEV_MODE = process.env.NEXT_PUBLIC_DEV_MODE === 'true'
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000'
+
+function completeAuthRedirect(path: string) {
+  window.location.assign(path)
+}
 
 export default function LoginPage() {
   return (
@@ -29,15 +36,21 @@ function LoginFallback() {
 }
 
 function LoginForm() {
-  const router = useRouter()
   const searchParams = useSearchParams()
   const [email, setEmail] = useState('')
   const [otp, setOtp] = useState('')
   const [step, setStep] = useState<'email' | 'otp'>('email')
   const [loading, setLoading] = useState(false)
   const [devLoading, setDevLoading] = useState(false)
+  const [navigating, setNavigating] = useState(false)
   const [error, setError] = useState('')
+  const [noAccount, setNoAccount] = useState(false)
+  const verifyLock = useRef(false)
+  const verifyFormRef = useRef<HTMLFormElement>(null)
+  const { cooldown, canResend, startCooldown } = useResendCooldown()
 
+  const accountDeleted = searchParams.get('deleted') === '1'
+  const emailPrefill = searchParams.get('email')
   const nextPath = searchParams.get('next')
   const safeNext =
     nextPath && nextPath.startsWith('/dashboard') && !nextPath.startsWith('//')
@@ -45,12 +58,79 @@ function LoginForm() {
       : '/dashboard'
 
   useEffect(() => {
+    if (emailPrefill) {
+      setEmail(emailPrefill)
+    }
+  }, [emailPrefill])
+
+  useEffect(() => {
     const existing = getToken()
     if (existing) {
       setToken(existing)
-      router.replace(safeNext)
+      window.location.assign(safeNext)
     }
-  }, [router, safeNext])
+  }, [safeNext])
+
+  useEffect(() => {
+    if (step !== 'otp' || otp.length !== 6 || loading || navigating || verifyLock.current) return
+    verifyFormRef.current?.requestSubmit()
+  }, [otp, step, loading, navigating])
+
+  async function sendLoginOtp() {
+    await requestOtp(email, 'login')
+    setStep('otp')
+    startCooldown()
+  }
+
+  async function handleRequestOtp(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    setNoAccount(false)
+    try {
+      await sendLoginOtp()
+    } catch (err) {
+      setNoAccount(isNoAccountError(err))
+      setError(authErrorMessage(err, 'Failed to send code. Try again.'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleResendOtp() {
+    if (!canResend || loading) return
+    setLoading(true)
+    setError('')
+    setNoAccount(false)
+    try {
+      await sendLoginOtp()
+    } catch (err) {
+      setNoAccount(isNoAccountError(err))
+      setError(authErrorMessage(err, 'Failed to resend code. Try again.'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleVerifyOtp(e: React.FormEvent) {
+    e.preventDefault()
+    if (verifyLock.current || navigating) return
+    verifyLock.current = true
+    setLoading(true)
+    setError('')
+    setNoAccount(false)
+    try {
+      const data = await verifyOtp(email, otp, { intent: 'login' })
+      setToken(data.access_token)
+      setNavigating(true)
+      completeAuthRedirect(safeNext)
+    } catch (err) {
+      verifyLock.current = false
+      setNoAccount(isNoAccountError(err))
+      setError(authErrorMessage(err, 'Invalid or expired code.'))
+      setLoading(false)
+    }
+  }
 
   async function handleDevLogin() {
     setDevLoading(true)
@@ -60,7 +140,8 @@ function LoginForm() {
       if (!res.ok) throw new Error('Dev token failed')
       const data = await res.json() as { access_token: string }
       setToken(data.access_token)
-      router.push(safeNext)
+      setNavigating(true)
+      window.location.assign(safeNext)
     } catch {
       setError('Could not connect to ZizkaDB API. Is docker-compose running on port 8000?')
     } finally {
@@ -68,33 +149,15 @@ function LoginForm() {
     }
   }
 
-  async function handleRequestOtp(e: React.FormEvent) {
-    e.preventDefault()
-    setLoading(true)
-    setError('')
-    try {
-      await requestOtp(email)
-      setStep('otp')
-    } catch {
-      setError('Failed to send code. Try again.')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  async function handleVerifyOtp(e: React.FormEvent) {
-    e.preventDefault()
-    setLoading(true)
-    setError('')
-    try {
-      const data = await verifyOtp(email, otp)
-      setToken(data.access_token)
-      router.replace(postAuthRedirect(data))
-    } catch (e) {
-      setError(e instanceof Error ? e.message : 'Invalid or expired code.')
-    } finally {
-      setLoading(false)
-    }
+  if (navigating) {
+    return (
+      <div style={{
+        minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center',
+        background: '#fafafa', fontFamily: 'Inter, system-ui, sans-serif', color: '#555',
+      }}>
+        <p style={{ fontSize: 15 }}>Signing you in…</p>
+      </div>
+    )
   }
 
   return (
@@ -108,7 +171,18 @@ function LoginForm() {
           <BrandLogo variant="full" suffix="The operational database for AI agents" />
         </div>
 
-        {/* Dev Mode Banner — shown only in self-hosted mode */}
+        {accountDeleted && (
+          <div style={{
+            background: '#fef3c7', border: '1px solid #fcd34d', borderRadius: 12,
+            padding: '14px 16px', marginBottom: 16, fontSize: 13, color: '#92400e', lineHeight: 1.55,
+          }}>
+            Your account was deleted.{' '}
+            <Link href="/signup/plan" style={{ color: '#111', fontWeight: 600 }}>
+              Create a new account →
+            </Link>
+          </div>
+        )}
+
         {IS_DEV_MODE && (
           <div style={{
             background: '#f0fdf4', border: '1px solid #bbf7d0', borderRadius: 12,
@@ -138,7 +212,6 @@ function LoginForm() {
           </div>
         )}
 
-        {/* Standard email login card */}
         <div style={{
           background: '#fff', borderRadius: 16, padding: '36px 32px',
           border: '1px solid #e5e5e5', boxShadow: '0 2px 20px rgba(0,0,0,0.05)',
@@ -181,7 +254,23 @@ function LoginForm() {
                     onBlur={e => (e.target.style.borderColor = '#ddd')}
                   />
                 </div>
-                {error && <p style={{ fontSize: 13, color: '#ef4444' }}>{error}</p>}
+                {error && (
+                  <div style={{ fontSize: 13, color: '#ef4444' }}>
+                    <p style={{ margin: 0 }}>{error}</p>
+                    {noAccount && (
+                      <Link
+                        href="/signup/plan"
+                        style={{
+                          display: 'inline-block', marginTop: 10, padding: '8px 14px',
+                          borderRadius: 8, background: '#111', color: '#fff',
+                          fontWeight: 600, textDecoration: 'none', fontSize: 13,
+                        }}
+                      >
+                        Create account
+                      </Link>
+                    )}
+                  </div>
+                )}
                 <button
                   type="submit"
                   disabled={loading || !email}
@@ -204,7 +293,7 @@ function LoginForm() {
               <p style={{ fontSize: 14, color: '#888', marginBottom: 24 }}>
                 We sent a 6-digit code to <strong style={{ color: '#111' }}>{email}</strong>
               </p>
-              <form onSubmit={handleVerifyOtp} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <form ref={verifyFormRef} onSubmit={handleVerifyOtp} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
                 <div>
                   <label style={{ display: 'block', fontSize: 13, fontWeight: 500, color: '#555', marginBottom: 6 }}>
                     Login code
@@ -217,6 +306,7 @@ function LoginForm() {
                     required
                     autoFocus
                     maxLength={6}
+                    disabled={loading}
                     style={{
                       width: '100%', boxSizing: 'border-box',
                       padding: '12px', borderRadius: 9, fontSize: 24,
@@ -228,7 +318,23 @@ function LoginForm() {
                     onBlur={e => (e.target.style.borderColor = '#ddd')}
                   />
                 </div>
-                {error && <p style={{ fontSize: 13, color: '#ef4444' }}>{error}</p>}
+                {error && (
+                  <div style={{ fontSize: 13, color: '#ef4444' }}>
+                    <p style={{ margin: 0 }}>{error}</p>
+                    {noAccount && (
+                      <Link
+                        href="/signup/plan"
+                        style={{
+                          display: 'inline-block', marginTop: 10, padding: '8px 14px',
+                          borderRadius: 8, background: '#111', color: '#fff',
+                          fontWeight: 600, textDecoration: 'none', fontSize: 13,
+                        }}
+                      >
+                        Create account
+                      </Link>
+                    )}
+                  </div>
+                )}
                 <button
                   type="submit"
                   disabled={loading || otp.length < 6}
@@ -238,11 +344,29 @@ function LoginForm() {
                     opacity: loading || otp.length < 6 ? 0.4 : 1,
                   }}
                 >
-                  {loading ? 'Verifying...' : 'Sign in →'}
+                  {loading ? 'Signing you in…' : 'Sign in →'}
                 </button>
                 <button
                   type="button"
-                  onClick={() => { setStep('email'); setOtp(''); setError('') }}
+                  onClick={handleResendOtp}
+                  disabled={!canResend || loading}
+                  style={{
+                    fontSize: 13, color: canResend ? '#555' : '#bbb',
+                    background: 'none', border: 'none',
+                    cursor: canResend && !loading ? 'pointer' : 'not-allowed',
+                  }}
+                >
+                  {canResend ? 'Resend code' : `Resend code in ${cooldown}s`}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    verifyLock.current = false
+                    setStep('email')
+                    setOtp('')
+                    setError('')
+                    setNoAccount(false)
+                  }}
                   style={{ fontSize: 13, color: '#888', background: 'none', border: 'none', cursor: 'pointer' }}
                 >
                   ← Use a different email
@@ -255,9 +379,9 @@ function LoginForm() {
         {!IS_DEV_MODE && (
           <p style={{ textAlign: 'center', fontSize: 13, color: '#aaa', marginTop: 16 }}>
             No account yet?{' '}
-            <a href="/signup" style={{ color: '#555', textDecoration: 'none', fontWeight: 500 }}>
+            <Link href="/signup/plan" style={{ color: '#555', textDecoration: 'none', fontWeight: 500 }}>
               Create one free →
-            </a>
+            </Link>
           </p>
         )}
         <p style={{ textAlign: 'center', fontSize: 13, color: '#ccc', marginTop: 8 }}>

--- a/dashboard/app/signup/page.tsx
+++ b/dashboard/app/signup/page.tsx
@@ -1,10 +1,23 @@
 'use client'
 
-import { Suspense, useEffect, useState } from 'react'
+import { Suspense, useEffect, useRef, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
-import { requestOtp, verifyOtp, postAuthRedirect, selectBillingPlan } from '@/lib/api'
+import { requestOtp, verifyOtp, selectBillingPlan } from '@/lib/api'
+import {
+  authErrorMessage,
+  isAlreadyRegisteredError,
+  isGdprConsentError,
+} from '@/lib/auth-errors'
 import { setToken } from '@/lib/auth'
+import { useResendCooldown } from '@/hooks/useResendCooldown'
+import {
+  clearSignupSession,
+  getStoredSignupPlan,
+  hasSignupConsent,
+  SIGNUP_CONSENT_MARKETING_KEY,
+  SIGNUP_PLAN_KEY,
+} from '@/lib/signup-funnel'
 import { BrandLogo } from '@/components/BrandLogo'
 
 export default function SignupPage() {
@@ -35,6 +48,10 @@ function SignupForm() {
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [alreadyRegistered, setAlreadyRegistered] = useState(false)
+  const [navigating, setNavigating] = useState(false)
+  const verifyLock = useRef(false)
+  const verifyFormRef = useRef<HTMLFormElement>(null)
+  const { cooldown, canResend, startCooldown } = useResendCooldown()
   // Gate the form render until the guard confirms the user belongs on /signup.
   // Prevents the email screen from flashing before a redirect to /signup/plan
   // or /signup/start resolves. Monotonic: only ever set true.
@@ -49,16 +66,16 @@ function SignupForm() {
 
     const planParam = searchParams.get('plan')
     if (planParam === 'pro' || planParam === 'team') {
-      sessionStorage.setItem('signup_plan', planParam)
+      sessionStorage.setItem(SIGNUP_PLAN_KEY, planParam)
     }
 
-    const stored = sessionStorage.getItem('signup_plan')
-    if (stored !== 'pro' && stored !== 'team') {
+    const stored = getStoredSignupPlan()
+    if (!stored) {
       router.replace('/signup/plan')
       return
     }
 
-    if (sessionStorage.getItem('signup_consent_gdpr') !== '1') {
+    if (!hasSignupConsent()) {
       router.replace(`/signup/start?plan=${stored}`)
       return
     }
@@ -66,20 +83,42 @@ function SignupForm() {
     setChecked(true)
   }, [searchParams, router])
 
+  useEffect(() => {
+    if (step !== 'otp' || otp.length !== 6 || loading || navigating || verifyLock.current) return
+    verifyFormRef.current?.requestSubmit()
+  }, [otp, step, loading, navigating])
+
+  async function sendSignupOtp() {
+    await requestOtp(email, 'signup')
+    setStep('otp')
+    startCooldown()
+  }
+
   async function handleRequestOtp(e: React.FormEvent) {
     e.preventDefault()
     setLoading(true)
     setError('')
     setAlreadyRegistered(false)
     try {
-      await requestOtp(email, 'signup')
-      setStep('otp')
+      await sendSignupOtp()
     } catch (e) {
-      const msg = e instanceof Error ? e.message : 'Could not send code. Please try again.'
-      if (msg.toLowerCase().includes('already registered')) {
-        setAlreadyRegistered(true)
-      }
-      setError(msg)
+      setAlreadyRegistered(isAlreadyRegisteredError(e))
+      setError(authErrorMessage(e, 'Could not send code. Please try again.'))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleResendOtp() {
+    if (!canResend || loading) return
+    setLoading(true)
+    setError('')
+    setAlreadyRegistered(false)
+    try {
+      await sendSignupOtp()
+    } catch (e) {
+      setAlreadyRegistered(isAlreadyRegisteredError(e))
+      setError(authErrorMessage(e, 'Failed to resend code. Try again.'))
     } finally {
       setLoading(false)
     }
@@ -87,30 +126,56 @@ function SignupForm() {
 
   async function handleVerifyOtp(e: React.FormEvent) {
     e.preventDefault()
+    if (verifyLock.current || navigating) return
+    verifyLock.current = true
     setLoading(true)
     setError('')
     try {
-      const gdprConsent = sessionStorage.getItem('signup_consent_gdpr') === '1'
-      const marketingConsent = sessionStorage.getItem('signup_consent_marketing') === '1'
+      const gdprConsent = hasSignupConsent()
+      const marketingConsent = sessionStorage.getItem(SIGNUP_CONSENT_MARKETING_KEY) === '1'
+      if (!gdprConsent) {
+        verifyLock.current = false
+        setLoading(false)
+        const plan = getStoredSignupPlan() ?? 'pro'
+        router.replace(`/signup/start?plan=${plan}`)
+        return
+      }
       const data = await verifyOtp(email, otp, {
+        intent: 'signup',
         gdprConsent,
         marketingConsent,
       })
+      const plan = getStoredSignupPlan()
       setToken(data.access_token)
-      sessionStorage.removeItem('signup_consent_gdpr')
-      sessionStorage.removeItem('signup_consent_marketing')
-      // Save the selected plan to the account (best-effort; doesn't block login)
-      const plan = sessionStorage.getItem('signup_plan') as 'pro' | 'team' | null
+      clearSignupSession()
       if (plan === 'pro' || plan === 'team') {
-        sessionStorage.removeItem('signup_plan')
         try { await selectBillingPlan(data.access_token, plan) } catch { /* non-fatal */ }
       }
-      router.replace(postAuthRedirect(data))
+      setNavigating(true)
+      window.location.assign('/dashboard')
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Invalid or expired code.')
-    } finally {
+      verifyLock.current = false
+      if (isGdprConsentError(e)) {
+        setLoading(false)
+        const plan = getStoredSignupPlan() ?? 'pro'
+        router.replace(`/signup/start?plan=${plan}`)
+        return
+      }
+      setAlreadyRegistered(isAlreadyRegisteredError(e))
+      setError(authErrorMessage(e, 'Invalid or expired code.'))
       setLoading(false)
     }
+  }
+
+  if (navigating) {
+    return (
+      <div style={{
+        minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center',
+        background: '#fafafa', fontFamily: 'Inter, system-ui, sans-serif', color: '#555',
+      }}>
+        <p style={{ fontSize: 15 }}>Creating your account…</p>
+      </div>
+    )
   }
 
   // Hold the neutral loader until the guard resolves, so the email/OTP form
@@ -169,7 +234,10 @@ function SignupForm() {
                     {alreadyRegistered && (
                       <>
                         {' '}
-                        <Link href="/login" style={{ color: '#111', fontWeight: 600 }}>
+                        <Link
+                          href={`/login?email=${encodeURIComponent(email)}`}
+                          style={{ color: '#111', fontWeight: 600 }}
+                        >
                           Sign in →
                         </Link>
                       </>
@@ -200,7 +268,7 @@ function SignupForm() {
               <p style={{ fontSize: 14, color: '#888', marginBottom: 24, lineHeight: 1.6 }}>
                 We sent a 6-digit code to <strong style={{ color: '#111' }}>{email}</strong>
               </p>
-              <form onSubmit={handleVerifyOtp} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <form ref={verifyFormRef} onSubmit={handleVerifyOtp} style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
                 <div>
                   <label style={{ display: 'block', fontSize: 13, fontWeight: 500, color: '#555', marginBottom: 6 }}>
                     Verification code
@@ -213,6 +281,7 @@ function SignupForm() {
                     required
                     autoFocus
                     maxLength={6}
+                    disabled={loading}
                     style={{
                       width: '100%', boxSizing: 'border-box',
                       padding: '12px', borderRadius: 9, fontSize: 28,
@@ -224,7 +293,22 @@ function SignupForm() {
                     onBlur={e => (e.target.style.borderColor = '#ddd')}
                   />
                 </div>
-                {error && <p style={{ fontSize: 13, color: '#ef4444', margin: 0 }}>{error}</p>}
+                {error && (
+                  <p style={{ fontSize: 13, color: '#ef4444', margin: 0 }}>
+                    {error}
+                    {alreadyRegistered && (
+                      <>
+                        {' '}
+                        <Link
+                          href={`/login?email=${encodeURIComponent(email)}`}
+                          style={{ color: '#111', fontWeight: 600 }}
+                        >
+                          Sign in →
+                        </Link>
+                      </>
+                    )}
+                  </p>
+                )}
                 <button
                   type="submit"
                   disabled={loading || otp.length < 6}
@@ -238,7 +322,25 @@ function SignupForm() {
                 </button>
                 <button
                   type="button"
-                  onClick={() => { setStep('email'); setOtp(''); setError('') }}
+                  onClick={handleResendOtp}
+                  disabled={!canResend || loading}
+                  style={{
+                    fontSize: 13, color: canResend ? '#555' : '#bbb',
+                    background: 'none', border: 'none',
+                    cursor: canResend && !loading ? 'pointer' : 'not-allowed',
+                  }}
+                >
+                  {canResend ? 'Resend code' : `Resend code in ${cooldown}s`}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    verifyLock.current = false
+                    setStep('email')
+                    setOtp('')
+                    setError('')
+                    setAlreadyRegistered(false)
+                  }}
                   style={{ fontSize: 13, color: '#888', background: 'none', border: 'none', cursor: 'pointer' }}
                 >
                   ← Use a different email

--- a/dashboard/app/signup/plan/page.tsx
+++ b/dashboard/app/signup/plan/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { BrandLogo } from '@/components/BrandLogo'
+import { SIGNUP_PLAN_KEY } from '@/lib/signup-funnel'
 
 const BRAND = '#f97316'
 
@@ -31,7 +32,7 @@ export default function SignupPlanPage() {
 
   function handleContinue() {
     if (typeof window !== 'undefined') {
-      sessionStorage.setItem('signup_plan', selected)
+      sessionStorage.setItem(SIGNUP_PLAN_KEY, selected)
     }
     router.push(`/signup/start?plan=${selected}`)
   }

--- a/dashboard/app/signup/start/page.tsx
+++ b/dashboard/app/signup/start/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useState } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import { BrandLogo } from '@/components/BrandLogo'
+import { SIGNUP_CONSENT_GDPR_KEY, SIGNUP_CONSENT_MARKETING_KEY, SIGNUP_PLAN_KEY } from '@/lib/signup-funnel'
 
 const GUIDELINES = [
   {
@@ -51,21 +52,21 @@ function SignupStartInner() {
     const resolved =
       planParam === 'pro' || planParam === 'team'
         ? planParam
-        : (sessionStorage.getItem('signup_plan') === 'pro' || sessionStorage.getItem('signup_plan') === 'team'
-          ? (sessionStorage.getItem('signup_plan') as 'pro' | 'team')
+        : (sessionStorage.getItem(SIGNUP_PLAN_KEY) === 'pro' || sessionStorage.getItem(SIGNUP_PLAN_KEY) === 'team'
+          ? (sessionStorage.getItem(SIGNUP_PLAN_KEY) as 'pro' | 'team')
           : null)
     if (!resolved) {
       router.replace('/signup/plan')
       return
     }
-    sessionStorage.setItem('signup_plan', resolved)
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, resolved)
     setPlan(resolved)
   }, [searchParams, router])
 
   function handleContinue() {
     if (!plan || !gdprConsent) return
-    sessionStorage.setItem('signup_consent_gdpr', '1')
-    sessionStorage.setItem('signup_consent_marketing', marketingConsent ? '1' : '0')
+    sessionStorage.setItem(SIGNUP_CONSENT_GDPR_KEY, '1')
+    sessionStorage.setItem(SIGNUP_CONSENT_MARKETING_KEY, marketingConsent ? '1' : '0')
     router.push(`/signup?plan=${plan}`)
   }
 

--- a/dashboard/hooks/useResendCooldown.ts
+++ b/dashboard/hooks/useResendCooldown.ts
@@ -1,0 +1,23 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+const DEFAULT_SECONDS = 60
+
+export function useResendCooldown(seconds = DEFAULT_SECONDS) {
+  const [cooldown, setCooldown] = useState(0)
+
+  useEffect(() => {
+    if (cooldown <= 0) return
+    const timer = window.setInterval(() => {
+      setCooldown((s) => (s <= 1 ? 0 : s - 1))
+    }, 1000)
+    return () => window.clearInterval(timer)
+  }, [cooldown])
+
+  const startCooldown = useCallback(() => {
+    setCooldown(seconds)
+  }, [seconds])
+
+  return { cooldown, canResend: cooldown === 0, startCooldown }
+}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -2,6 +2,16 @@
 // Falls back to '' (relative URL) so Nginx can route /v1/ → FastAPI.
 const API = process.env.NEXT_PUBLIC_API_URL ?? ''
 
+export class AuthRequestError extends Error {
+  readonly status: number
+
+  constructor(message: string, status: number) {
+    super(message)
+    this.name = 'AuthRequestError'
+    this.status = status
+  }
+}
+
 function formatApiError(detail: unknown, fallback: string): string {
   if (typeof detail === 'string') return detail
   if (Array.isArray(detail)) {
@@ -262,18 +272,21 @@ export async function getApiKeyUsage(token: string): Promise<ApiKeyUsage> {
   return apiFetch('/v1/auth/api-keys/usage', token)
 }
 
-export async function requestOtp(email: string, intent?: 'signup' | 'login') {
+export async function requestOtp(email: string, intent: 'signup' | 'login' = 'login') {
   const res = await fetch(`${API}/v1/auth/request-otp`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       email: email.toLowerCase().trim(),
-      ...(intent ? { intent } : {}),
+      intent,
     }),
   })
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: res.statusText }))
-    throw new Error(formatApiError(err.detail, 'Failed to send code'))
+    throw new AuthRequestError(
+      formatApiError(err.detail, 'Failed to send code'),
+      res.status,
+    )
   }
   return res.json()
 }
@@ -281,21 +294,30 @@ export async function requestOtp(email: string, intent?: 'signup' | 'login') {
 export async function verifyOtp(
   email: string,
   otp: string,
-  opts?: { gdprConsent?: boolean; marketingConsent?: boolean },
+  opts?: {
+    intent?: 'signup' | 'login'
+    gdprConsent?: boolean
+    marketingConsent?: boolean
+  },
 ) {
+  const intent = opts?.intent ?? 'login'
   const res = await fetch(`${API}/v1/auth/verify-otp`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       email: email.toLowerCase().trim(),
       otp: otp.trim(),
+      intent,
       ...(opts?.gdprConsent ? { gdpr_consent: true } : {}),
       ...(opts?.marketingConsent ? { marketing_consent: true } : {}),
     }),
   })
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: res.statusText }))
-    throw new Error(formatApiError(err.detail, 'Invalid or expired code'))
+    throw new AuthRequestError(
+      formatApiError(err.detail, 'Invalid or expired code'),
+      res.status,
+    )
   }
   const data = await res.json()
   if (!data?.access_token) throw new Error('Sign-in succeeded but no session token was returned')

--- a/dashboard/lib/auth-errors.ts
+++ b/dashboard/lib/auth-errors.ts
@@ -1,0 +1,26 @@
+import { AuthRequestError } from '@/lib/api'
+
+export function isNoAccountError(err: unknown): boolean {
+  return err instanceof AuthRequestError && err.status === 404
+}
+
+export function isAlreadyRegisteredError(err: unknown): boolean {
+  return err instanceof AuthRequestError && err.status === 409
+}
+
+export function isGdprConsentError(err: unknown): boolean {
+  if (err instanceof AuthRequestError && err.status === 401) {
+    return err.message.toLowerCase().includes('gdpr consent')
+  }
+  if (err instanceof Error) {
+    return err.message.toLowerCase().includes('gdpr consent')
+  }
+  return false
+}
+
+export function authErrorMessage(err: unknown, fallback: string): string {
+  if (err instanceof AuthRequestError || err instanceof Error) {
+    return err.message
+  }
+  return fallback
+}

--- a/dashboard/lib/signup-funnel.ts
+++ b/dashboard/lib/signup-funnel.ts
@@ -1,0 +1,23 @@
+/** sessionStorage keys for the signup funnel (plan → consent → OTP). */
+
+export const SIGNUP_PLAN_KEY = 'signup_plan'
+export const SIGNUP_CONSENT_GDPR_KEY = 'signup_consent_gdpr'
+export const SIGNUP_CONSENT_MARKETING_KEY = 'signup_consent_marketing'
+
+export function clearSignupSession(): void {
+  if (typeof window === 'undefined') return
+  sessionStorage.removeItem(SIGNUP_PLAN_KEY)
+  sessionStorage.removeItem(SIGNUP_CONSENT_GDPR_KEY)
+  sessionStorage.removeItem(SIGNUP_CONSENT_MARKETING_KEY)
+}
+
+export function hasSignupConsent(): boolean {
+  if (typeof window === 'undefined') return false
+  return sessionStorage.getItem(SIGNUP_CONSENT_GDPR_KEY) === '1'
+}
+
+export function getStoredSignupPlan(): 'pro' | 'team' | null {
+  if (typeof window === 'undefined') return null
+  const stored = sessionStorage.getItem(SIGNUP_PLAN_KEY)
+  return stored === 'pro' || stored === 'team' ? stored : null
+}

--- a/wiki/REST-API.md
+++ b/wiki/REST-API.md
@@ -68,8 +68,8 @@ GET /v1/events/{event_id}/why?depth=10
 
 | Method | Path | Description |
 |--------|------|-------------|
-| POST | `/v1/auth/request-otp` | Login OTP |
-| POST | `/v1/auth/verify-otp` | Get JWT |
+| POST | `/v1/auth/request-otp` | Send OTP — body `{email, intent:"login"|"signup"}`. Login returns **404** if email unknown; signup returns **409** if already registered. |
+| POST | `/v1/auth/verify-otp` | Get JWT — body `{email, otp, intent:"login"|"signup", gdpr_consent?, marketing_consent?}`. Login only works for existing users; signup requires `gdpr_consent:true` for new accounts. |
 | POST | `/v1/auth/api-keys` | Tenant-wide key (dashboard JWT only) |
 | GET | `/v1/auth/api-keys` | List all keys |
 | GET | `/v1/auth/api-keys/usage` | Plan key quota `{plan, limit, used, unlimited, at_limit}` |


### PR DESCRIPTION
Separate login and signup verify paths, atomic OTP consume, and smooth sign-in/sign-up UX. Fixes re-register after delete and stuck OTP screen.