### PR TITLE
Add lifecycle email automation, enterprise page, and knowledge bases.

### DIFF
--- a/.cursor/rules/authentication-knowledge-base.mdc
+++ b/.cursor/rules/authentication-knowledge-base.mdc
@@ -1,0 +1,451 @@
+---
+description: Single source of truth for ZizkaDB passwordless OTP auth — flows, rules, security, edge cases
+globs: core/services/auth.py,core/api/auth.py,core/api/deps.py,core/api/account.py,core/services/account.py,core/api/admin.py,core/tests/test_auth_flow.py,dashboard/app/login/**,dashboard/app/signup/**,dashboard/lib/auth.ts,dashboard/lib/auth-errors.ts,dashboard/lib/signup-funnel.ts,dashboard/lib/session-cookies.ts,dashboard/middleware.ts,dashboard/components/DashboardShell.tsx,dashboard/lib/api.ts
+alwaysApply: false
+---
+
+# ZizkaDB Authentication — Knowledge Base
+
+> **Last verified:** 2026-07-03  
+> **Related:** `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` (§7, §10, §19), `.cursor/rules/backend-dashboard-contract.mdc`, `.cursor/rules/email-lifecycle-knowledge-base.mdc` (OTP send, lifecycle scheduling, churn promo, newsletter sync), `wiki/REST-API.md`
+
+This is the **definitive reference** for passwordless OTP authentication (login, signup, sessions, admin, account deletion). Consult before bug fixes, feature work, refactors, security changes, or code reviews touching auth.
+
+---
+
+## 1. System Overview
+
+### High-level architecture
+
+Managed cloud dashboard auth is **passwordless email OTP**. No passwords. Successful verify returns a **JWT access token** (7-day TTL) stored client-side; the backend also sets an **HttpOnly refresh-token cookie** (30-day TTL — not used by the dashboard for rotation yet).
+
+```mermaid
+flowchart TB
+  subgraph Client["Dashboard (Next.js)"]
+    Login["/login"]
+    Signup["/signup/*"]
+    MW["middleware.ts\ncookie gate"]
+    AuthLib["lib/auth.ts\nlocalStorage + cookie"]
+  end
+
+  subgraph API["Core (FastAPI)"]
+    ReqOTP["POST /v1/auth/request-otp"]
+    VerOTP["POST /v1/auth/verify-otp"]
+    AuthSvc["services/auth.py"]
+    Deps["api/deps.py"]
+    DB[("Postgres\nusers, auth_otps, tenants")]
+    Email["Email service"]
+  end
+
+  Login --> ReqOTP --> AuthSvc --> DB
+  AuthSvc --> Email
+  Login --> VerOTP --> AuthSvc
+  Signup --> VerOTP
+  VerOTP --> AuthLib
+  AuthLib --> MW
+  MW --> Dashboard["/dashboard/*"]
+  Dashboard --> Deps
+```
+
+### Authentication modes
+
+| Mode | When | How |
+|------|------|-----|
+| **OTP login** | Production cloud, returning user | `intent: login` → verify → JWT |
+| **OTP signup** | New cloud user | Funnel → `intent: signup` + GDPR → verify → create tenant/user → JWT |
+| **Dev token** | `NEXT_PUBLIC_DEV_MODE=true` + backend `ENV=development` | `POST /v1/auth/dev-token` |
+| **Admin OTP** | Operator `/admin` | Allow-listed email; separate `is_admin` JWT |
+| **API keys** | SDK/MCP/integrations | `get_tenant` via key hash — **not** dashboard login |
+| **Dev API key** | Self-host local | `DEV_API_KEY` or known dev keys |
+
+### Technologies
+
+| Layer | Stack |
+|-------|-------|
+| Backend | FastAPI, asyncpg, bcrypt (OTP hash), PyJWT HS256, in-memory rate limits |
+| Frontend | Next.js 14 App Router, `sessionStorage` (funnel), `localStorage` + cookie (token) |
+| Edge | `dashboard/middleware.ts` — cookie **presence** only (no JWT validation) |
+
+### Lifecycle
+
+1. **Request OTP** → rate limit → intent/existence checks → invalidate old OTPs → bcrypt hash → email 6-digit code (15 min).
+2. **Verify OTP** → validate hash → intent rules → DB transaction → atomic OTP burn → issue tokens.
+3. **Client** → `setToken(access_token)` → hard redirect to `/dashboard`.
+4. **API calls** → `Authorization: Bearer <access_token>`.
+5. **Logout** → client clears token only (no server revoke endpoint).
+6. **Delete account** → purge tenant → `/login?deleted=1` → re-register via signup funnel.
+
+---
+
+## 2. Authentication Flows
+
+### 2.1 Sign Up
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant P as /signup/plan
+  participant S as /signup/start
+  participant E as /signup
+  participant API as Core API
+  participant DB as Postgres
+
+  U->>P: Choose pro or team
+  P->>P: sessionStorage signup_plan
+  P->>S: /signup/start?plan=
+  U->>S: GDPR consent
+  S->>S: signup_consent_gdpr=1
+  S->>E: /signup?plan=
+  U->>E: Enter email
+  E->>API: POST request-otp intent=signup
+  API->>DB: 409 if email exists
+  U->>E: 6-digit OTP
+  E->>API: POST verify-otp intent=signup gdpr_consent=true
+  API->>DB: txn create tenant+user+trial
+  API->>DB: atomic OTP burn
+  E->>E: setToken, clearSignupSession
+  E->>U: window.location /dashboard
+```
+
+| Step | Route / module | Details |
+|------|----------------|---------|
+| Plan | `/signup/plan` | Writes `SIGNUP_PLAN_KEY` (`pro`\|`team`) |
+| Consent | `/signup/start` | Required GDPR; optional marketing; `signup-funnel.ts` keys |
+| Email + OTP | `/signup/page.tsx` | `requestOtp(email, 'signup')`; 409 → `/login?email=` |
+| Verify | `verifyOtp(..., { intent: 'signup', gdprConsent, marketingConsent, promoCode? })` | Creates user; sets trial |
+| Post-auth | | `selectBillingPlan` best-effort; `clearSignupSession()`; hard redirect |
+
+**Optional:** `?promo=` / `SIGNUP_PROMO_KEY` → `promo_code` on verify → churn promo redemption (`redeem_churn_promo`).
+
+### 2.2 Sign In
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant L as /login
+  participant API as Core API
+
+  U->>L: Enter email
+  L->>API: POST request-otp intent=login
+  alt No account
+    API-->>L: 404
+    L->>U: Create account CTA
+  else Existing user
+    API-->>L: 200
+    U->>L: OTP auto-submit at 6 digits
+    L->>API: POST verify-otp intent=login
+    L->>U: hard redirect /dashboard
+  end
+```
+
+- **Existing user:** `intent: login`; updates `last_login`; no GDPR.
+- **Unknown email:** **404 at request-otp** (not verify) — inline "Create account" → `/signup/plan`.
+- **Session restore:** If `getToken()` on mount → re-`setToken` + redirect to `safeNext`.
+- **Query params:** `?email=` prefill; `?deleted=1` banner; `?next=/dashboard/...` (open-redirect guarded).
+- **Dev mode:** `POST /v1/auth/dev-token` when `NEXT_PUBLIC_DEV_MODE=true`.
+
+### 2.3 Account Deletion
+
+**Trigger:** Settings → confirm `DELETE` → `DELETE /v1/account` (JWT-only, managed cloud only).
+
+**Deleted** (`services/account.py::delete_managed_account`):
+- Qdrant vectors for tenant (best-effort)
+- `users`, `auth_otps` (by email), `tenants` (cascades agents/events/api_keys)
+
+**Side effects:** Churn promo email queued; pending lifecycle emails cancelled. **Email details:** `.cursor/rules/email-lifecycle-knowledge-base.mdc` §5–§7.
+
+**Client cleanup:** `clearToken()` + `clearSignupSession()` → `router.replace('/login?deleted=1')`.
+
+**Re-registration:** Email gone from `users` → full signup funnel with `intent=signup` + fresh GDPR. **Never** use login verify for new accounts after delete.
+
+### 2.4 Logout
+
+**No backend `/logout` endpoint.**
+
+```typescript
+// DashboardShell.tsx
+clearToken()           // localStorage + zizkadb_token cookie
+router.push('/login')  // soft nav
+```
+
+**Gap:** HttpOnly `refresh_token` cookie is **not** cleared on logout. No server-side session revocation.
+
+---
+
+## 3. Components & Services
+
+### Backend
+
+| Module | Purpose |
+|--------|---------|
+| `core/services/auth.py` | `request_otp`, `verify_otp(intent)`, `email_exists`, JWT issue/decode, API key verify |
+| `core/api/auth.py` | HTTP routes, OTP rate limit, refresh cookie on verify |
+| `core/api/deps.py` | `get_tenant` (JWT or API key); `require_dashboard_session` (JWT-only) |
+| `core/api/account.py` | Delete account, retention trial |
+| `core/services/account.py` | Deletion + churn email logic |
+| `core/api/admin.py` | Operator OTP; `verify_otp(..., intent="login")`; admin JWT with `is_admin` |
+
+### Frontend
+
+| Module | Purpose |
+|--------|---------|
+| `dashboard/app/login/page.tsx` | Login UI — `intent: login`, verifyLock, resend cooldown, hard redirect |
+| `dashboard/app/signup/page.tsx` | Signup OTP — funnel guard (`checked`), `intent: signup`, promo |
+| `dashboard/app/signup/plan/page.tsx` | Plan selection |
+| `dashboard/app/signup/start/page.tsx` | GDPR consent |
+| `dashboard/lib/api.ts` | `requestOtp`, `verifyOtp`, `AuthRequestError` |
+| `dashboard/lib/auth.ts` | `getToken` / `setToken` / `clearToken` / `requireAuth` |
+| `dashboard/lib/auth-errors.ts` | 404/409/GDPR error helpers |
+| `dashboard/lib/signup-funnel.ts` | sessionStorage keys, `clearSignupSession()` |
+| `dashboard/lib/session-cookies.ts` | `zizkadb_token`, `TOKEN_MAX_AGE_SEC` |
+| `dashboard/hooks/useResendCooldown.ts` | 60s client resend cooldown |
+| `dashboard/middleware.ts` | Edge cookie gate |
+| `dashboard/components/DashboardShell.tsx` | Sign out |
+
+### API endpoints
+
+| Method | Path | Auth | Notes |
+|--------|------|------|-------|
+| POST | `/v1/auth/request-otp` | None | `{email, intent?}` default `login` |
+| POST | `/v1/auth/verify-otp` | None | Returns `{access_token, ...billing}` |
+| POST | `/v1/auth/dev-token` | None | Dev only |
+| DELETE | `/v1/account` | JWT | Managed cloud delete |
+| POST | `/v1/admin/auth/*` | None / admin JWT | Operator only |
+
+---
+
+## 4. Business Rules
+
+### Intent model (critical)
+
+| Intent | request-otp | verify-otp |
+|--------|-------------|------------|
+| `login` (default) | **404** if email unknown | Existing user only; no GDPR |
+| `signup` | **409** if email exists | New user only; **`gdpr_consent: true` required** |
+
+**Why:** Prevents re-register-after-delete via login path (which skipped GDPR and misclassified users).
+
+### OTP rules
+
+- 6 digits; bcrypt hash at rest; **15-minute** expiry
+- New request invalidates prior unused OTPs for same email
+- Burn is **atomic inside verify transaction** — pre-check failures do **not** consume OTP
+- Invalid OTP → 401 `"Invalid OTP"` — code remains valid for retry
+
+### Signup side effects
+
+- Creates `tenants` + `users`; persists GDPR/marketing consent
+- Sets `plan=pro`, `subscription_status=trialing`, `trial_ends_at=+30d` (if unset)
+- Schedules signup lifecycle emails when `is_new_signup` — see email KB §5
+
+### Tokens
+
+| Token | TTL | Storage | Used by |
+|-------|-----|---------|---------|
+| Access JWT | 7 days | localStorage + JS cookie | API calls, middleware gate |
+| Refresh JWT | 30 days | HttpOnly cookie | Set on verify; no dashboard refresh flow |
+| Admin JWT | 7 days | `zizkadb_admin_token` | `/admin/*` |
+
+**Access JWT claims:** `sub`, `email`, `tenant_id`, `exp`, `iat`
+
+### Authorization
+
+- **`get_tenant`:** JWT or API key — does **not** check subscription status
+- **`require_dashboard_session`:** JWT only — account, API key creation, agent creation
+- **Agent-scoped keys:** `assert_agent_allowed` → 403 if wrong agent
+- **Admin:** `is_admin: true` + allow-listed `ADMIN_EMAIL`; wrong email → **404** (not 403)
+
+---
+
+## 5. State Management
+
+```mermaid
+flowchart LR
+  subgraph Persistent
+    LS["localStorage zizkadb_token"]
+    CK["cookie zizkadb_token"]
+    RF["HttpOnly refresh_token"]
+  end
+  subgraph Session
+    SS["sessionStorage signup_*"]
+  end
+  Verify --> setToken
+  setToken --> LS
+  setToken --> CK
+  Verify --> RF
+  SS --> SignupPages
+  CK --> Middleware
+  LS --> apiFetch
+```
+
+| Store | Keys | Cleared when |
+|-------|------|--------------|
+| `localStorage` | `zizkadb_token` | logout, account delete |
+| Cookie (JS) | `zizkadb_token` | `clearToken()` |
+| Cookie (HttpOnly) | `refresh_token` | Not cleared on logout (gap) |
+| `sessionStorage` | `signup_plan`, consent keys, `signup_promo` | successful signup, account delete |
+
+No global auth context — each page uses `getToken()` / `requireAuth()`. **No token refresh** on frontend today.
+
+---
+
+## 6. Edge Cases
+
+| Scenario | Behavior |
+|----------|----------|
+| Delete → sign up same email | Signup funnel + `intent=signup`; login returns 404 at request-otp |
+| Delete → try login | 404 at request-otp; `/login?deleted=1` banner → signup |
+| Invalid OTP | 401; OTP **not** burned |
+| Expired OTP | 401 `"OTP expired or not found"` |
+| Double verify (race) | Second: `"OTP already used"` |
+| Double-click verify (UI) | `verifyLock` ref blocks duplicate submit |
+| Resend OTP | Invalidates previous code; 60s client cooldown |
+| Rate limit request-otp | 429 after 10/email/15min (in-memory) |
+| Refresh mid-funnel | sessionStorage survives |
+| Multiple tabs | Shared localStorage — last write wins |
+| Token cookie vs localStorage mismatch | Middleware vs client API can disagree — always use `setToken`/`clearToken` |
+| `selectBillingPlan` fails post-signup | Swallowed — user on dashboard with default trial |
+| Missing plan/consent on `/signup` | Redirect to `/signup/plan` or `/signup/start` |
+| Self-host delete | `managed_cloud: false` — delete UI hidden |
+
+---
+
+## 7. Security
+
+### Implemented
+
+- OTP bcrypt hashed; short-lived; single-use (atomic burn)
+- Intent + existence checks before account mutations
+- Request-otp rate limiting (10/15min per email)
+- JWT secrets required in production (`JWT_SECRET`, `JWT_REFRESH_SECRET`)
+- Dev token / dev API key blocked in production
+- Admin panel obscurity (404 for wrong email)
+- Login `?next=` open-redirect guard
+
+### Known gaps (deferred — separate PR)
+
+| Gap | Risk |
+|-----|------|
+| Access token in **localStorage** | XSS can steal session |
+| Middleware checks cookie **presence only** | Expired token may pass edge guard |
+| **No verify-otp rate limit** | OTP brute-force |
+| **In-memory** rate limits | Resets on restart; not multi-instance |
+| **Refresh token not cleared** on logout | Stale cookie until expiry |
+| **No refresh rotation** | Future concern when refresh endpoint added |
+
+### HTTP status codes
+
+- **401** — OTP/auth failures (incl. business rule violations on verify)
+- **404** — login request for unknown email; admin wrong email
+- **409** — signup for existing email
+- **429** — OTP request rate limit
+
+---
+
+## 8. Development Guidelines
+
+### Adding auth features
+
+1. Read this rule + `backend-dashboard-contract.mdc`
+2. Decide: login vs signup vs JWT-only vs public
+3. Backend: preserve intent semantics; never burn OTP before transaction success
+4. Frontend: use `AuthRequestError` + `auth-errors.ts`; pass explicit `intent`
+5. Update `wiki/REST-API.md`, `core/tests/test_auth_flow.py`, KB sections
+
+### Safe patterns
+
+```python
+# OTP burn INSIDE transaction, after user mutation
+burned = await conn.fetchval(
+    "UPDATE auth_otps SET used = TRUE WHERE otp_id = $1 AND used = FALSE RETURNING otp_id",
+    row["otp_id"],
+)
+if not burned:
+    raise ValueError("OTP already used")
+```
+
+```typescript
+// Hard redirect after auth success (avoids stuck OTP screen)
+setToken(data.access_token)
+window.location.assign('/dashboard')
+
+// Always pass explicit intent on signup
+await verifyOtp(email, otp, { intent: 'signup', gdprConsent: true })
+```
+
+### Common mistakes
+
+- `verifyOtp` without `intent` on signup (defaults to `login`)
+- `router.replace` after OTP success instead of hard redirect
+- Clearing localStorage without cookie (breaks middleware)
+- Mocking `request_otp` in tests but not `email_exists` (login default intent)
+
+### Testing
+
+```bash
+cd core && .venv/bin/pytest tests/test_auth_flow.py tests/test_rate_limiting.py -q
+```
+
+Cover: intent routing, GDPR required, no burn on invalid OTP, atomic burn race, billing fail-open, rate limits with `email_exists` mock.
+
+**Manual smoke:** delete → signup → dashboard; login 404 CTA; resend + auto-submit OTP.
+
+---
+
+## 9. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| GDPR error on re-register | Login verify used instead of signup | `intent: signup` + funnel consent |
+| Stuck on OTP after success | Soft nav / double-submit | Hard redirect; check `verifyLock` |
+| Middleware → login but token exists | Cookie/localStorage mismatch | Use `setToken` (writes both) |
+| 404 on login for valid user | Typo or account deleted | Check `users` table |
+| 409 on signup | Account exists | `/login?email=` |
+| OTP "already used" on first try | Parallel verify requests | UI lock; request new code |
+| 429 on OTP request | 10+ requests in 15 min | Wait; in dev clear `_otp_rate` |
+
+### Key files
+
+- `core/services/auth.py`, `core/api/auth.py`
+- `dashboard/app/login/page.tsx`, `dashboard/app/signup/page.tsx`
+- `dashboard/lib/api.ts`, `dashboard/lib/auth.ts`
+- `core/tests/test_auth_flow.py`
+
+### Logging
+
+- `request_otp failed` — email/DB issues
+- `verify_otp failed` — unexpected 500
+- `billing status lookup failed after verify` — non-fatal
+- `Managed account deleted` — audit
+
+---
+
+## 10. Future Improvements
+
+### Security (planned separate PR)
+
+- Verify-otp rate limiting / lockout
+- Redis-backed rate limits
+- HttpOnly access token; remove localStorage JWT
+- Refresh rotation + `POST /v1/auth/logout`
+- Middleware JWT signature + expiry validation
+
+### UX / architecture
+
+- Shared `<OtpForm />` (login/signup duplication)
+- `useSignupFunnelGuard()` hook
+- E2E tests (Playwright) for full funnel
+- Clear `refresh_token` on logout
+
+---
+
+## Maintenance checklist
+
+When changing authentication:
+
+- [ ] Update **this rule**
+- [ ] Update `.cursor/rules/email-lifecycle-knowledge-base.mdc` if OTP send, lifecycle hooks, churn promo, or newsletter sync change
+- [ ] Update `wiki/REST-API.md` auth endpoints
+- [ ] Update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` §7, §10, §19
+- [ ] Extend `core/tests/test_auth_flow.py`
+- [ ] Verify `backend-dashboard-contract.mdc` invariants

--- a/.cursor/rules/backend-dashboard-contract.mdc
+++ b/.cursor/rules/backend-dashboard-contract.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # Backend ↔ Dashboard Contract
 
-The dashboard (`dashboard/`) is a client of this FastAPI backend. Before changing these files, check how the dashboard consumes them: `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` — endpoint map (§17.3), auth model (§17.2), backend state machine (§18), data model (§21).
+The dashboard (`dashboard/`) is a client of this FastAPI backend. Before changing these files, check how the dashboard consumes them: `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` — endpoint map (§17.3), auth model (§17.2), backend state machine (§18), data model (§21). **Auth OTP/intent flows:** `.cursor/rules/authentication-knowledge-base.mdc`. **Email/lifecycle:** `.cursor/rules/email-lifecycle-knowledge-base.mdc`.
 
 ## Contracts the dashboard relies on (do not break silently)
 - **`verify-otp` response shape** (`core/api/auth.py`): `{access_token, token_type, requires_plan_selection, requires_checkout, has_access, plan}`. Signup/login always get `has_access: true`, `requires_checkout: false` (no payment gate).
@@ -18,7 +18,7 @@ The dashboard (`dashboard/`) is a client of this FastAPI backend. Before changin
 - **API key plan limits** (`core/services/plan_limits.py` = single source of truth; `core/services/api_keys.py::assert_and_reserve_api_key_slot`): active keys per tenant capped by plan (Pro 3 / Team 10; else unlimited). Guard runs in a per-tenant advisory-locked txn before insert. Behind kill switch `API_KEY_LIMITS_ENFORCED` (default OFF). Usage: `GET /v1/auth/api-keys/usage` → `{plan, limit, used, unlimited, at_limit}`.
 
 ## Data model
-Schema in `core/db/schema.sql` + `migrations/002-006` + runtime DDL in `core/db/connection.py`. Plan/trial state lives on `users` (`stripe_*` columns retained but unused). Qdrant `agent_events` is 1536-dim COSINE; embeddings are dual-written to Postgres `events.embedding` + Qdrant. See §21.
+Schema in `core/db/schema.sql` + `migrations/002-007` + runtime DDL in `core/db/connection.py`. Plan/trial state lives on `users` (`stripe_*` columns retained but unused). Qdrant `agent_events` is 1536-dim COSINE; embeddings are dual-written to Postgres `events.embedding` + Qdrant. See §21.
 
 ## Keep the KB in sync
 If you change any contract above, a route, the billing/auth logic, or the DB schema, update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` (§17.3, §18, §21) in the same change — and the matching `dashboard/lib/api.ts` types/callers if the response shape changed.

--- a/.cursor/rules/dashboard.mdc
+++ b/.cursor/rules/dashboard.mdc
@@ -6,7 +6,7 @@ alwaysApply: false
 
 # ZizkaDB Dashboard — Agent Guide
 
-**Read first:** `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` is the source of truth (has a Table of Contents). Consult it before implementing features, fixing bugs, or reasoning about flows. Section map: architecture (§1-3), funnel (§5), business rules (§7), API layer (§8), touch points (§17), backend state machine (§18), per-screen behavior (§19), marketing/community/docs/admin surfaces (§20), data model / DB schema (§21), glossary (§22).
+**Read first:** `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` is the source of truth (has a Table of Contents). **Auth deep dive:** `.cursor/rules/authentication-knowledge-base.mdc` (OTP flows, intent model, security, edge cases). **Email/lifecycle:** `.cursor/rules/email-lifecycle-knowledge-base.mdc`. Consult before implementing features, fixing bugs, or reasoning about flows.
 
 ## Conventions (match these)
 - Next.js 14 App Router. Interactive pages are Client Components (`'use client'`). TS `strict`, `@/*` alias. No Prettier — match surrounding style (2-space, single quotes, no semicolons).

--- a/.cursor/rules/email-lifecycle-knowledge-base.mdc
+++ b/.cursor/rules/email-lifecycle-knowledge-base.mdc
@@ -1,0 +1,496 @@
+---
+description: Single source of truth for ZizkaDB email — OTP delivery, lifecycle campaigns C1–C8, outbox worker, newsletter, churn recovery
+globs: core/services/email/**,core/workers/email_worker.py,core/templates/email/**,core/api/newsletter.py,core/db/migrations/007_email_automation.sql,core/tests/test_email*.py,core/tests/test_churn_promo.py,core/tests/test_newsletter.py,core/services/auth.py,core/api/auth.py,core/services/account.py,core/services/api_keys.py,core/api/admin.py,dashboard/components/marketing/NewsletterPopup.tsx,dashboard/app/page.tsx,dashboard/app/signup/page.tsx,dashboard/app/signup/plan/page.tsx,dashboard/lib/api.ts,dashboard/lib/signup-funnel.ts,docs/email-automation-qa.md,infra/docker-compose.yml
+alwaysApply: false
+---
+
+# ZizkaDB Email Lifecycle — Knowledge Base
+
+> **Last verified:** 2026-07-03  
+> **Related:** `.cursor/rules/authentication-knowledge-base.mdc` (OTP auth flow, signup intent), `docs/email-automation-qa.md` (manual rollout), `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` (§18.8 dashboard summary)
+
+This is the **definitive reference** for all outbound email: OTP delivery, lifecycle campaigns (C1–C8), transactional outbox, ARQ worker, newsletter, and churn recovery. Consult before bug fixes, new campaigns, worker changes, or production rollout.
+
+**Scope boundary:** OTP *auth intent/signup funnel UX* lives in the auth KB. This rule owns `EmailService`, campaigns, outbox, worker, eligibility, newsletter, churn, and integration hooks.
+
+---
+
+## 1. System Overview
+
+### High-level architecture
+
+Passwordless OTP and lifecycle campaigns share `EmailService` + Jinja2 templates. **Two delivery paths:**
+
+| Path | When | How |
+|------|------|-----|
+| **Direct send** | OTP (`request-otp`) | `EmailService.send_otp()` → SMTP immediately |
+| **Outbox + worker** | Lifecycle C1–C8 | API/triggers **enqueue** → ARQ worker **sends** |
+
+```mermaid
+flowchart TB
+  subgraph API["FastAPI — enqueue only"]
+    AuthVerify["auth.py verify-otp"]
+    ApiKeys["api_keys.py create"]
+    AccountDel["account.py delete"]
+    NewsletterAPI["newsletter.py subscribe"]
+    AuthOTP["auth.py request-otp"]
+  end
+
+  subgraph EmailModule["core/services/email/"]
+    Triggers["triggers.py"]
+    Outbox["outbox.py"]
+    Processor["processor.py"]
+    Eligibility["eligibility.py"]
+    Service["service.py"]
+    Config["config.py"]
+  end
+
+  subgraph Worker["email_worker ARQ"]
+    Drain["drain_outbox every 1 min"]
+    Scan["scan_campaigns every 15 min"]
+  end
+
+  DB[("Postgres: email_outbox, email_send_log, churn_offers, newsletter_subscribers")]
+  SMTP["SmtpEmailProvider"]
+
+  AuthVerify --> Triggers
+  ApiKeys --> Triggers
+  AccountDel --> Outbox
+  AccountDel --> Triggers
+  NewsletterAPI --> Triggers
+  AuthOTP --> Service
+
+  Triggers --> Outbox
+  Scan --> Outbox
+  Drain --> Processor
+  Processor --> Eligibility
+  Processor --> Service
+  Service --> SMTP
+  Outbox --> DB
+  Processor --> DB
+```
+
+### Core invariants (never break)
+
+1. **API enqueues only; worker sends.** No lifecycle SMTP from HTTP handlers.
+2. **Auth never blocks on email failure.** All hooks: `try/except` + `log.warning`; signup/login/delete succeed even if SMTP is down.
+3. **OTP is transactional.** Campaign `otp` category bypasses `lifecycle_enabled()` and allowlist.
+4. **Lifecycle gated by `EMAIL_LIFECYCLE_ENABLED`** (default `false`).
+5. **Allowlist skip cancels outbox** — `send_template` returns `"skipped"` → processor calls `cancel_outbox_row`, **not** `mark_sent`.
+
+### Technologies
+
+| Layer | Stack |
+|-------|-------|
+| Backend | FastAPI, asyncpg, Jinja2, smtplib (via `asyncio.to_thread`) |
+| Worker | ARQ + Redis cron (`core/workers/email_worker.py`) |
+| Frontend | `NewsletterPopup.tsx`, `subscribeNewsletter()` in `lib/api.ts` |
+| Infra | `email_worker` service in `infra/docker-compose.yml` |
+
+---
+
+## 2. Campaign Registry
+
+All campaigns registered in `core/services/email/config.py` → `CAMPAIGNS`.
+
+| ID | Label | Category | Trigger | Delay | `recipient_key` | `dedupe_key` |
+|----|-------|----------|---------|-------|-----------------|--------------|
+| `otp` | OTP login | transactional | `request-otp` | immediate | — (direct send) | — |
+| `welcome` | C1 Welcome | lifecycle | Signup verify | +5 min | `user_id` | `default` |
+| `getting_started` | C2 Getting started | lifecycle | Signup verify | +10 min | `user_id` | `default` |
+| `no_api_72h` | C3 No API 72h | lifecycle | Signup verify | +72h | `user_id` | `default` |
+| `api_no_events` | C4 API no events | lifecycle | First API key | +7d | `tenant_id` | `first_key` |
+| `inactive_7d` | C5 Inactive 7d | lifecycle | Worker scan | immediate | `tenant_id` | `week-{ISO week}` |
+| `active_checkin` | C6 Active check-in | lifecycle | Worker scan | immediate | `user_id` | `window-{epoch//15d}` |
+| `account_deleted` | C7 Account deleted | transactional | Pre-delete | immediate | `email` | `delete_id` (UUID) |
+| `newsletter_welcome` | C8 Newsletter | marketing | Subscribe API | immediate | `email` (lower) | `default` |
+
+**Constants:**
+
+- `TEST_AGENT_ID = "dashboard-connection-test"` — excluded from “real event” activity metrics (C3–C6 eligibility and scans).
+- `FOUNDER_EMAIL`, `CALENDLY_URL` — injected into template context by `processor.build_context()`.
+- C5/C6 scan queries use `LIMIT 200` per run.
+
+**Delay compression (dev/staging only):** `EMAIL_STAGING_COMPRESS_DELAYS=true` maps delays >10 min to ~5 min. **Blocked when `ENV=production`.**
+
+---
+
+## 3. Data Model
+
+Migration: `core/db/migrations/007_email_automation.sql` (applied via `core/db/connection.py` init).
+
+### `email_outbox`
+
+| Column | Purpose |
+|--------|---------|
+| `campaign_id`, `recipient_key`, `dedupe_key` | **UNIQUE** — idempotent enqueue |
+| `to_email`, `payload` (JSONB) | Recipient + template context |
+| `scheduled_at` | Worker picks when `<= NOW()` |
+| `status` | `pending` → `processing` → `sent` \| `failed` \| `cancelled` |
+| `attempts`, `last_error` | Retry with exponential backoff (max 5) |
+
+**Status machine:**
+
+```
+pending ──claim_batch──► processing ──send OK──► sent (+ email_send_log row)
+   ▲                         │
+   │                         ├── eligibility fail / skipped ──► cancelled
+   │                         └── exception ──► pending (backoff) or failed (≥5 attempts)
+   └── reclaim_stale_processing (10 min stale processing)
+```
+
+**Claim:** `SELECT … FOR UPDATE SKIP LOCKED` — safe for multiple worker replicas.
+
+### `email_send_log`
+
+Audit of successfully sent lifecycle emails. Used by C6 to enforce 15-day minimum between `active_checkin` sends.
+
+### `churn_offers`
+
+| Column | Purpose |
+|--------|---------|
+| `promo_code` | `COMEBACK-{token}` unique |
+| `email` | Must match on redeem |
+| `expires_at` | 90 days from creation |
+| `redeemed_at` | Set atomically on signup redeem |
+
+### `newsletter_subscribers`
+
+| Column | Purpose |
+|--------|---------|
+| `email` | UNIQUE |
+| `unsubscribe_token_hash` | SHA-256 of plaintext token (returned only on subscribe flow) |
+| `unsubscribed_at` | NULL = active |
+
+### User columns (auth integration)
+
+- `marketing_consent`, `marketing_consent_at` on `users` — set at signup; synced with newsletter row via `newsletter_sync.py`.
+
+---
+
+## 4. Module Map
+
+| File | Responsibility |
+|------|----------------|
+| `config.py` | Campaign registry, `lifecycle_enabled()`, allowlist, delay compression, `is_recipient_allowed()` |
+| `service.py` | `EmailService.send_template()` / `send_otp()` — single SMTP entrypoint |
+| `renderer.py` | Jinja2 HTML/text from `core/templates/email/` |
+| `outbox.py` | `enqueue`, `claim_batch`, `mark_sent`, `mark_failed`, `cancel_*`, `outbox_stats` |
+| `triggers.py` | Fire-and-forget enqueue hooks (`schedule_signup_lifecycle`, etc.) |
+| `processor.py` | `process_outbox_batch`, `scan_scheduled_campaigns`, `build_context` |
+| `eligibility.py` | Pre-send checks; `ELIGIBILITY_HANDLERS` map |
+| `churn.py` | `create_churn_offer`, `redeem_churn_promo` |
+| `newsletter_sync.py` | Link/unlink newsletter row on signup vs `marketing_consent` |
+| `providers/smtp.py` | SMTP send; prints to stdout if `EMAIL_*` unset |
+| `providers/mock.py` | Test provider |
+| `workers/email_worker.py` | ARQ cron: drain every minute, scan at :00/:15/:30/:45 |
+
+**Templates:** `core/templates/email/{campaign_id}.html` (+ optional `.txt` for `otp`, `welcome`, `getting_started`).
+
+---
+
+## 5. Integration Points
+
+### Signup lifecycle (C1–C3)
+
+**File:** `core/api/auth.py` — after successful `verify-otp` when `is_new_signup`:
+
+```python
+schedule_signup_lifecycle(user_id=..., email=..., tenant_id=...)
+```
+
+Wrapped in `try/except`; failure logs `signup lifecycle schedule failed`.
+
+**File:** `core/services/email/triggers.py` — enqueues welcome, getting_started, no_api_72h with computed delays. No-op if `lifecycle_enabled()` is false.
+
+### OTP (direct send)
+
+**File:** `core/services/auth.py` — `request_otp()` after DB insert:
+
+```python
+await get_email_service().send_otp(email, otp)
+```
+
+Failure logs `OTP email send failed` — **request still returns 200** (code is in DB).
+
+### First API key (C4)
+
+**File:** `core/services/api_keys.py` — `_schedule_key_lifecycle_email(tenant_id)` after key create. Resolves tenant owner email; calls `schedule_api_key_lifecycle`.
+
+### Account deletion (C7 + cancel)
+
+**File:** `core/services/account.py` — `delete_managed_account()`:
+
+1. Always: `cancel_pending_for_user(user_id)` + `cancel_pending_for_tenant(tenant_id)` (C4 uses tenant as `recipient_key`).
+2. If `lifecycle_enabled()`: `create_churn_offer(email)` → `on_account_deleted_enqueue(...)` with unique `delete_id` dedupe key.
+3. Then purge Qdrant + delete user/tenant.
+
+C7 runs **before** user row is deleted so worker can still send; eligibility for C7 always returns `True`.
+
+### Churn promo redeem
+
+**File:** `core/services/auth.py` — `verify_otp()` on new signup when `promo_code` in body:
+
+- Rate limit: `_check_promo_rate_limit(email)` — 5 attempts / 15 min (in-memory).
+- `redeem_churn_promo(email, promo_code, user_id)` — extends trial 30 days, sets `subscription_status='trialing'`.
+- Invalid promo: logs warning, signup still succeeds (no UI feedback).
+
+**Dashboard:** `?promo=COMEBACK-*` → `sessionStorage` (`SIGNUP_PROMO_KEY`) → `verifyOtp(..., { promoCode })`.
+
+### Newsletter (C8)
+
+**API:** `core/api/newsletter.py`
+
+- `POST /v1/newsletter/subscribe` — 503 if `lifecycle_enabled()` false; honeypot `botcheck`; rate limit 10/hr/IP.
+- `GET /v1/newsletter/unsubscribe?token=` — token ≥16 chars; SHA-256 lookup.
+
+**Signup sync:** `sync_newsletter_on_signup()` — if popup subscriber exists but user declined marketing at signup → unsubscribe row.
+
+**Dashboard:** `NewsletterPopup.tsx` — gated by `NEXT_PUBLIC_NEWSLETTER_ENABLED === 'true'`; 15s delay; 7d dismiss in localStorage.
+
+### Admin monitoring
+
+**API:** `GET /v1/admin/email/stats` (admin JWT) → `{ outbox: {status: count}, sent_24h, failed, pending }`.
+
+---
+
+## 6. Environment & Flags
+
+From `.env.example`:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `EMAIL_HOST`, `EMAIL_PORT`, `EMAIL_USER`, `EMAIL_PASS`, `EMAIL_FROM` | — | SMTP; unset → OTP/lifecycle print to API stdout |
+| `EMAIL_LIFECYCLE_ENABLED` | `false` | Master kill switch for lifecycle enqueue + worker processing |
+| `EMAIL_LIFECYCLE_ALLOWLIST` | empty | Comma-separated emails; when set, only those receive lifecycle/marketing |
+| `EMAIL_DEV_REDIRECT` | empty | Redirect all sends to this address (dev only) |
+| `EMAIL_STAGING_COMPRESS_DELAYS` | `false` | Compress long delays; **never prod** |
+| `NEXT_PUBLIC_NEWSLETTER_ENABLED` | `false` | Dashboard build-time; controls popup |
+| `DASHBOARD_URL` | `https://db.zizka.ai` | Links in templates |
+| `REDIS_URL` | — | Required for ARQ worker |
+
+### Recipient allow rules (`is_recipient_allowed`)
+
+| Category | Rules |
+|----------|-------|
+| `transactional` | Always allowed (`otp`, `account_deleted`) |
+| `lifecycle` / `marketing` | Requires `lifecycle_enabled()` + SMTP configured + allowlist pass (if set) |
+
+### Production rollout
+
+See `docs/email-automation-qa.md`:
+
+1. Deploy with `EMAIL_LIFECYCLE_ENABLED=false`
+2. Enable with `EMAIL_LIFECYCLE_ALLOWLIST=founder@…` — soak 24h
+3. Remove allowlist for global enable — monitor 48h
+
+**Instant rollback:** set both flags false, restart `api` + `email_worker`, redeploy dashboard.
+
+---
+
+## 7. Execution Flows
+
+### C1–C3: Signup lifecycle
+
+```
+verify-otp (signup) → schedule_signup_lifecycle (async task)
+  → enqueue welcome (+5m), getting_started (+10m), no_api_72h (+72h)
+  → worker drain → eligibility → send_template → mark_sent
+```
+
+C3 eligibility at send time: user exists + zero active API keys.
+
+### C4: API key, no events
+
+```
+create API key → schedule_api_key_lifecycle (tenant owner)
+  → enqueue api_no_events (+7d, dedupe first_key)
+  → at send: keys exist AND no real events (excludes connection_test)
+```
+
+### C5: Inactive 7 days
+
+```
+scan_campaigns (every 15 min) → SQL scan (LIMIT 200)
+  → enqueue inactive_7d (dedupe week-{ISO})
+  → eligibility: keys + had events + no events in 7d
+```
+
+### C6: Active check-in
+
+```
+scan_campaigns → SQL: events in 7d AND no active_checkin in send_log within 15d
+  → enqueue (dedupe window-{15d epoch})
+  → eligibility mirrors scan + user exists
+```
+
+### C7: Account deleted + churn
+
+```
+delete_managed_account → cancel pending outbox
+  → create_churn_offer → enqueue account_deleted (immediate)
+  → email contains signup_url with ?promo=COMEBACK-...
+```
+
+### C8: Newsletter
+
+```
+NewsletterPopup (15s) → POST /v1/newsletter/subscribe
+  → insert/update newsletter_subscribers → on_newsletter_subscribed
+  → enqueue newsletter_welcome
+```
+
+Unsubscribe link uses hashed token (not stored plaintext).
+
+### Real vs test events
+
+Eligibility and scans filter:
+
+```sql
+AND NOT (agent_id = 'dashboard-connection-test' AND event_type = 'connection_test')
+```
+
+---
+
+## 8. Eligibility & Send Rules
+
+Handlers in `eligibility.py` → `ELIGIBILITY_HANDLERS`:
+
+| Campaign | Check |
+|----------|-------|
+| `welcome`, `getting_started` | `user_exists(user_id)` |
+| `no_api_72h` | user exists + `count_active_keys == 0` |
+| `api_no_events` | keys > 0 + no real events ever |
+| `inactive_7d` | keys > 0 + had events + no events in 7d |
+| `active_checkin` | user exists + events in 7d + no send_log in 15d |
+| `account_deleted`, `newsletter_welcome` | always `True` at eligibility stage |
+
+**Processor skips eligibility** for `account_deleted` and `newsletter_welcome` (already vetted at enqueue).
+
+**Marketing consent:** campaigns with `category="marketing"` call `eligible_marketing_send()` — `newsletter_welcome` exempt (explicit opt-in at subscribe).
+
+**C4 vs C5 mutual exclusion:** C4 requires keys + never sent real events; C5 requires keys + sent events + quiet 7d. Cannot both qualify (see `test_email_campaign_overlap.py`).
+
+**Send skip → cancel:** When `send_template` returns `"skipped"` (allowlist, disabled campaign), processor **cancels** the outbox row — prevents false “sent” metrics.
+
+**Retries:** `MAX_ATTEMPTS = 5`; backoff `min(30, 2^attempts)` minutes; then `status = failed`.
+
+---
+
+## 9. Testing
+
+```bash
+cd core && pytest tests/test_email*.py tests/test_churn_promo.py tests/test_newsletter.py -q
+```
+
+| File | Covers |
+|------|--------|
+| `test_email_service.py` | `send_otp`, allowlist skip, dev redirect |
+| `test_email_outbox.py` | enqueue dedupe, cancel, claim |
+| `test_email_triggers.py` | signup lifecycle gated on flag |
+| `test_email_eligibility.py` | C3/C4/C5/C6 rules |
+| `test_email_eligibility_welcome.py` | C1/C2 user exists |
+| `test_email_processor.py` | batch send, skip→cancel |
+| `test_email_hardening.py` | OTP non-blocking, newsletter sync |
+| `test_email_deletion.py` | cancel on delete, C7 gated |
+| `test_email_campaign_overlap.py` | C4/C5 mutual exclusion |
+| `test_churn_promo.py` | create, redeem, expiry, wrong email |
+| `test_newsletter.py` | subscribe 503 when off, rate limit, unsubscribe |
+
+Auth integration: `test_auth_flow.py` mocks `schedule_signup_lifecycle`.
+
+**Manual:** `docs/email-automation-qa.md` before production enable.
+
+---
+
+## 10. Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| Outbox `pending` grows | Worker not running or lifecycle off | `docker compose ps email_worker`; check `EMAIL_LIFECYCLE_ENABLED` |
+| No lifecycle sends | Flag false or allowlist | Enable flag; check recipient in allowlist |
+| OTP works, lifecycle doesn't | Lifecycle flag / SMTP for lifecycle category | Lifecycle requires `smtp_configured_for_lifecycle()` |
+| Duplicate sends | Should not happen | UNIQUE on outbox; check dedupe_key per campaign |
+| Stuck `processing` | Worker crash | Auto-reclaim after 10 min (`STALE_PROCESSING_MINUTES`) |
+| C6 too frequent | Dedupe bug | Verify `active_checkin_dedupe_key()` + send_log 15d check |
+| Newsletter 503 | Lifecycle disabled | Expected; enable flag + redeploy |
+| Popup not showing | Build flag | `NEXT_PUBLIC_NEWSLETTER_ENABLED=true` + rebuild dashboard |
+| Promo not applied | Invalid/expired/wrong email | Check `churn_offers` table; logs `promo redeem skipped` |
+
+### Key log strings
+
+- `email trigger failed`
+- `outbox send failed id=… campaign=…`
+- `OTP email send failed for … (code saved in DB)`
+- `signup lifecycle schedule failed`
+- `newsletter welcome enqueue failed`
+- `api key lifecycle schedule skipped`
+
+### Observability
+
+```bash
+# Admin JWT required
+GET /v1/admin/email/stats
+
+# Worker logs
+docker compose -f infra/docker-compose.yml logs -f email_worker
+```
+
+---
+
+## 11. Pitfalls & Future Improvements
+
+### Known limitations (P2)
+
+| Issue | Detail |
+|-------|--------|
+| In-memory rate limits | Newsletter (10/hr/IP), promo redeem (5/15min) — not multi-API safe |
+| Scan pagination | C5/C6 `LIMIT 200` per run — large tenant bases need pagination |
+| Promo UX | Invalid promo on signup fails silently (logged only) |
+| `send_log` retention | No archival job |
+| `account_deleted` | Transactional — bypasses allowlist (intentional for churn email) |
+| No integration tests | Worker + real Postgres not in CI |
+
+### Safe extension checklist (new campaign)
+
+1. Add `CampaignConfig` to `config.py` + template(s)
+2. Add eligibility handler (if conditional)
+3. Add trigger in `triggers.py` OR scan in `processor.scan_scheduled_campaigns`
+4. Choose `recipient_key` + `dedupe_key` strategy
+5. Never send from API — enqueue only
+6. Add tests + update this rule + `docs/email-automation-qa.md`
+
+### Future improvements
+
+- Redis-backed rate limits for horizontal API scaling
+- Alerting when `outbox.failed > 0`
+- `email_send_log` retention/archival job
+- Resend/SES provider behind `providers/` protocol
+- Promo redeem feedback on signup UI
+- Worker integration tests
+
+---
+
+## Maintenance checklist
+
+When changing email behavior:
+
+- [ ] Update **this rule**
+- [ ] Update `docs/email-automation-qa.md` if rollout steps change
+- [ ] Update `.env.example` for new flags
+- [ ] Add/extend tests in `core/tests/test_email*.py`
+- [ ] Update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` §18.8 if dashboard contract changes
+- [ ] Update `backend-dashboard-contract.mdc` if API shapes change
+- [ ] Verify `infra/docker-compose.yml` if worker config changes
+
+### Key files
+
+- `core/services/email/` — all business logic
+- `core/workers/email_worker.py` — cron schedule
+- `core/templates/email/` — Jinja2 templates
+- `core/api/newsletter.py` — public newsletter API
+- `core/services/auth.py`, `core/api/auth.py` — OTP + lifecycle + promo hooks
+- `core/services/account.py` — delete + cancel + C7
+- `core/services/api_keys.py` — C4 trigger
+- `dashboard/components/marketing/NewsletterPopup.tsx`
+- `dashboard/lib/api.ts` — `subscribeNewsletter`, `verifyOtp` promo body

--- a/.cursor/rules/enterprise-page-knowledge-base.mdc
+++ b/.cursor/rules/enterprise-page-knowledge-base.mdc
@@ -1,0 +1,46 @@
+---
+description: Enterprise marketing page — copy guardrails, lead capture, QA, and cross-links
+globs: dashboard/app/enterprise/**,dashboard/components/marketing/enterprise/**,dashboard/components/marketing/MarketingFooter.tsx,dashboard/components/marketing/MarketingPageStyles.tsx,dashboard/components/SiteNav.tsx,dashboard/lib/demo.ts,core/api/demo_requests.py,core/db/migrations/008_demo_requests_enterprise.sql,docs/enterprise-page-qa.md
+alwaysApply: false
+---
+
+# Enterprise Page — Agent Guide
+
+**Route:** `/enterprise` · **QA checklist:** `docs/enterprise-page-qa.md` · **Dashboard KB:** §20.5 · **Copy source:** `dashboard/components/marketing/enterprise/enterprise-copy.ts`
+
+## Page composition (order)
+
+Hero → What ZizkaDB is → Multi-agent fleets (drift bands) → Capabilities (open core vs VPC) → Tier compare → VPC deploy → Platform → FAQ → Footer CTA (`#connect`) → Resources strip.
+
+Shared shell: `SiteNav active="enterprise"`, `MarketingPageStyles`, `MarketingFooter`, `CalendlyBookModal`.
+
+## Lead capture
+
+- Form: `EnterpriseConnectForm` → `submitDemoRequest` (`lib/demo.ts`) → `POST /v1/demo-requests`
+- Always sends `source: 'enterprise'`; optional `position` (role/title)
+- Honeypot field name: **`botcheck`** (not `website`); client silently drops if filled
+- Backend allowlist: `enterprise`, `landing`, `newsletter` — else 422
+- Admin demo tab shows Role + Source; search includes both
+
+## Copy guardrails (must NOT claim on `/enterprise`)
+
+SOC 2, HIPAA, SSO/SAML/SCIM **as shipped**, Slack/PagerDuty alerts, SLA guarantees, hallucination **detection** (negation OK).
+
+**Must stay honest:** behavioral drift (not hallucination detection), VPC deployment, commercial license, Week-1 package, fleet UI + audit export **in customer VPC** (not public cloud today). SSO/SAML only as **roadmap** footnote in platform section.
+
+## Cross-page consistency
+
+- Trust `#limits`: Enterprise row → Contact sales / Custom (VPC)
+- Landing `#pricing`: link to `/enterprise`
+- `MarketingFooter` on trust, docs, community, enterprise, landing
+
+## Before merge
+
+```bash
+cd dashboard && npm run lint && npm run build
+cd ../core && pytest tests/test_rate_limiting.py -q
+rg -i 'SOC 2|HIPAA|SAML|SCIM|PagerDuty|Slack alert|SLA guarantee|detects hallucination' \
+  dashboard/components/marketing/enterprise dashboard/app/enterprise
+```
+
+Update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` §20.5 and `backend-dashboard-contract.mdc` if demo-requests contract changes.

--- a/.cursor/rules/project-knowledge-base.mdc
+++ b/.cursor/rules/project-knowledge-base.mdc
@@ -1,0 +1,343 @@
+---
+description: Master knowledge base — architecture, conventions, flows, and safe-change rules for the entire ZizkaDB repo
+alwaysApply: true
+---
+
+# ZizkaDB — Project Knowledge Base (Cursor Rules)
+
+> **Last verified:** 2026-07-03  
+> **Purpose:** Single source of truth for humans and AI agents working in this repository.  
+> **Deep dives:** `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` (dashboard UI), `.cursor/rules/authentication-knowledge-base.mdc` (OTP auth), `.cursor/rules/email-lifecycle-knowledge-base.mdc` (email/lifecycle), `docs/email-automation-qa.md` (email rollout).
+
+---
+
+## 1. Project Overview
+
+### What this system does
+
+**ZizkaDB** is an operational database for AI agents: multi-tenant event logging, semantic search, memory/context APIs, agent baseline/drift, and a Next.js dashboard for onboarding and ops. SDKs (Python/TS), MCP, and LangChain/CrewAI integrations **write events**; the dashboard **reads** them.
+
+There is **no payment provider** at runtime. Signup = plan selection → GDPR consent → email OTP → 30-day trial (`subscription_status='trialing'`). Legacy Stripe columns may exist but are unused.
+
+### Core problem it solves
+
+Agents need a durable, queryable event log with vectors for “why did this happen?”, session replay, and production debugging — without building custom Postgres + Qdrant plumbing per project.
+
+### High-level architecture
+
+```
+Producers (SDK / MCP / integrations) ──POST /v1/events──► FastAPI (core/)
+                                                              │
+Dashboard (Next.js, PM2 :3001) ◄──JWT / API keys─────────────┤
+                                                              ├── Postgres (source of truth)
+                                                              ├── Qdrant (vector search)
+                                                              ├── Redis (embedding cache, ARQ)
+                                                              └── email_worker (lifecycle mail)
+
+Production: EC2, docker-compose (API + Postgres + Qdrant + Redis + email_worker), nginx → dashboard + /v1/
+```
+
+---
+
+## 2. System Architecture
+
+### Modules / services
+
+| Area | Path | Role |
+|------|------|------|
+| **API** | `core/main.py`, `core/api/*` | FastAPI routers, thin HTTP layer |
+| **Business logic** | `core/services/*` | Auth, billing, events, email, account, embeddings |
+| **Data** | `core/db/` | `schema.sql`, migrations, `connection.py` (pool + init) |
+| **Worker** | `core/workers/email_worker.py` | ARQ cron: drain email outbox, scan C5/C6 |
+| **Dashboard** | `dashboard/` | Next.js 14 App Router, client-heavy |
+| **SDK** | `sdk/python`, `sdk/typescript` | Client libraries for event write/search |
+| **MCP** | `mcp/` | ZizkaDB MCP server for Cursor/agents |
+| **Integrations** | `integrations/*` | LangChain, CrewAI adapters |
+| **Infra** | `infra/` | docker-compose, deploy scripts, nginx |
+
+### Data flow (event write)
+
+1. Client sends `POST /v1/events` with API key (tenant/agent scoped).
+2. `core/services/event_write.py`: upsert agent, insert event (checksum), optional embedding.
+3. Dual-write: Postgres `events.embedding` + Qdrant `agent_events`.
+4. `usage_daily.events_written` incremented.
+
+### Key integrations
+
+- **Postgres** (`DATABASE_URL`) — all relational state.
+- **Qdrant** (`QDRANT_URL`) — cosine search on 1536-dim embeddings.
+- **Redis** (`REDIS_URL`) — embedding cache; ARQ queue for email worker.
+- **SMTP** (`EMAIL_*`) — OTP + lifecycle emails via `EmailService`.
+- **OpenAI** (`OPENAI_API_KEY`) — platform embeddings when tenant has no BYOK key.
+
+### External dependencies
+
+Python: FastAPI, asyncpg, qdrant-client, redis, arq, jinja2, bcrypt, PyJWT.  
+Dashboard: Next.js, React, Tailwind + inline marketing styles, recharts.
+
+---
+
+## 3. Core Concepts (Domain Knowledge)
+
+| Term | Meaning |
+|------|---------|
+| **Tenant** | Isolation root; all events, keys, users belong to one `tenant_id`. |
+| **Agent** | Named identity within tenant (`agents` table); events tagged with `agent_id`. |
+| **Event** | Append-only row: `event_type` + JSONB `data`, optional causal `parent_event_id`. |
+| **Session** | Events sharing `session_id`. |
+| **API key** | `zizkadb_live_*` (SHA-256 stored); tenant-wide or agent-scoped. |
+| **JWT** | Dashboard session from OTP; distinct from API keys. |
+| **OTP** | 6-digit bcrypt-hashed code, 15-min TTL (`auth_otps`). |
+| **Trial** | `subscription_status='trialing'`, `trial_ends_at` on `users`. |
+| **Outbox** | `email_outbox` queue; worker sends asynchronously. |
+| **Campaign** | Lifecycle email type (C1–C8) registered in `services/email/config.py`. |
+| **Test agent** | `dashboard-connection-test` — excluded from email activity metrics. |
+
+### Email lifecycle
+
+Eight campaigns (C1–C8) behind `EMAIL_LIFECYCLE_ENABLED` (default off). API enqueues; ARQ worker sends. **Full reference:** `.cursor/rules/email-lifecycle-knowledge-base.mdc`.
+
+---
+
+## 4. Folder & Code Structure
+
+### Repository layout (where to put things)
+
+```
+core/api/           → HTTP routers only (validate, call service, map errors)
+core/services/      → Business logic (no FastAPI imports in pure helpers)
+core/services/email/→ All lifecycle email logic
+core/db/migrations/ → Numbered SQL (007_email_automation.sql, etc.)
+core/templates/email/→ Jinja2 HTML/text templates
+core/tests/         → pytest; mark integration tests appropriately
+core/workers/       → ARQ background jobs
+dashboard/app/      → Next.js routes (mostly 'use client')
+dashboard/lib/      → api.ts (all HTTP), auth.ts, signup-funnel.ts
+dashboard/components/→ Reusable UI
+infra/              → docker-compose, deploy-*.sh, nginx
+docs/               → QA checklists, runbooks
+.cursor/rules/      → Cursor AI rules (this file + specialized rules)
+```
+
+### Rules for new code
+
+- **New API route:** `core/api/<domain>.py` → register in `main.py` under `/v1/`.
+- **New dashboard call:** add function to `dashboard/lib/api.ts`; match backend response shape.
+- **New email campaign:** entry in `config.py` + template + eligibility function + trigger or cron scan.
+- **New DB table:** migration SQL in `core/db/migrations/` + apply in `connection.py` init if idempotent.
+- **Do not** send email directly from API handlers — use `EmailService` or outbox enqueue.
+
+---
+
+## 5. Coding Standards & Conventions
+
+### Naming
+
+- Python: `snake_case` modules/functions; async services throughout API layer.
+- TypeScript: camelCase functions; `PascalCase` components; cookie keys in `session-cookies.ts`.
+- Campaign IDs: `snake_case` strings matching template folder names (`welcome`, `no_api_72h`).
+
+### API patterns
+
+- Prefix: `/v1/<resource>`.
+- Auth: `get_tenant` (JWT or API key) in `core/api/deps.py`; account routes JWT-only.
+- Public endpoints: demo-requests (`source` allowlist: `enterprise`, `landing`, `newsletter`), newsletter subscribe (gated by `lifecycle_enabled()`), health.
+- Enterprise leads: `/enterprise` form → `demo_requests.position` + `demo_requests.source`; migration `008_demo_requests_enterprise.sql`.
+- Admin: `/v1/admin/*` — founder email only; 404 for non-admin (not 403).
+
+### Error handling
+
+- Services raise `ValueError` for expected auth/business failures → API maps to 401/409/404.
+- Email/lifecycle hooks: **try/except + log warning**; never fail signup/login/delete.
+- OTP send failure after DB insert: log warning, return 200 (code is in DB).
+
+### Logging
+
+- Module-level `log = logging.getLogger(__name__)`.
+- `log.warning` for recoverable email/auth side effects; `log.error`/`log.exception` for unexpected API failures.
+
+### Dashboard state
+
+- No global store: `useState` per page; `sessionStorage` for signup funnel; `localStorage` + cookie for JWT.
+- Hard redirect after auth: `window.location.assign` (not client router) to avoid stuck OTP screens.
+
+### Async / concurrency
+
+- FastAPI async endpoints; `asyncpg` pool via `get_pool()`.
+- Outbox claim: `SELECT FOR UPDATE SKIP LOCKED` (safe for multiple workers).
+- SMTP: `asyncio.to_thread` in `EmailService` (sync smtplib).
+- In-memory rate limits (OTP, newsletter, promo): **single EC2 OK**; use Redis if API scales horizontally.
+
+---
+
+## 6. Key Features & Flows
+
+### Signup funnel
+
+```
+/signup/plan → /signup/start (consent) → /signup (OTP) → verify-otp → schedule lifecycle (async) → /dashboard
+```
+
+- `intent=signup` on request-otp/verify-otp; GDPR required; `marketing_consent` persisted.
+- Lifecycle scheduling on signup — see email KB.
+- Churn promo on signup — see email KB.
+
+### OTP login
+
+- `intent=login`; 404 if unknown email on request; existing user only on verify.
+- OTP via `EmailService` (transactional; see email KB).
+
+### Account deletion (production only)
+
+- Cancels pending outbox, optional C7 + churn — see email KB.
+
+### Email edge cases
+
+See `.cursor/rules/email-lifecycle-knowledge-base.mdc` §8–§10 (allowlist skip, eligibility, worker reclaim, SMTP-down OTP).
+
+### Enterprise marketing (`/enterprise`)
+
+- Static marketing + lead form; no tenant auth.
+- Copy guardrails and QA: `.cursor/rules/enterprise-page-knowledge-base.mdc`, `docs/enterprise-page-qa.md`.
+- Fleet dashboard and audit export framed as **VPC delivery**, not live on public `db.zizka.ai`.
+
+---
+
+## 7. Debugging & Observability
+
+### Trace issues
+
+1. **API:** `docker compose logs api`; hit `/health`.
+2. **Auth:** see `.cursor/rules/authentication-knowledge-base.mdc`.
+3. **Email:** see `.cursor/rules/email-lifecycle-knowledge-base.mdc` §10 (`GET /v1/admin/email/stats`).
+4. **Events/search:** verify API key tenant, Qdrant connectivity, embedding dim = 1536.
+5. **Dashboard:** browser network tab → `/v1/*`; check `zizkadb_token` cookie.
+
+### Common failure points
+
+- Email worker / lifecycle flags — see email KB §10.
+- `JWT_SECRET` unset in production → API refuses to start.
+- Qdrant/Postgres embedding mismatch (non-1536) → embedding skipped.
+- GPG-signed git commits on dev machines (local commit tooling).
+
+### Logs to search
+
+- Email-specific log strings — see email KB §10.
+
+---
+
+## 8. Adding New Features (Guidelines)
+
+### Process
+
+1. Read this file + specialized rule for the area (auth, dashboard, email).
+2. Implement in **service layer** first; keep API router thin.
+3. Add/update tests in `core/tests/` (`pytest -m "not integration"`).
+4. Update `dashboard/lib/api.ts` + KB if contract changes.
+5. For email: never block auth; use outbox + worker; add campaign to `config.py`.
+6. Run CI locally: `ruff check core`, `pytest core/tests/ -m "not integration"`.
+
+### What NOT to break
+
+- `verify-otp` response shape (dashboard routing depends on it).
+- `billing_status_payload` shape (`TenantPlanBanner`).
+- `get_tenant` / agent scope checks on events API.
+- Auth never blocked by email failures.
+- Production deploy: **never** `docker compose down -v` (use `infra/deploy-production.sh`).
+
+### PR checklist
+
+- [ ] Tests pass
+- [ ] No secrets in code or outbox payload
+- [ ] Feature flags default safe (lifecycle off)
+- [ ] KB/rules updated if contract changed
+- [ ] Dashboard build if `NEXT_PUBLIC_*` changed
+
+---
+
+## 9. Known Issues / Pitfalls
+
+| Area | Issue |
+|------|--------|
+| **Rate limits** | In-memory per process; ineffective with multiple API replicas |
+| **Email lifecycle** | See email KB §11 (rate limits, promo UX, send_log retention) |
+| **Refresh token** | HttpOnly cookie set; dashboard doesn't rotate yet |
+| **API_KEY_LIMITS** | Behind `API_KEY_LIMITS_ENFORCED` (default OFF) |
+| **Stripe columns** | Legacy; unused |
+
+### Fragile areas
+
+- `core/db/connection.py` runtime DDL (must stay idempotent).
+- Signup page redirect gates (`checked` state) — avoid flash/regression.
+- Dual-write embeddings (Postgres + Qdrant) — partial failure leaves inconsistency.
+
+---
+
+## 10. Testing Strategy
+
+### CI (`.github/workflows/ci.yml`)
+
+- `ruff check` on core, sdk, mcp, integrations.
+- `pytest core/tests/ -m "not integration"`.
+- Dashboard `npm ci && npm run build`.
+
+### Must test before release
+
+- `test_auth_flow.py` — OTP intent, signup/login separation.
+- Email tests — see email KB §9.
+- Any change to `verify-otp` or `billing_status_payload` → billing + auth tests.
+
+### Local
+
+```bash
+cd core && pytest tests/ -m "not integration" -q
+cd dashboard && npm run build
+```
+
+---
+
+## 11. Future Improvements
+
+| Priority | Item |
+|----------|------|
+| High | Redis-backed rate limits when scaling API horizontally |
+| Email | See email KB §11 |
+| Low | Refresh token rotation in dashboard |
+
+### Scalability path
+
+- Email worker scaling — see email KB §11.
+- Separate read replicas for analytics/admin only.
+
+---
+
+## Quick reference — environment flags
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `EMAIL_*` / lifecycle flags | — | See email KB §6 |
+| `ENV` | `development` | `production` on managed cloud |
+| `API_KEY_LIMITS_ENFORCED` | off | Pro 3 / Team 10 key caps |
+
+### Production deploy (safe)
+
+```bash
+EMAIL_LIFECYCLE_ENABLED=false
+NEXT_PUBLIC_NEWSLETTER_ENABLED=false
+bash infra/deploy-production.sh
+```
+
+### Specialized rules (consult when editing matching files)
+
+| Rule file | Topic |
+|-----------|--------|
+| `authentication-knowledge-base.mdc` | OTP auth, signup/login, admin auth |
+| `email-lifecycle-knowledge-base.mdc` | Lifecycle email C1–C8, outbox, worker, newsletter, churn |
+| `backend-dashboard-contract.mdc` | API shapes the dashboard depends on |
+| `dashboard.mdc` | Frontend conventions |
+| `zizkadb-mcp.mdc` | MCP agent name for ZizkaDB tools |
+| `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` | Full UI/route reference |
+
+---
+
+*Update this file when adding major subsystems or changing cross-cutting contracts.*

--- a/.cursor/rules/zizkadb-mcp.mdc
+++ b/.cursor/rules/zizkadb-mcp.mdc
@@ -1,0 +1,17 @@
+---
+description: ZizkaDB MCP agent identity for Cursor
+globs:
+alwaysApply: true
+---
+
+# ZizkaDB MCP (Cursor)
+
+This project has ZizkaDB MCP configured in `.cursor/mcp.json`.
+
+When calling ZizkaDB MCP tools (`log_event`, `why`, `search_memory`, `get_context`, `time_travel`, `memory_diff`, `forget`), always use:
+
+- **agent:** `my-personal-cursor-agent`
+
+The API key is scoped to that agent name only. Using a different agent name returns HTTP 403.
+
+After changing MCP config, reload MCP in Cursor or restart the app.

--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,18 @@ NEXT_PUBLIC_DEV_MODE=true
 # Trial length for new signups (days)
 TRIAL_DAYS=30
 
+# Lifecycle email automation (requires EMAIL_* and email_worker)
+EMAIL_LIFECYCLE_ENABLED=false
+# Redirect all lifecycle emails in dev (optional)
+# EMAIL_DEV_REDIRECT=you@test.com
+# Compress 72h/7d delays to ~5min for staging QA (never enable in production)
+# EMAIL_STAGING_COMPRESS_DELAYS=true
+# Restrict lifecycle sends to specific addresses during prod rollout
+# EMAIL_LIFECYCLE_ALLOWLIST=founder@zizka.ai
+
+# Show newsletter popup on landing (enable with EMAIL_LIFECYCLE_ENABLED)
+NEXT_PUBLIC_NEWSLETTER_ENABLED=false
+
 # Dashboard URL (production: https://db.zizka.ai)
 DASHBOARD_URL=http://localhost:3001
 # Set on managed cloud EC2:

--- a/core/api/admin.py
+++ b/core/api/admin.py
@@ -501,6 +501,8 @@ async def admin_demo_requests(
                 OR company_name ILIKE ${n}
                 OR website ILIKE ${n}
                 OR email ILIKE ${n}
+                OR COALESCE(position, '') ILIKE ${n}
+                OR COALESCE(source, '') ILIKE ${n}
             )
         """
 
@@ -509,7 +511,7 @@ async def admin_demo_requests(
 
     rows = await pool.fetch(
         f"""
-        SELECT request_id, first_name, last_name, email, company_name, website, ip_address, created_at
+        SELECT request_id, first_name, last_name, email, company_name, website, position, source, ip_address, created_at
         FROM demo_requests
         {where}
         ORDER BY created_at DESC
@@ -526,8 +528,31 @@ async def admin_demo_requests(
             "email":        r["email"],
             "company_name": r["company_name"],
             "website":      r["website"],
+            "position":     r["position"],
+            "source":       r["source"],
             "ip_address":   r["ip_address"],
             "created_at":   r["created_at"].isoformat() if r["created_at"] else None,
         }
         for r in rows
     ]
+
+
+@router.get("/email/stats")
+async def admin_email_stats(_: dict = Depends(require_admin)):
+    """Outbox and send log counts for email automation monitoring."""
+    from services.email.outbox import outbox_stats
+
+    pool = get_pool()
+    outbox = await outbox_stats()
+    sent_24h = await pool.fetchval(
+        """
+        SELECT COUNT(*)::int FROM email_send_log
+        WHERE sent_at > NOW() - INTERVAL '24 hours'
+        """
+    )
+    return {
+        "outbox": outbox,
+        "sent_24h": sent_24h or 0,
+        "failed": outbox.get("failed", 0),
+        "pending": outbox.get("pending", 0),
+    }

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -55,6 +55,7 @@ class VerifyOTPBody(BaseModel):
     intent: Literal["signup", "login"] = "login"
     gdpr_consent: bool | None = None
     marketing_consent: bool | None = None
+    promo_code: str | None = None
 
 
 class CreateAPIKeyBody(BaseModel):
@@ -99,6 +100,7 @@ async def verify_otp_route(body: VerifyOTPBody, response: Response):
             intent=body.intent,
             gdpr_consent=body.gdpr_consent,
             marketing_consent=body.marketing_consent,
+            promo_code=body.promo_code,
         )
     except ValueError as e:
         raise HTTPException(status_code=401, detail=str(e))
@@ -117,6 +119,18 @@ async def verify_otp_route(body: VerifyOTPBody, response: Response):
         billing = billing_status_payload(billing_row)
     except Exception as e:
         log.warning("billing status lookup failed after verify for %s: %s", email, e)
+
+    if tokens.get("is_new_signup"):
+        from services.email.triggers import schedule_signup_lifecycle
+
+        try:
+            schedule_signup_lifecycle(
+                user_id=tokens["user_id"],
+                email=email,
+                tenant_id=tokens["tenant_id"],
+            )
+        except Exception as e:
+            log.warning("signup lifecycle schedule failed for %s: %s", email, e)
 
     response.set_cookie(
         key="refresh_token",

--- a/core/api/demo_requests.py
+++ b/core/api/demo_requests.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 _rate: dict[str, list[float]] = {}
 RATE_WINDOW_SEC = 3600
 RATE_MAX = 8
+VALID_SOURCES = frozenset({"enterprise", "landing", "newsletter"})
 
 
 class CreateDemoRequestBody(BaseModel):
@@ -26,6 +27,8 @@ class CreateDemoRequestBody(BaseModel):
     email: EmailStr
     company_name: str = Field(min_length=1, max_length=255)
     website: str = Field(min_length=1, max_length=500)
+    position: str | None = Field(default=None, max_length=120)
+    source: str | None = Field(default=None, max_length=64)
     botcheck: str | None = None  # honeypot — must be empty
 
 
@@ -53,11 +56,15 @@ async def create_demo_request(body: CreateDemoRequestBody, request: Request):
     ip = _client_ip(request)
     _check_rate(ip)
 
+    source = body.source.strip() if body.source else None
+    if source and source not in VALID_SOURCES:
+        raise HTTPException(status_code=422, detail="Invalid source")
+
     pool = get_pool()
     row = await pool.fetchrow(
         """
-        INSERT INTO demo_requests (first_name, last_name, email, company_name, website, ip_address)
-        VALUES ($1, $2, $3, $4, $5, $6)
+        INSERT INTO demo_requests (first_name, last_name, email, company_name, website, position, source, ip_address)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         RETURNING request_id, created_at
         """,
         body.first_name.strip(),
@@ -65,6 +72,8 @@ async def create_demo_request(body: CreateDemoRequestBody, request: Request):
         str(body.email).strip().lower(),
         body.company_name.strip(),
         body.website.strip(),
+        body.position.strip() if body.position else None,
+        source,
         ip,
     )
     log.info("demo request from %s (%s %s)", ip, body.first_name, body.company_name)

--- a/core/api/newsletter.py
+++ b/core/api/newsletter.py
@@ -1,0 +1,134 @@
+"""Newsletter subscription API."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import secrets
+import time
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, EmailStr, Field
+
+from db.connection import get_pool
+from services.email.config import dashboard_url, lifecycle_enabled
+from services.email.triggers import on_newsletter_subscribed
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+_rate: dict[str, list[float]] = {}
+RATE_WINDOW_SEC = 3600
+RATE_MAX = 10
+
+
+class SubscribeBody(BaseModel):
+    email: EmailStr
+    botcheck: str | None = None
+    source: str = Field(default="popup", max_length=32)
+
+
+def _client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _check_rate(ip: str) -> None:
+    now = time.time()
+    hits = [t for t in _rate.get(ip, []) if now - t < RATE_WINDOW_SEC]
+    if len(hits) >= RATE_MAX:
+        raise HTTPException(status_code=429, detail="Too many requests. Try again later.")
+    hits.append(now)
+    _rate[ip] = hits
+
+
+def _hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+@router.post("/subscribe", status_code=201)
+async def subscribe(body: SubscribeBody, request: Request):
+    if not lifecycle_enabled():
+        raise HTTPException(status_code=503, detail="Newsletter is not available at this time.")
+
+    if body.botcheck:
+        raise HTTPException(status_code=400, detail="Invalid submission")
+
+    ip = _client_ip(request)
+    _check_rate(ip)
+
+    email = str(body.email).lower().strip()
+    pool = get_pool()
+
+    existing = await pool.fetchrow(
+        """
+        SELECT subscriber_id, unsubscribed_at
+        FROM newsletter_subscribers WHERE email = $1
+        """,
+        email,
+    )
+    if existing and existing["unsubscribed_at"] is None:
+        return {"message": "You are already subscribed.", "already_subscribed": True}
+
+    token = secrets.token_urlsafe(32)
+    token_hash = _hash_token(token)
+
+    if existing:
+        await pool.execute(
+            """
+            UPDATE newsletter_subscribers
+            SET subscribed_at = NOW(), unsubscribed_at = NULL,
+                source = $2, unsubscribe_token_hash = $3
+            WHERE email = $1
+            """,
+            email,
+            body.source,
+            token_hash,
+        )
+    else:
+        await pool.execute(
+            """
+            INSERT INTO newsletter_subscribers (email, source, unsubscribe_token_hash)
+            VALUES ($1, $2, $3)
+            """,
+            email,
+            body.source,
+            token_hash,
+        )
+
+    if lifecycle_enabled():
+        try:
+            await on_newsletter_subscribed(email=email)
+        except Exception as e:
+            log.warning("newsletter welcome enqueue failed: %s", e)
+
+    return {"message": "Thanks for subscribing!", "already_subscribed": False}
+
+
+@router.get("/unsubscribe")
+async def unsubscribe(token: str):
+    if not token or len(token) < 16:
+        raise HTTPException(status_code=400, detail="Invalid token")
+
+    token_hash = _hash_token(token)
+    pool = get_pool()
+    row = await pool.fetchrow(
+        """
+        UPDATE newsletter_subscribers
+        SET unsubscribed_at = NOW()
+        WHERE unsubscribe_token_hash = $1 AND unsubscribed_at IS NULL
+        RETURNING email
+        """,
+        token_hash,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Subscription not found or already unsubscribed")
+
+    home = dashboard_url()
+    return {
+        "message": "You have been unsubscribed.",
+        "email": row["email"],
+        "home_url": home,
+    }

--- a/core/db/connection.py
+++ b/core/db/connection.py
@@ -1,5 +1,6 @@
 import asyncpg
 import redis.asyncio as redis
+from pathlib import Path
 from qdrant_client import AsyncQdrantClient
 from qdrant_client.models import Distance, VectorParams
 import os
@@ -151,6 +152,14 @@ async def init_db():
     await _pg_pool.execute("""
         ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS email VARCHAR(255) NOT NULL DEFAULT '';
     """)
+
+    migration_path = Path(__file__).resolve().parent / "migrations" / "007_email_automation.sql"
+    if migration_path.exists():
+        await _pg_pool.execute(migration_path.read_text())
+
+    enterprise_demo_path = Path(__file__).resolve().parent / "migrations" / "008_demo_requests_enterprise.sql"
+    if enterprise_demo_path.exists():
+        await _pg_pool.execute(enterprise_demo_path.read_text())
 
     _redis = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379"))
     logger.info("Redis connected")

--- a/core/db/migrations/007_email_automation.sql
+++ b/core/db/migrations/007_email_automation.sql
@@ -1,0 +1,68 @@
+-- Email automation: outbox, send log, churn offers, newsletter subscribers
+
+CREATE TABLE IF NOT EXISTS email_outbox (
+    outbox_id       UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    campaign_id     VARCHAR(64) NOT NULL,
+    recipient_key   VARCHAR(255) NOT NULL,
+    dedupe_key      VARCHAR(255) NOT NULL DEFAULT 'default',
+    to_email        VARCHAR(255) NOT NULL,
+    payload         JSONB NOT NULL DEFAULT '{}'::jsonb,
+    scheduled_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    status          VARCHAR(32) NOT NULL DEFAULT 'pending',
+    attempts        INTEGER NOT NULL DEFAULT 0,
+    last_error      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    sent_at         TIMESTAMPTZ,
+    UNIQUE (campaign_id, recipient_key, dedupe_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_outbox_pending
+    ON email_outbox (scheduled_at ASC)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_email_outbox_user_pending
+    ON email_outbox (recipient_key)
+    WHERE status = 'pending';
+
+CREATE TABLE IF NOT EXISTS email_send_log (
+    log_id              UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    campaign_id         VARCHAR(64) NOT NULL,
+    to_email            VARCHAR(255) NOT NULL,
+    user_id             UUID,
+    tenant_id           UUID,
+    provider_message_id VARCHAR(255),
+    metadata            JSONB NOT NULL DEFAULT '{}'::jsonb,
+    sent_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_send_log_campaign
+    ON email_send_log (campaign_id, sent_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_email_send_log_user
+    ON email_send_log (user_id, campaign_id, sent_at DESC)
+    WHERE user_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS churn_offers (
+    offer_id        UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email           VARCHAR(255) NOT NULL,
+    promo_code      VARCHAR(64) NOT NULL UNIQUE,
+    expires_at      TIMESTAMPTZ NOT NULL,
+    redeemed_at     TIMESTAMPTZ,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_churn_offers_email
+    ON churn_offers (email, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS newsletter_subscribers (
+    subscriber_id       UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email               VARCHAR(255) NOT NULL UNIQUE,
+    subscribed_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    unsubscribed_at     TIMESTAMPTZ,
+    source              VARCHAR(32) NOT NULL DEFAULT 'popup',
+    unsubscribe_token_hash VARCHAR(64) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_newsletter_active
+    ON newsletter_subscribers (email)
+    WHERE unsubscribed_at IS NULL;

--- a/core/db/migrations/008_demo_requests_enterprise.sql
+++ b/core/db/migrations/008_demo_requests_enterprise.sql
@@ -1,0 +1,3 @@
+-- Enterprise lead capture: role/title and form source (e.g. enterprise page)
+ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS position VARCHAR(120);
+ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS source VARCHAR(64);

--- a/core/db/schema.sql
+++ b/core/db/schema.sql
@@ -148,6 +148,8 @@ CREATE TABLE demo_requests (
     email         VARCHAR(255) NOT NULL,
     company_name  VARCHAR(255) NOT NULL,
     website       VARCHAR(500) NOT NULL,
+    position      VARCHAR(120),
+    source        VARCHAR(64),
     ip_address    VARCHAR(64),
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/core/main.py
+++ b/core/main.py
@@ -20,6 +20,7 @@ from api.community import router as community_router
 from api.demo_requests import router as demo_requests_router
 from api.settings import router as settings_router
 from api.account import router as account_router
+from api.newsletter import router as newsletter_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -75,6 +76,7 @@ app.include_router(community_router, prefix="/v1/community", tags=["community"])
 app.include_router(demo_requests_router, prefix="/v1/demo-requests", tags=["demo"])
 app.include_router(settings_router,  prefix="/v1/settings",  tags=["settings"])
 app.include_router(account_router,   prefix="/v1/account",   tags=["account"])
+app.include_router(newsletter_router, prefix="/v1/newsletter", tags=["newsletter"])
 
 
 @app.get("/health")

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -10,3 +10,5 @@ PyJWT>=2.8.0
 bcrypt>=4.1.3
 python-dotenv>=1.0.1
 cryptography>=42.0.0
+jinja2>=3.1.0
+arq>=0.26.0

--- a/core/services/account.py
+++ b/core/services/account.py
@@ -1,9 +1,10 @@
-"""Managed-cloud account lifecycle — delete account or one-time trial extension."""
+"""Account deletion with churn recovery email."""
 
 from __future__ import annotations
 
 import logging
 import os
+import uuid
 from datetime import datetime, timedelta, timezone
 
 from db.connection import get_pool, get_qdrant, QDRANT_COLLECTION
@@ -110,6 +111,25 @@ async def delete_managed_account(*, user_id: str, tenant_id: str) -> None:
 
     email = row["email"]
     tid = str(row["tenant_id"])
+
+    from services.email.config import lifecycle_enabled
+    from services.email.outbox import cancel_pending_for_tenant, cancel_pending_for_user
+
+    await cancel_pending_for_user(user_id)
+    await cancel_pending_for_tenant(tid)
+
+    if lifecycle_enabled():
+        from services.email.churn import create_churn_offer
+        from services.email.triggers import on_account_deleted_enqueue
+
+        delete_id = str(uuid.uuid4())
+        offer = await create_churn_offer(email)
+        await on_account_deleted_enqueue(
+            email=email,
+            promo_code=offer["promo_code"],
+            promo_expires_at=offer["expires_at"],
+            delete_id=delete_id,
+        )
 
     await _purge_tenant_vectors(tid)
 

--- a/core/services/api_keys.py
+++ b/core/services/api_keys.py
@@ -6,6 +6,7 @@ import logging
 
 from fastapi import HTTPException
 
+from db.connection import get_pool
 from services.auth import generate_api_key
 from services.billing import fetch_tenant_plan
 from services.plan_limits import api_key_limit_for_plan, limits_enforced
@@ -110,7 +111,7 @@ async def create_api_key_record(
         name,
         agent_id,
     )
-    return {
+    result = {
         "key_id": str(row["key_id"]),
         "key": raw_key,
         "prefix": prefix,
@@ -118,6 +119,31 @@ async def create_api_key_record(
         "agent_id": agent_id,
         "warning": "Save this key — it will not be shown again.",
     }
+    await _schedule_key_lifecycle_email(tenant_id)
+    return result
+
+
+async def _schedule_key_lifecycle_email(tenant_id: str) -> None:
+    try:
+        pool = get_pool()
+        owner = await pool.fetchrow(
+            """
+            SELECT user_id::text, email FROM users
+            WHERE tenant_id = $1::uuid
+            ORDER BY created_at ASC LIMIT 1
+            """,
+            tenant_id,
+        )
+        if owner:
+            from services.email.triggers import schedule_api_key_lifecycle
+
+            schedule_api_key_lifecycle(
+                tenant_id=tenant_id,
+                user_id=owner["user_id"],
+                email=owner["email"],
+            )
+    except Exception as e:
+        log.warning("api key lifecycle schedule skipped for tenant %s: %s", tenant_id, e)
 
 
 async def list_api_keys_for_agent(pool, tenant_id: str, agent_id: str) -> list[dict]:

--- a/core/services/auth.py
+++ b/core/services/auth.py
@@ -6,12 +6,10 @@ import logging
 import jwt
 import bcrypt
 import random
-import smtplib
 from typing import Literal
-from email.mime.text import MIMEText
-from email.mime.multipart import MIMEMultipart
 from datetime import datetime, timedelta, timezone
 from db.connection import get_pool
+from services.billing import TRIAL_DAYS
 
 log = logging.getLogger(__name__)
 
@@ -42,6 +40,24 @@ JWT_SECRET = _required_secret("JWT_SECRET", "dev-secret")
 JWT_REFRESH_SECRET = _required_secret("JWT_REFRESH_SECRET", "dev-refresh-secret")
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24 * 7  # 7 days
 REFRESH_TOKEN_EXPIRE_DAYS = 30
+
+_PROMO_RATE_WINDOW_SEC = 15 * 60
+_PROMO_RATE_MAX = 10
+_promo_rate: dict[str, list[float]] = {}
+
+
+def _check_promo_rate_limit(email: str) -> None:
+    """Limit promo redeem attempts per email (anti brute-force)."""
+    key = email.lower().strip()
+    now = datetime.now(timezone.utc).timestamp()
+    window_start = now - _PROMO_RATE_WINDOW_SEC
+    hits = [t for t in _promo_rate.get(key, []) if t > window_start]
+    if len(hits) >= _PROMO_RATE_MAX:
+        raise ValueError(
+            "Too many promo attempts. Wait 15 minutes and try again."
+        )
+    hits.append(now)
+    _promo_rate[key] = hits
 
 
 # ─────────────────────────────────────────
@@ -123,7 +139,12 @@ async def request_otp(email: str) -> None:
         email, otp_hash, expires_at,
     )
 
-    await _send_otp_email(email, otp)
+    from services.email.service import get_email_service
+
+    try:
+        await get_email_service().send_otp(email, otp)
+    except Exception as e:
+        log.warning("OTP email send failed for %s (code saved in DB): %s", email, e)
 
 
 async def _save_signup_consent(
@@ -139,7 +160,8 @@ async def _save_signup_consent(
             """
             UPDATE users SET
                 gdpr_consent_at = $2,
-                marketing_consent = $3
+                marketing_consent = $3,
+                marketing_consent_at = CASE WHEN $3 THEN $2 ELSE marketing_consent_at END
             WHERE user_id = $1::uuid
             """,
             user_id,
@@ -162,7 +184,8 @@ async def _save_signup_consent(
         """
         UPDATE users SET
             gdpr_consent_at = $2,
-            marketing_consent = $3
+            marketing_consent = $3,
+            marketing_consent_at = CASE WHEN $3 THEN $2 ELSE marketing_consent_at END
         WHERE user_id = $1::uuid
         """,
         user_id,
@@ -189,6 +212,7 @@ async def verify_otp(
     intent: AuthIntent = "login",
     gdpr_consent: bool | None = None,
     marketing_consent: bool | None = None,
+    promo_code: str | None = None,
 ) -> dict:
     email = email.lower().strip()
     pool = get_pool()
@@ -269,12 +293,12 @@ async def verify_otp(
                         "consent persistence skipped for user %s: %s", user_id, e
                     )
                 await conn.execute(
-                    """
+                    f"""
                     UPDATE users
                     SET plan = COALESCE(plan, 'pro'),
                         subscription_status = COALESCE(subscription_status, 'trialing'),
                         trial_ends_at = COALESCE(
-                            trial_ends_at, NOW() + INTERVAL '30 days'
+                            trial_ends_at, NOW() + INTERVAL '{TRIAL_DAYS} days'
                         )
                     WHERE user_id = $1::uuid
                     """,
@@ -306,7 +330,36 @@ async def verify_otp(
             if not burned:
                 raise ValueError("OTP already used")
 
-    return _issue_tokens(user_id, email, tenant_id)
+    if intent == "signup":
+        try:
+            from services.email.newsletter_sync import sync_newsletter_on_signup
+
+            await sync_newsletter_on_signup(
+                email=email,
+                marketing_consent=bool(marketing_consent),
+            )
+        except Exception as e:
+            log.warning("newsletter sync skipped for %s: %s", user_id, e)
+
+        if promo_code:
+            _check_promo_rate_limit(email)
+            from services.email.churn import redeem_churn_promo
+
+            try:
+                await redeem_churn_promo(
+                    email=email,
+                    promo_code=promo_code,
+                    user_id=user_id,
+                )
+            except Exception as e:
+                log.warning("promo redeem skipped for %s: %s", user_id, e)
+
+    return {
+        **_issue_tokens(user_id, email, tenant_id),
+        "user_id": user_id,
+        "tenant_id": tenant_id,
+        "is_new_signup": intent == "signup",
+    }
 
 
 def _issue_tokens(user_id: str, email: str, tenant_id: str) -> dict:
@@ -343,70 +396,3 @@ def _issue_tokens(user_id: str, email: str, tenant_id: str) -> dict:
 
 def decode_access_token(token: str) -> dict:
     return jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
-
-
-# ─────────────────────────────────────────
-# EMAIL
-# ─────────────────────────────────────────
-
-SMTP_TIMEOUT_SEC = int(os.getenv("EMAIL_SMTP_TIMEOUT", "15"))
-
-
-def _send_otp_email_sync(email: str, otp: str) -> None:
-    """Blocking SMTP — always call via asyncio.to_thread so the API stays responsive."""
-    host = os.getenv("EMAIL_HOST")
-    user = os.getenv("EMAIL_USER")
-    password = os.getenv("EMAIL_PASS")
-
-    if not host or not user or not password:
-        print(f"\n{'='*50}")
-        print(f"OTP FOR {email}: {otp}")
-        print(f"(Set EMAIL_HOST / EMAIL_USER / EMAIL_PASS to send real emails)")
-        print(f"{'='*50}\n", flush=True)
-        return
-
-    port = int(os.getenv("EMAIL_PORT", 587))
-    from_addr = os.getenv("EMAIL_FROM", f'"ZizkaDB" <{user}>')
-    is_ssl = port == 465
-
-    msg = MIMEMultipart("alternative")
-    msg["Subject"] = f"{otp} is your ZizkaDB login code"
-    msg["From"] = from_addr
-    msg["To"] = email
-
-    text = f"Your ZizkaDB login code: {otp}\n\nExpires in 15 minutes."
-    html = f"""
-    <div style="font-family:Arial,sans-serif;max-width:420px;margin:40px auto;padding:24px;background:#fff;border-radius:12px;">
-      <p style="font-size:14px;color:#555;margin:0 0 20px">Your ZizkaDB login code:</p>
-      <div style="font-size:38px;font-weight:700;letter-spacing:10px;
-                  background:#f5f5f5;padding:24px;text-align:center;
-                  border-radius:8px;color:#111;font-family:monospace">
-        {otp}
-      </div>
-      <p style="color:#aaa;font-size:12px;margin-top:20px;line-height:1.6">
-        Expires in 15 minutes.<br>
-        If you did not request this, ignore this email.
-      </p>
-    </div>
-    """
-
-    msg.attach(MIMEText(text, "plain"))
-    msg.attach(MIMEText(html, "html"))
-
-    if is_ssl:
-        import ssl
-        context = ssl.create_default_context()
-        with smtplib.SMTP_SSL(
-            host, port, context=context, timeout=SMTP_TIMEOUT_SEC,
-        ) as server:
-            server.login(user, password)
-            server.sendmail(from_addr, email, msg.as_string())
-    else:
-        with smtplib.SMTP(host, port, timeout=SMTP_TIMEOUT_SEC) as server:
-            server.starttls()
-            server.login(user, password)
-            server.sendmail(from_addr, email, msg.as_string())
-
-
-async def _send_otp_email(email: str, otp: str) -> None:
-    await asyncio.to_thread(_send_otp_email_sync, email, otp)

--- a/core/services/billing.py
+++ b/core/services/billing.py
@@ -18,7 +18,7 @@ PLAN_CATALOG: list[dict[str, Any]] = [
         "price": "€39",
         "price_sub": "/ month",
         "highlight": True,
-        "features": ["100M events", "90-day retention", "3 projects", "Email support"],
+        "features": ["100M events", "90-day retention", "3 active API keys", "Email support"],
     },
     {
         "id": "team",
@@ -26,7 +26,7 @@ PLAN_CATALOG: list[dict[str, Any]] = [
         "price": "€99",
         "price_sub": "/ month",
         "highlight": False,
-        "features": ["Up to 1B events/mo", "1-year retention", "10 seats", "Priority support"],
+        "features": ["Up to 1B events/mo", "1-year retention", "10 active API keys", "Priority support"],
     },
 ]
 

--- a/core/services/email/__init__.py
+++ b/core/services/email/__init__.py
@@ -1,0 +1,5 @@
+"""User lifecycle email automation."""
+
+from services.email.service import EmailService, get_email_service
+
+__all__ = ["EmailService", "get_email_service"]

--- a/core/services/email/churn.py
+++ b/core/services/email/churn.py
@@ -1,0 +1,86 @@
+"""Churn recovery promo codes."""
+
+from __future__ import annotations
+
+import logging
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from db.connection import get_pool
+
+log = logging.getLogger(__name__)
+
+PROMO_PREFIX = "COMEBACK"
+PROMO_VALID_DAYS = 90
+REDEEM_TRIAL_DAYS = 30
+
+
+def generate_promo_code() -> str:
+    return f"{PROMO_PREFIX}-{secrets.token_urlsafe(8).upper().replace('_', '').replace('-', '')[:10]}"
+
+
+async def create_churn_offer(email: str) -> dict:
+    pool = get_pool()
+    code = generate_promo_code()
+    expires = datetime.now(timezone.utc) + timedelta(days=PROMO_VALID_DAYS)
+    row = await pool.fetchrow(
+        """
+        INSERT INTO churn_offers (email, promo_code, expires_at)
+        VALUES ($1, $2, $3)
+        RETURNING offer_id::text, promo_code, expires_at
+        """,
+        email.lower().strip(),
+        code,
+        expires,
+    )
+    return {
+        "offer_id": row["offer_id"],
+        "promo_code": row["promo_code"],
+        "expires_at": row["expires_at"].isoformat(),
+    }
+
+
+async def redeem_churn_promo(*, email: str, promo_code: str, user_id: str) -> bool:
+    pool = get_pool()
+    email = email.lower().strip()
+    code = promo_code.strip().upper()
+    row = await pool.fetchrow(
+        """
+        SELECT offer_id, expires_at, redeemed_at
+        FROM churn_offers
+        WHERE promo_code = $1 AND email = $2
+        """,
+        code,
+        email,
+    )
+    if not row:
+        return False
+    if row["redeemed_at"]:
+        return False
+    if row["expires_at"] < datetime.now(timezone.utc):
+        return False
+
+    new_trial_end = datetime.now(timezone.utc) + timedelta(days=REDEEM_TRIAL_DAYS)
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            updated = await conn.fetchval(
+                """
+                UPDATE churn_offers SET redeemed_at = NOW()
+                WHERE offer_id = $1 AND redeemed_at IS NULL
+                RETURNING offer_id
+                """,
+                row["offer_id"],
+            )
+            if not updated:
+                return False
+            await conn.execute(
+                f"""
+                UPDATE users
+                SET trial_ends_at = NOW() + INTERVAL '{REDEEM_TRIAL_DAYS} days',
+                    subscription_status = 'trialing'
+                WHERE user_id = $1::uuid
+                """,
+                user_id,
+            )
+    log.info("churn promo redeemed user_id=%s", user_id)
+    return True

--- a/core/services/email/config.py
+++ b/core/services/email/config.py
@@ -1,0 +1,178 @@
+"""Campaign registry and environment helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+CampaignCategory = Literal["transactional", "lifecycle", "marketing"]
+
+# Test / dashboard connection events — excluded from activity metrics.
+TEST_AGENT_ID = "dashboard-connection-test"
+
+CALENDLY_URL = "https://calendly.com/founder-zizka/15-minutes"
+FOUNDER_EMAIL = "founder@zizka.ai"
+
+
+@dataclass(frozen=True)
+class CampaignConfig:
+    id: str
+    subject: str
+    template: str
+    category: CampaignCategory
+    enabled: bool = True
+    delay_seconds: int = 0
+    reply_to: str | None = None
+
+
+CAMPAIGNS: dict[str, CampaignConfig] = {
+    "otp": CampaignConfig(
+        id="otp",
+        subject="{otp} is your ZizkaDB login code",
+        template="otp",
+        category="transactional",
+        enabled=True,
+    ),
+    "welcome": CampaignConfig(
+        id="welcome",
+        subject="Welcome to ZizkaDB",
+        template="welcome",
+        category="lifecycle",
+        enabled=True,
+        delay_seconds=300,
+    ),
+    "getting_started": CampaignConfig(
+        id="getting_started",
+        subject="Your ZizkaDB getting started guide",
+        template="getting_started",
+        category="lifecycle",
+        enabled=True,
+        delay_seconds=600,
+    ),
+    "no_api_72h": CampaignConfig(
+        id="no_api_72h",
+        subject="Create your first ZizkaDB API key",
+        template="no_api_72h",
+        category="lifecycle",
+        enabled=True,
+        delay_seconds=72 * 3600,
+    ),
+    "api_no_events": CampaignConfig(
+        id="api_no_events",
+        subject="Send your first agent event to ZizkaDB",
+        template="api_no_events",
+        category="lifecycle",
+        enabled=True,
+        delay_seconds=7 * 86400,
+    ),
+    "inactive_7d": CampaignConfig(
+        id="inactive_7d",
+        subject="Need help getting back on track with ZizkaDB?",
+        template="inactive_7d",
+        category="lifecycle",
+        enabled=True,
+        reply_to=FOUNDER_EMAIL,
+    ),
+    "active_checkin": CampaignConfig(
+        id="active_checkin",
+        subject="How is your ZizkaDB experience?",
+        template="active_checkin",
+        category="lifecycle",
+        enabled=True,
+        reply_to=FOUNDER_EMAIL,
+    ),
+    "account_deleted": CampaignConfig(
+        id="account_deleted",
+        subject="We're sorry to see you go — come back anytime",
+        template="account_deleted",
+        category="transactional",
+        enabled=True,
+    ),
+    "newsletter_welcome": CampaignConfig(
+        id="newsletter_welcome",
+        subject="You're subscribed to ZizkaDB updates",
+        template="newsletter_welcome",
+        category="marketing",
+        enabled=True,
+    ),
+}
+
+
+def _truthy(name: str, default: str = "false") -> bool:
+    return os.getenv(name, default).strip().lower() in ("1", "true", "yes", "on")
+
+
+def lifecycle_enabled() -> bool:
+    return _truthy("EMAIL_LIFECYCLE_ENABLED", "false")
+
+
+def compress_delays() -> bool:
+    """Staging/dev: map long delays to ~5 minutes. Never enable in production."""
+    if os.getenv("ENV", "development") == "production":
+        return False
+    return _truthy("EMAIL_STAGING_COMPRESS_DELAYS", "false")
+
+
+def effective_delay_seconds(seconds: int) -> int:
+    if not compress_delays():
+        return seconds
+    if seconds <= 600:
+        return seconds
+    return 300
+
+
+def dev_redirect_email() -> str | None:
+    addr = os.getenv("EMAIL_DEV_REDIRECT", "").strip()
+    return addr or None
+
+
+def allowlist() -> set[str] | None:
+    raw = os.getenv("EMAIL_LIFECYCLE_ALLOWLIST", "").strip()
+    if not raw:
+        return None
+    return {e.strip().lower() for e in raw.split(",") if e.strip()}
+
+
+def is_recipient_allowed(email: str, *, category: CampaignCategory) -> bool:
+    if category == "transactional":
+        return True
+    if not lifecycle_enabled():
+        return False
+    if not smtp_configured_for_lifecycle():
+        return False
+    allowed = allowlist()
+    if allowed is not None:
+        return email.lower().strip() in allowed
+    return True
+
+
+def smtp_configured_for_lifecycle() -> bool:
+    from services.email.providers.smtp import smtp_configured
+
+    return smtp_configured()
+
+
+def get_campaign(campaign_id: str) -> CampaignConfig | None:
+    cfg = CAMPAIGNS.get(campaign_id)
+    if not cfg or not cfg.enabled:
+        return None
+    return cfg
+
+
+def dashboard_url() -> str:
+    return os.getenv("DASHBOARD_URL", "https://db.zizka.ai").rstrip("/")
+
+
+def docs_url() -> str:
+    return f"{dashboard_url()}/docs"
+
+
+def active_checkin_dedupe_key(when: datetime | None = None) -> str:
+    """Rolling 15-day window key so C6 can repeat every ~15 days."""
+    from datetime import timezone
+
+    ts = (when or datetime.now(timezone.utc)).timestamp()
+    window = int(ts // (15 * 86400))
+    return f"window-{window}"

--- a/core/services/email/eligibility.py
+++ b/core/services/email/eligibility.py
@@ -1,0 +1,149 @@
+"""Campaign eligibility checks before send."""
+
+from __future__ import annotations
+
+from db.connection import get_pool
+from services.email.config import TEST_AGENT_ID
+
+_REAL_EVENT_FILTER = """
+    AND NOT (agent_id = $2 AND event_type = 'connection_test')
+"""
+
+
+async def user_exists(user_id: str) -> bool:
+    pool = get_pool()
+    row = await pool.fetchval(
+        "SELECT 1 FROM users WHERE user_id = $1::uuid",
+        user_id,
+    )
+    return row is not None
+
+
+async def count_active_keys(tenant_id: str) -> int:
+    pool = get_pool()
+    return int(
+        await pool.fetchval(
+            """
+            SELECT COUNT(*) FROM api_keys
+            WHERE tenant_id = $1::uuid AND revoked = FALSE
+            """,
+            tenant_id,
+        )
+        or 0
+    )
+
+
+async def has_real_events(tenant_id: str) -> bool:
+    pool = get_pool()
+    row = await pool.fetchval(
+        f"""
+        SELECT 1 FROM events
+        WHERE tenant_id = $1::uuid
+        {_REAL_EVENT_FILTER}
+        LIMIT 1
+        """,
+        tenant_id,
+        TEST_AGENT_ID,
+    )
+    return row is not None
+
+
+async def events_in_last_days(tenant_id: str, days: int) -> bool:
+    pool = get_pool()
+    row = await pool.fetchval(
+        f"""
+        SELECT 1 FROM events
+        WHERE tenant_id = $1::uuid
+          AND timestamp > NOW() - ($3 || ' days')::interval
+        {_REAL_EVENT_FILTER}
+        LIMIT 1
+        """,
+        tenant_id,
+        TEST_AGENT_ID,
+        str(days),
+    )
+    return row is not None
+
+
+async def eligible_no_api_72h(*, user_id: str, tenant_id: str) -> bool:
+    if not await user_exists(user_id):
+        return False
+    return await count_active_keys(tenant_id) == 0
+
+
+async def eligible_api_no_events(*, tenant_id: str) -> bool:
+    if await count_active_keys(tenant_id) == 0:
+        return False
+    return not await has_real_events(tenant_id)
+
+
+async def eligible_inactive_7d(*, tenant_id: str) -> bool:
+    if await count_active_keys(tenant_id) == 0:
+        return False
+    if not await has_real_events(tenant_id):
+        return False
+    return not await events_in_last_days(tenant_id, 7)
+
+
+async def eligible_active_checkin(*, user_id: str, tenant_id: str) -> bool:
+    if not await user_exists(user_id):
+        return False
+    if not await events_in_last_days(tenant_id, 7):
+        return False
+    pool = get_pool()
+    row = await pool.fetchval(
+        """
+        SELECT 1 FROM email_send_log
+        WHERE user_id = $1::uuid
+          AND campaign_id = 'active_checkin'
+          AND sent_at > NOW() - INTERVAL '15 days'
+        LIMIT 1
+        """,
+        user_id,
+    )
+    return row is None
+
+
+async def eligible_welcome(*, user_id: str) -> bool:
+    return await user_exists(user_id)
+
+
+async def user_has_marketing_consent(user_id: str) -> bool:
+    pool = get_pool()
+    row = await pool.fetchval(
+        "SELECT marketing_consent FROM users WHERE user_id = $1::uuid",
+        user_id,
+    )
+    return bool(row)
+
+
+async def eligible_marketing_send(*, user_id: str | None, campaign_id: str) -> bool:
+    """Marketing-category sends require consent (newsletter welcome is explicit opt-in)."""
+    if campaign_id == "newsletter_welcome":
+        return True
+    if not user_id:
+        return False
+    return await user_has_marketing_consent(user_id)
+
+
+ELIGIBILITY_HANDLERS = {
+    "welcome": lambda p: eligible_welcome(user_id=p["user_id"]),
+    "getting_started": lambda p: eligible_welcome(user_id=p["user_id"]),
+    "no_api_72h": lambda p: eligible_no_api_72h(
+        user_id=p["user_id"], tenant_id=p["tenant_id"]
+    ),
+    "api_no_events": lambda p: eligible_api_no_events(tenant_id=p["tenant_id"]),
+    "inactive_7d": lambda p: eligible_inactive_7d(tenant_id=p["tenant_id"]),
+    "active_checkin": lambda p: eligible_active_checkin(
+        user_id=p["user_id"], tenant_id=p["tenant_id"]
+    ),
+    "account_deleted": lambda p: True,
+    "newsletter_welcome": lambda p: True,
+}
+
+
+async def check_eligibility(campaign_id: str, payload: dict) -> bool:
+    handler = ELIGIBILITY_HANDLERS.get(campaign_id)
+    if not handler:
+        return True
+    return await handler(payload)

--- a/core/services/email/newsletter_sync.py
+++ b/core/services/email/newsletter_sync.py
@@ -1,0 +1,56 @@
+"""Sync newsletter subscriber state when a user signs up."""
+
+from __future__ import annotations
+
+import logging
+
+from db.connection import get_pool
+
+log = logging.getLogger(__name__)
+
+
+async def sync_newsletter_on_signup(
+    *,
+    email: str,
+    marketing_consent: bool,
+) -> None:
+    """Link popup subscriber to signup consent.
+
+    If the user declined marketing at signup, unsubscribe any existing
+    newsletter row for this email. If they opted in, reactivate a prior row.
+    """
+    pool = get_pool()
+    email = email.lower().strip()
+    row = await pool.fetchrow(
+        """
+        SELECT subscriber_id, unsubscribed_at
+        FROM newsletter_subscribers
+        WHERE email = $1
+        """,
+        email,
+    )
+    if not row:
+        return
+
+    if marketing_consent:
+        if row["unsubscribed_at"] is not None:
+            await pool.execute(
+                """
+                UPDATE newsletter_subscribers
+                SET unsubscribed_at = NULL, subscribed_at = NOW()
+                WHERE email = $1
+                """,
+                email,
+            )
+        return
+
+    if row["unsubscribed_at"] is None:
+        await pool.execute(
+            """
+            UPDATE newsletter_subscribers
+            SET unsubscribed_at = NOW()
+            WHERE email = $1
+            """,
+            email,
+        )
+        log.info("newsletter unsubscribed on signup (marketing_consent=false): %s", email)

--- a/core/services/email/outbox.py
+++ b/core/services/email/outbox.py
@@ -1,0 +1,222 @@
+"""Transactional outbox for lifecycle emails."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import Any
+
+from db.connection import get_pool
+
+log = logging.getLogger(__name__)
+
+MAX_ATTEMPTS = 5
+STALE_PROCESSING_MINUTES = 10
+BATCH_SIZE = 50
+
+
+async def enqueue(
+    *,
+    campaign_id: str,
+    recipient_key: str,
+    to_email: str,
+    payload: dict[str, Any] | None = None,
+    dedupe_key: str = "default",
+    scheduled_at: datetime | None = None,
+) -> str | None:
+    """Insert outbox row. Returns outbox_id or None if duplicate."""
+    pool = get_pool()
+    when = scheduled_at or datetime.now(timezone.utc)
+    try:
+        row = await pool.fetchrow(
+            """
+            INSERT INTO email_outbox (
+                campaign_id, recipient_key, dedupe_key, to_email,
+                payload, scheduled_at, status
+            )
+            VALUES ($1, $2, $3, $4, $5::jsonb, $6, 'pending')
+            ON CONFLICT (campaign_id, recipient_key, dedupe_key) DO NOTHING
+            RETURNING outbox_id::text
+            """,
+            campaign_id,
+            recipient_key,
+            dedupe_key,
+            to_email.lower().strip(),
+            json.dumps(payload or {}),
+            when,
+        )
+        if row:
+            return row[0]
+        return None
+    except Exception as e:
+        log.warning("outbox enqueue failed campaign=%s key=%s: %s", campaign_id, recipient_key, e)
+        return None
+
+
+async def cancel_outbox_row(outbox_id: str, reason: str = "") -> None:
+    pool = get_pool()
+    await pool.execute(
+        """
+        UPDATE email_outbox
+        SET status = 'cancelled', last_error = $2
+        WHERE outbox_id = $1::uuid
+        """,
+        outbox_id,
+        reason[:500] if reason else None,
+    )
+
+
+async def cancel_pending_for_user(user_id: str) -> int:
+    pool = get_pool()
+    result = await pool.execute(
+        """
+        UPDATE email_outbox
+        SET status = 'cancelled'
+        WHERE recipient_key = $1
+          AND status = 'pending'
+        """,
+        user_id,
+    )
+    return int(result.split()[-1]) if result else 0
+
+
+async def cancel_pending_for_tenant(tenant_id: str) -> int:
+    pool = get_pool()
+    result = await pool.execute(
+        """
+        UPDATE email_outbox
+        SET status = 'cancelled'
+        WHERE recipient_key = $1
+          AND status = 'pending'
+        """,
+        tenant_id,
+    )
+    return int(result.split()[-1]) if result else 0
+
+
+async def reclaim_stale_processing() -> None:
+    pool = get_pool()
+    await pool.execute(
+        """
+        UPDATE email_outbox
+        SET status = 'pending'
+        WHERE status = 'processing'
+          AND created_at < NOW() - ($1 || ' minutes')::interval
+        """,
+        str(STALE_PROCESSING_MINUTES),
+    )
+
+
+async def claim_batch(limit: int = BATCH_SIZE) -> list[dict]:
+    pool = get_pool()
+    await reclaim_stale_processing()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            rows = await conn.fetch(
+                """
+                SELECT outbox_id, campaign_id, recipient_key, dedupe_key,
+                       to_email, payload, attempts
+                FROM email_outbox
+                WHERE status = 'pending'
+                  AND scheduled_at <= NOW()
+                ORDER BY scheduled_at ASC
+                LIMIT $1
+                FOR UPDATE SKIP LOCKED
+                """,
+                limit,
+            )
+            if not rows:
+                return []
+            ids = [r["outbox_id"] for r in rows]
+            await conn.execute(
+                """
+                UPDATE email_outbox
+                SET status = 'processing'
+                WHERE outbox_id = ANY($1::uuid[])
+                """,
+                ids,
+            )
+            return [dict(r) for r in rows]
+
+
+async def mark_sent(
+    outbox_id: str,
+    *,
+    user_id: str | None = None,
+    tenant_id: str | None = None,
+    provider_message_id: str | None = None,
+    campaign_id: str,
+    to_email: str,
+    metadata: dict | None = None,
+) -> None:
+    pool = get_pool()
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                """
+                UPDATE email_outbox
+                SET status = 'sent', sent_at = NOW(), last_error = NULL
+                WHERE outbox_id = $1::uuid
+                """,
+                outbox_id,
+            )
+            await conn.execute(
+                """
+                INSERT INTO email_send_log (
+                    campaign_id, to_email, user_id, tenant_id,
+                    provider_message_id, metadata
+                )
+                VALUES ($1, $2, $3::uuid, $4::uuid, $5, $6::jsonb)
+                """,
+                campaign_id,
+                to_email,
+                user_id,
+                tenant_id,
+                provider_message_id,
+                json.dumps(metadata or {}),
+            )
+
+
+async def mark_failed(outbox_id: str, error: str, attempts: int) -> None:
+    pool = get_pool()
+    if attempts >= MAX_ATTEMPTS:
+        await pool.execute(
+            """
+            UPDATE email_outbox
+            SET status = 'failed', attempts = $2, last_error = $3
+            WHERE outbox_id = $1::uuid
+            """,
+            outbox_id,
+            attempts,
+            error[:2000],
+        )
+        return
+
+    backoff_min = min(30, 2 ** attempts)
+    await pool.execute(
+        """
+        UPDATE email_outbox
+        SET status = 'pending',
+            attempts = $2,
+            last_error = $3,
+            scheduled_at = NOW() + ($4 || ' minutes')::interval
+        WHERE outbox_id = $1::uuid
+        """,
+        outbox_id,
+        attempts,
+        error[:2000],
+        str(backoff_min),
+    )
+
+
+async def outbox_stats() -> dict[str, int]:
+    pool = get_pool()
+    rows = await pool.fetch(
+        """
+        SELECT status, COUNT(*)::int AS n
+        FROM email_outbox
+        GROUP BY status
+        """
+    )
+    return {r["status"]: r["n"] for r in rows}

--- a/core/services/email/processor.py
+++ b/core/services/email/processor.py
@@ -1,0 +1,213 @@
+"""Process outbox rows and scheduled campaign scans."""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+
+from db.connection import get_pool
+from services.email.config import (
+    CALENDLY_URL,
+    FOUNDER_EMAIL,
+    active_checkin_dedupe_key,
+    dashboard_url,
+    docs_url,
+    lifecycle_enabled,
+)
+from services.email.outbox import cancel_outbox_row, claim_batch, mark_failed, mark_sent
+from services.email.eligibility import check_eligibility, eligible_marketing_send
+from services.email.service import get_email_service
+
+log = logging.getLogger(__name__)
+
+
+async def build_context(campaign_id: str, payload: dict, to_email: str) -> dict:
+    ctx = dict(payload)
+    ctx.setdefault("dashboard_url", dashboard_url())
+    ctx.setdefault("docs_url", docs_url())
+    ctx.setdefault("calendly_url", CALENDLY_URL)
+    ctx.setdefault("founder_email", FOUNDER_EMAIL)
+
+    user_id = payload.get("user_id")
+    if user_id and campaign_id in ("welcome", "getting_started", "no_api_72h"):
+        pool = get_pool()
+        row = await pool.fetchrow(
+            """
+            SELECT plan, trial_ends_at FROM users WHERE user_id = $1::uuid
+            """,
+            user_id,
+        )
+        if row:
+            plan = row["plan"] or "pro"
+            ctx["plan_name"] = plan.capitalize()
+            if row["trial_ends_at"]:
+                ctx["trial_ends_at"] = row["trial_ends_at"].strftime("%B %d, %Y")
+        else:
+            ctx["plan_name"] = "Pro"
+    if campaign_id == "no_api_72h":
+        ctx.setdefault("days_ago", "3")
+
+    return ctx
+
+
+async def process_outbox_batch() -> int:
+    if not lifecycle_enabled():
+        return 0
+
+    rows = await claim_batch()
+    if not rows:
+        return 0
+
+    svc = get_email_service()
+    processed = 0
+
+    for row in rows:
+        outbox_id = str(row["outbox_id"])
+        campaign_id = row["campaign_id"]
+        attempts = int(row["attempts"] or 0) + 1
+        payload = row["payload"]
+        if isinstance(payload, str):
+            payload = json.loads(payload)
+        to_email = row["to_email"]
+
+        try:
+            if campaign_id not in ("account_deleted", "newsletter_welcome"):
+                if not await check_eligibility(campaign_id, payload):
+                    await cancel_outbox_row(outbox_id, "eligibility not met")
+                    continue
+
+            context = await build_context(campaign_id, payload, to_email)
+            cfg_reply = None
+            from services.email.config import get_campaign
+
+            camp = get_campaign(campaign_id)
+            if camp:
+                cfg_reply = camp.reply_to
+                if camp.category == "marketing":
+                    if not await eligible_marketing_send(
+                        user_id=payload.get("user_id"),
+                        campaign_id=campaign_id,
+                    ):
+                        await cancel_outbox_row(outbox_id, "marketing consent not given")
+                        continue
+
+            result = await svc.send_template(
+                campaign_id=campaign_id,
+                to_email=to_email,
+                context=context,
+                reply_to=cfg_reply,
+            )
+            if result == "skipped":
+                await cancel_outbox_row(outbox_id, "recipient not allowed or campaign disabled")
+                continue
+
+            await mark_sent(
+                outbox_id,
+                user_id=payload.get("user_id"),
+                tenant_id=payload.get("tenant_id"),
+                campaign_id=campaign_id,
+                to_email=to_email,
+            )
+            processed += 1
+        except Exception as e:
+            log.warning(
+                "outbox send failed id=%s campaign=%s: %s",
+                outbox_id,
+                campaign_id,
+                e,
+            )
+            await mark_failed(outbox_id, str(e), attempts)
+
+    return processed
+
+
+async def scan_scheduled_campaigns() -> int:
+    """Daily-style scans for C5 inactive and C6 active check-in."""
+    if not lifecycle_enabled():
+        return 0
+
+    from services.email.outbox import enqueue
+
+    pool = get_pool()
+    enqueued = 0
+
+    inactive_rows = await pool.fetch(
+        """
+        SELECT u.user_id::text, u.email, u.tenant_id::text
+        FROM users u
+        WHERE u.tenant_id IS NOT NULL
+          AND u.subscription_status IN ('trialing', 'active', 'past_due')
+          AND EXISTS (
+              SELECT 1 FROM api_keys ak
+              WHERE ak.tenant_id = u.tenant_id AND ak.revoked = FALSE
+          )
+          AND EXISTS (
+              SELECT 1 FROM events e
+              WHERE e.tenant_id = u.tenant_id
+                AND NOT (e.agent_id = $1 AND e.event_type = 'connection_test')
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM events e
+              WHERE e.tenant_id = u.tenant_id
+                AND e.timestamp > NOW() - INTERVAL '7 days'
+                AND NOT (e.agent_id = $1 AND e.event_type = 'connection_test')
+          )
+        LIMIT 200
+        """,
+        "dashboard-connection-test",
+    )
+    week_key = datetime.now(timezone.utc).strftime("%Y-W%W")
+    for r in inactive_rows:
+        oid = await enqueue(
+            campaign_id="inactive_7d",
+            recipient_key=r["tenant_id"],
+            to_email=r["email"],
+            dedupe_key=f"week-{week_key}",
+            payload={
+                "user_id": r["user_id"],
+                "tenant_id": r["tenant_id"],
+                "email": r["email"],
+            },
+        )
+        if oid:
+            enqueued += 1
+
+    active_rows = await pool.fetch(
+        """
+        SELECT u.user_id::text, u.email, u.tenant_id::text
+        FROM users u
+        WHERE u.tenant_id IS NOT NULL
+          AND EXISTS (
+              SELECT 1 FROM events e
+              WHERE e.tenant_id = u.tenant_id
+                AND e.timestamp > NOW() - INTERVAL '7 days'
+                AND NOT (e.agent_id = $1 AND e.event_type = 'connection_test')
+          )
+          AND NOT EXISTS (
+              SELECT 1 FROM email_send_log l
+              WHERE l.user_id = u.user_id
+                AND l.campaign_id = 'active_checkin'
+                AND l.sent_at > NOW() - INTERVAL '15 days'
+          )
+        LIMIT 200
+        """,
+        "dashboard-connection-test",
+    )
+    period_key = active_checkin_dedupe_key()
+    for r in active_rows:
+        oid = await enqueue(
+            campaign_id="active_checkin",
+            recipient_key=r["user_id"],
+            to_email=r["email"],
+            dedupe_key=period_key,
+            payload={
+                "user_id": r["user_id"],
+                "tenant_id": r["tenant_id"],
+                "email": r["email"],
+            },
+        )
+        if oid:
+            enqueued += 1
+
+    return enqueued

--- a/core/services/email/providers/__init__.py
+++ b/core/services/email/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Email provider adapters."""

--- a/core/services/email/providers/base.py
+++ b/core/services/email/providers/base.py
@@ -1,0 +1,25 @@
+"""Email provider protocol."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True)
+class SendResult:
+    provider_message_id: str | None = None
+
+
+class EmailProvider(Protocol):
+    def send_sync(
+        self,
+        *,
+        to_email: str,
+        subject: str,
+        html_body: str,
+        text_body: str,
+        from_addr: str,
+        reply_to: str | None = None,
+    ) -> SendResult:
+        """Blocking send — call via asyncio.to_thread from async code."""

--- a/core/services/email/providers/mock.py
+++ b/core/services/email/providers/mock.py
@@ -1,0 +1,34 @@
+"""In-memory email provider for tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from services.email.providers.base import SendResult
+
+
+@dataclass
+class MockEmailProvider:
+    sent: list[dict] = field(default_factory=list)
+
+    def send_sync(
+        self,
+        *,
+        to_email: str,
+        subject: str,
+        html_body: str,
+        text_body: str,
+        from_addr: str,
+        reply_to: str | None = None,
+    ) -> SendResult:
+        self.sent.append(
+            {
+                "to_email": to_email,
+                "subject": subject,
+                "html_body": html_body,
+                "text_body": text_body,
+                "from_addr": from_addr,
+                "reply_to": reply_to,
+            }
+        )
+        return SendResult(provider_message_id=f"mock-{len(self.sent)}")

--- a/core/services/email/providers/smtp.py
+++ b/core/services/email/providers/smtp.py
@@ -1,0 +1,78 @@
+"""SMTP email provider (stdlib smtplib)."""
+
+from __future__ import annotations
+
+import os
+import smtplib
+import ssl
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+from services.email.providers.base import SendResult
+
+SMTP_TIMEOUT_SEC = int(os.getenv("EMAIL_SMTP_TIMEOUT", "15"))
+
+
+def smtp_configured() -> bool:
+    return bool(
+        os.getenv("EMAIL_HOST")
+        and os.getenv("EMAIL_USER")
+        and os.getenv("EMAIL_PASS")
+    )
+
+
+def default_from_addr() -> str:
+    user = os.getenv("EMAIL_USER", "")
+    return os.getenv("EMAIL_FROM", f'"ZizkaDB" <{user}>')
+
+
+class SmtpEmailProvider:
+    def send_sync(
+        self,
+        *,
+        to_email: str,
+        subject: str,
+        html_body: str,
+        text_body: str,
+        from_addr: str,
+        reply_to: str | None = None,
+    ) -> SendResult:
+        host = os.getenv("EMAIL_HOST")
+        user = os.getenv("EMAIL_USER")
+        password = os.getenv("EMAIL_PASS")
+
+        if not host or not user or not password:
+            print(f"\n{'='*50}", flush=True)
+            print(f"EMAIL TO {to_email}", flush=True)
+            print(f"SUBJECT: {subject}", flush=True)
+            print(f"(Set EMAIL_HOST / EMAIL_USER / EMAIL_PASS to send real emails)", flush=True)
+            print(f"{'='*50}\n", flush=True)
+            return SendResult(provider_message_id="stdout")
+
+        port = int(os.getenv("EMAIL_PORT", "587"))
+        is_ssl = port == 465
+
+        msg = MIMEMultipart("alternative")
+        msg["Subject"] = subject
+        msg["From"] = from_addr
+        msg["To"] = to_email
+        if reply_to:
+            msg["Reply-To"] = reply_to
+
+        msg.attach(MIMEText(text_body, "plain"))
+        msg.attach(MIMEText(html_body, "html"))
+
+        if is_ssl:
+            context = ssl.create_default_context()
+            with smtplib.SMTP_SSL(
+                host, port, context=context, timeout=SMTP_TIMEOUT_SEC,
+            ) as server:
+                server.login(user, password)
+                server.sendmail(from_addr, to_email, msg.as_string())
+        else:
+            with smtplib.SMTP(host, port, timeout=SMTP_TIMEOUT_SEC) as server:
+                server.starttls()
+                server.login(user, password)
+                server.sendmail(from_addr, to_email, msg.as_string())
+
+        return SendResult(provider_message_id=None)

--- a/core/services/email/renderer.py
+++ b/core/services/email/renderer.py
@@ -1,0 +1,38 @@
+"""Jinja2 email template rendering."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+_TEMPLATES_DIR = Path(__file__).resolve().parents[2] / "templates" / "email"
+
+_env = Environment(
+    loader=FileSystemLoader(str(_TEMPLATES_DIR)),
+    autoescape=select_autoescape(["html", "xml"]),
+)
+
+
+def render_template(template_name: str, context: dict) -> tuple[str, str]:
+    """Return (html_body, text_body). Text template is optional (.txt)."""
+    html_tpl = _env.get_template(f"{template_name}.html")
+    html_body = html_tpl.render(**context)
+    text_name = f"{template_name}.txt"
+    try:
+        text_tpl = _env.get_template(text_name)
+        text_body = text_tpl.render(**context)
+    except Exception:
+        text_body = _strip_html_fallback(html_body)
+    return html_body, text_body
+
+
+def render_subject(template: str, context: dict) -> str:
+    return template.format(**context)
+
+
+def _strip_html_fallback(html: str) -> str:
+    import re
+
+    text = re.sub(r"<[^>]+>", " ", html)
+    return re.sub(r"\s+", " ", text).strip()

--- a/core/services/email/service.py
+++ b/core/services/email/service.py
@@ -1,0 +1,76 @@
+"""Email send service — single entrypoint for all outbound mail."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Literal
+
+from services.email.config import (
+    dev_redirect_email,
+    get_campaign,
+    is_recipient_allowed,
+)
+from services.email.providers.base import EmailProvider
+from services.email.providers.smtp import SmtpEmailProvider, default_from_addr
+from services.email.renderer import render_subject, render_template
+
+log = logging.getLogger(__name__)
+
+SendResult = Literal["sent", "skipped"]
+
+_default_provider: EmailProvider | None = None
+
+
+def get_email_service(provider: EmailProvider | None = None) -> "EmailService":
+    global _default_provider
+    if provider is not None:
+        return EmailService(provider)
+    if _default_provider is None:
+        _default_provider = SmtpEmailProvider()
+    return EmailService(_default_provider)
+
+
+class EmailService:
+    def __init__(self, provider: EmailProvider) -> None:
+        self._provider = provider
+
+    async def send_template(
+        self,
+        *,
+        campaign_id: str,
+        to_email: str,
+        context: dict[str, Any],
+        reply_to: str | None = None,
+    ) -> SendResult:
+        cfg = get_campaign(campaign_id)
+        if not cfg:
+            log.debug("campaign %s disabled or missing", campaign_id)
+            return "skipped"
+        if not is_recipient_allowed(to_email, category=cfg.category):
+            log.debug("recipient not allowed for campaign=%s", campaign_id)
+            return "skipped"
+
+        dest = dev_redirect_email() or to_email
+        subject = render_subject(cfg.subject, context)
+        html_body, text_body = render_template(cfg.template, context)
+        from_addr = default_from_addr()
+        rt = reply_to or cfg.reply_to
+
+        await asyncio.to_thread(
+            self._provider.send_sync,
+            to_email=dest,
+            subject=subject,
+            html_body=html_body,
+            text_body=text_body,
+            from_addr=from_addr,
+            reply_to=rt,
+        )
+        return "sent"
+
+    async def send_otp(self, email: str, otp: str) -> SendResult:
+        await self.send_template(
+            campaign_id="otp",
+            to_email=email,
+            context={"otp": otp},
+        )

--- a/core/services/email/triggers.py
+++ b/core/services/email/triggers.py
@@ -1,0 +1,129 @@
+"""Lifecycle email triggers — enqueue only, never block callers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+
+from services.email.config import CAMPAIGNS, effective_delay_seconds, lifecycle_enabled
+from services.email.outbox import enqueue
+
+log = logging.getLogger(__name__)
+
+
+def _fire(coro) -> None:
+    """Schedule coroutine without blocking or failing the caller."""
+    try:
+        asyncio.get_running_loop().create_task(_safe_enqueue(coro))
+    except RuntimeError:
+        pass
+
+
+async def _safe_enqueue(coro):
+    try:
+        await coro
+    except Exception as e:
+        log.warning("email trigger failed: %s", e)
+
+
+async def on_signup_completed(
+    *,
+    user_id: str,
+    email: str,
+    tenant_id: str,
+) -> None:
+    if not lifecycle_enabled():
+        return
+    now = datetime.now(timezone.utc)
+    payload = {"user_id": user_id, "tenant_id": tenant_id, "email": email}
+
+    welcome_delay = effective_delay_seconds(CAMPAIGNS["welcome"].delay_seconds)
+    gs_delay = effective_delay_seconds(CAMPAIGNS["getting_started"].delay_seconds)
+    no_api_delay = effective_delay_seconds(CAMPAIGNS["no_api_72h"].delay_seconds)
+
+    await enqueue(
+        campaign_id="welcome",
+        recipient_key=user_id,
+        to_email=email,
+        payload=payload,
+        scheduled_at=now + timedelta(seconds=welcome_delay),
+    )
+    await enqueue(
+        campaign_id="getting_started",
+        recipient_key=user_id,
+        to_email=email,
+        payload=payload,
+        scheduled_at=now + timedelta(seconds=gs_delay),
+    )
+    await enqueue(
+        campaign_id="no_api_72h",
+        recipient_key=user_id,
+        to_email=email,
+        payload=payload,
+        scheduled_at=now + timedelta(seconds=no_api_delay),
+    )
+
+
+def schedule_signup_lifecycle(*, user_id: str, email: str, tenant_id: str) -> None:
+    _fire(on_signup_completed(user_id=user_id, email=email, tenant_id=tenant_id))
+
+
+async def on_api_key_created(*, tenant_id: str, user_id: str, email: str) -> None:
+    if not lifecycle_enabled():
+        return
+    delay = effective_delay_seconds(CAMPAIGNS["api_no_events"].delay_seconds)
+    now = datetime.now(timezone.utc)
+    await enqueue(
+        campaign_id="api_no_events",
+        recipient_key=tenant_id,
+        to_email=email,
+        payload={"tenant_id": tenant_id, "user_id": user_id, "email": email},
+        dedupe_key="first_key",
+        scheduled_at=now + timedelta(seconds=delay),
+    )
+
+
+def schedule_api_key_lifecycle(*, tenant_id: str, user_id: str, email: str) -> None:
+    _fire(on_api_key_created(tenant_id=tenant_id, user_id=user_id, email=email))
+
+
+async def on_account_deleted_enqueue(
+    *,
+    email: str,
+    promo_code: str,
+    promo_expires_at: str,
+    delete_id: str,
+) -> None:
+    if not lifecycle_enabled():
+        return
+    from services.email.config import dashboard_url
+
+    signup_url = f"{dashboard_url()}/signup/plan?promo={promo_code}"
+    await enqueue(
+        campaign_id="account_deleted",
+        recipient_key=email,
+        to_email=email,
+        dedupe_key=delete_id,
+        payload={
+            "email": email,
+            "promo_code": promo_code,
+            "promo_expires_at": promo_expires_at,
+            "signup_url": signup_url,
+        },
+        scheduled_at=datetime.now(timezone.utc),
+    )
+
+
+async def on_newsletter_subscribed(*, email: str) -> None:
+    if not lifecycle_enabled():
+        return
+    from services.email.config import docs_url
+
+    await enqueue(
+        campaign_id="newsletter_welcome",
+        recipient_key=email.lower(),
+        to_email=email,
+        payload={"email": email, "docs_url": docs_url()},
+        scheduled_at=datetime.now(timezone.utc),
+    )

--- a/core/templates/email/account_deleted.html
+++ b/core/templates/email/account_deleted.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-size:20px;color:#111;margin:0 0 16px">We're sorry to see you go</h1>
+<p style="font-size:14px;color:#444;line-height:1.7">Your ZizkaDB account has been deleted. Thank you for trying us — your feedback helps us build a better product.</p>
+{% if promo_code %}
+<p style="font-size:14px;color:#444;line-height:1.7;margin:16px 0">
+  Changed your mind? Use promo code <strong style="font-family:monospace;font-size:16px">{{ promo_code }}</strong> when you sign up again for an exclusive extra month on us.
+</p>
+<p style="margin:24px 0">
+  <a href="{{ signup_url }}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600">Reactivate your account</a>
+</p>
+<p style="font-size:12px;color:#888">Code expires {{ promo_expires_at }}</p>
+{% endif %}
+<p style="font-size:13px;color:#666;margin-top:24px">Wishing you success with your agents.</p>
+{% endblock %}

--- a/core/templates/email/active_checkin.html
+++ b/core/templates/email/active_checkin.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-size:20px;color:#111;margin:0 0 16px">How is ZizkaDB working for you?</h1>
+<p style="font-size:14px;color:#444;line-height:1.7">We'd love your feedback:</p>
+<ul style="color:#444;font-size:14px;line-height:1.8">
+  <li>How is your experience so far?</li>
+  <li>What could we improve?</li>
+  <li>Any feature requests?</li>
+</ul>
+<p style="font-size:13px;color:#666">Just reply to this email — we read every message.</p>
+{% endblock %}

--- a/core/templates/email/api_no_events.html
+++ b/core/templates/email/api_no_events.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-size:20px;color:#111;margin:0 0 16px">Send your first event</h1>
+<p style="font-size:14px;color:#444;line-height:1.7">You created an API key but haven't logged any agent events yet. One <code>db.log()</code> call unlocks search, baselines, and session replay.</p>
+<p style="margin:24px 0">
+  <a href="{{ docs_url }}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600">Quick start guide</a>
+</p>
+{% endblock %}

--- a/core/templates/email/base.html
+++ b/core/templates/email/base.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+</head>
+<body style="margin:0;padding:0;background:#f5f5f5;font-family:Inter,Arial,sans-serif;">
+  <div style="max-width:560px;margin:40px auto;background:#fff;border-radius:12px;padding:32px;border:1px solid #e5e5e5;">
+    {% block content %}{% endblock %}
+    <p style="color:#aaa;font-size:12px;margin-top:32px;line-height:1.6;border-top:1px solid #eee;padding-top:16px;">
+      ZizkaDB — Operational database for AI agents<br>
+      {% if unsubscribe_url %}
+      <a href="{{ unsubscribe_url }}" style="color:#888;">Unsubscribe</a>
+      {% endif %}
+    </p>
+  </div>
+</body>
+</html>

--- a/core/templates/email/getting_started.html
+++ b/core/templates/email/getting_started.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-size:20px;color:#111;margin:0 0 16px">Getting started with ZizkaDB</h1>
+<ol style="padding-left:20px;color:#444;line-height:1.8;font-size:14px">
+  <li>Create an agent in the dashboard</li>
+  <li>Copy your API key</li>
+  <li>Connect via Python SDK, TypeScript SDK, MCP, or REST</li>
+  <li>Log events with a consistent <code>session_id</code></li>
+</ol>
+<p style="margin:20px 0">
+  <a href="{{ dashboard_url }}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:14px;margin-right:8px">Dashboard</a>
+  <a href="{{ docs_url }}" style="display:inline-block;background:#f5f5f5;color:#111;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:14px">Documentation</a>
+</p>
+<p style="font-size:13px;color:#666;line-height:1.6">Questions? Reply to this email or book a demo anytime.</p>
+{% endblock %}

--- a/core/templates/email/getting_started.txt
+++ b/core/templates/email/getting_started.txt
@@ -1,0 +1,9 @@
+Getting started with ZizkaDB
+
+1. Create an agent in the dashboard
+2. Copy your API key
+3. Connect via SDK, MCP, or REST
+4. Log events with a consistent session_id
+
+Dashboard: {{ dashboard_url }}
+Docs: {{ docs_url }}

--- a/core/templates/email/inactive_7d.html
+++ b/core/templates/email/inactive_7d.html
@@ -1,0 +1,10 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-size:20px;color:#111;margin:0 0 16px">Can we help?</h1>
+<p style="font-size:14px;color:#444;line-height:1.7">We noticed no agent events from your account in the last 7 days. If you're stuck on integration, we're happy to help.</p>
+<p style="margin:20px 0">
+  <a href="{{ calendly_url }}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;margin-right:8px">Book a demo</a>
+  <a href="{{ docs_url }}" style="display:inline-block;background:#f5f5f5;color:#111;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600">Documentation</a>
+</p>
+<p style="font-size:13px;color:#666">Or email us at {{ founder_email }}</p>
+{% endblock %}

--- a/core/templates/email/newsletter_welcome.html
+++ b/core/templates/email/newsletter_welcome.html
@@ -1,0 +1,6 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-size:20px;color:#111;margin:0 0 16px">You're subscribed</h1>
+<p style="font-size:14px;color:#444;line-height:1.7">Thanks for subscribing to ZizkaDB updates — product news, AI engineering insights, and tutorials.</p>
+<p style="font-size:13px;color:#666">Explore the docs: <a href="{{ docs_url }}">{{ docs_url }}</a></p>
+{% endblock %}

--- a/core/templates/email/no_api_72h.html
+++ b/core/templates/email/no_api_72h.html
@@ -1,0 +1,8 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-size:20px;color:#111;margin:0 0 16px">Your API key is one click away</h1>
+<p style="font-size:14px;color:#444;line-height:1.7">You signed up for ZizkaDB {{ days_ago }} days ago but haven't created an API key yet. Keys unlock logging, search, and session replay for your agents.</p>
+<p style="margin:24px 0">
+  <a href="{{ dashboard_url }}/dashboard" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600">Create your first API key</a>
+</p>
+{% endblock %}

--- a/core/templates/email/otp.html
+++ b/core/templates/email/otp.html
@@ -1,0 +1,11 @@
+{% extends "base.html" %}
+{% block content %}
+<p style="font-size:14px;color:#555;margin:0 0 20px">Your ZizkaDB login code:</p>
+<div style="font-size:38px;font-weight:700;letter-spacing:10px;background:#f5f5f5;padding:24px;text-align:center;border-radius:8px;color:#111;font-family:monospace">
+  {{ otp }}
+</div>
+<p style="color:#aaa;font-size:12px;margin-top:20px;line-height:1.6">
+  Expires in 15 minutes.<br>
+  If you did not request this, ignore this email.
+</p>
+{% endblock %}

--- a/core/templates/email/otp.txt
+++ b/core/templates/email/otp.txt
@@ -1,0 +1,4 @@
+Your ZizkaDB login code: {{ otp }}
+
+Expires in 15 minutes.
+If you did not request this, ignore this email.

--- a/core/templates/email/welcome.html
+++ b/core/templates/email/welcome.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+<h1 style="font-size:22px;color:#111;margin:0 0 16px">Welcome to ZizkaDB</h1>
+<p style="font-size:15px;color:#444;line-height:1.7;margin:0 0 16px">
+  You're in. ZizkaDB is the operational database for AI agents — log every step, replay sessions, and catch drift before your users do.
+</p>
+<p style="font-size:14px;color:#666;line-height:1.6;margin:0 0 8px">
+  <strong>Plan:</strong> {{ plan_name }}<br>
+  {% if trial_ends_at %}<strong>Trial until:</strong> {{ trial_ends_at }}{% endif %}
+</p>
+<p style="margin:24px 0">
+  <a href="{{ dashboard_url }}" style="display:inline-block;background:#111;color:#fff;text-decoration:none;padding:12px 24px;border-radius:8px;font-weight:600;font-size:14px">Open dashboard</a>
+</p>
+{% endblock %}

--- a/core/templates/email/welcome.txt
+++ b/core/templates/email/welcome.txt
@@ -1,0 +1,8 @@
+Welcome to ZizkaDB!
+
+You're in. ZizkaDB is the operational database for AI agents.
+
+Plan: {{ plan_name }}
+{% if trial_ends_at %}Trial until: {{ trial_ends_at }}{% endif %}
+
+Open your dashboard: {{ dashboard_url }}

--- a/core/tests/test_auth_flow.py
+++ b/core/tests/test_auth_flow.py
@@ -227,3 +227,44 @@ class TestVerifyOtpRoute:
         )
         assert res.status_code == 200
         assert res.json()["access_token"] == "tok"
+
+    @patch("api.auth.request_otp", new_callable=AsyncMock)
+    @patch("api.auth.email_exists", new_callable=AsyncMock)
+    def test_request_otp_route_succeeds_when_send_fails(self, mock_exists, mock_request):
+        mock_exists.return_value = True
+        mock_request.return_value = None
+        res = client.post(
+            "/v1/auth/request-otp",
+            json={"email": "user@example.com", "intent": "login"},
+        )
+        assert res.status_code == 200
+
+    @patch("services.email.triggers.schedule_signup_lifecycle")
+    @patch("api.auth.verify_otp", new_callable=AsyncMock)
+    @patch("services.billing.fetch_user_billing", new_callable=AsyncMock)
+    def test_signup_succeeds_when_lifecycle_trigger_raises(
+        self, mock_billing, mock_verify, mock_schedule
+    ):
+        mock_verify.return_value = {
+            "access_token": "tok",
+            "refresh_token": "ref",
+            "token_type": "bearer",
+            "user_id": "u1",
+            "tenant_id": "t1",
+            "is_new_signup": True,
+        }
+        mock_billing.return_value = None
+        mock_schedule.side_effect = RuntimeError("lifecycle down")
+
+        res = client.post(
+            "/v1/auth/verify-otp",
+            json={
+                "email": "new@example.com",
+                "otp": "123456",
+                "intent": "signup",
+                "gdpr_consent": True,
+            },
+        )
+        assert res.status_code == 200
+        assert res.json()["access_token"] == "tok"
+        mock_schedule.assert_called_once()

--- a/core/tests/test_churn_promo.py
+++ b/core/tests/test_churn_promo.py
@@ -1,0 +1,103 @@
+"""Churn promo code tests."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_generate_promo_code_format():
+    from services.email.churn import generate_promo_code
+
+    code = generate_promo_code()
+    assert code.startswith("COMEBACK-")
+
+
+@pytest.mark.asyncio
+async def test_redeem_invalid_code():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(return_value=None)
+    with patch("services.email.churn.get_pool", return_value=pool):
+        from services.email.churn import redeem_churn_promo
+
+        ok = await redeem_churn_promo(
+            email="a@b.com",
+            promo_code="COMEBACK-INVALID",
+            user_id="u1",
+        )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_redeem_success():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(
+        return_value={
+            "offer_id": "o1",
+            "expires_at": datetime.now(timezone.utc) + timedelta(days=1),
+            "redeemed_at": None,
+        }
+    )
+    conn = MagicMock()
+    conn.fetchval = AsyncMock(return_value="o1")
+    conn.execute = AsyncMock()
+    txn = MagicMock()
+    txn.__aenter__ = AsyncMock(return_value=None)
+    txn.__aexit__ = AsyncMock(return_value=None)
+    conn.transaction = MagicMock(return_value=txn)
+    pool.acquire = MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("services.email.churn.get_pool", return_value=pool):
+        from services.email.churn import redeem_churn_promo
+
+        ok = await redeem_churn_promo(
+            email="a@b.com",
+            promo_code="COMEBACK-ABC",
+            user_id="u1",
+        )
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_redeem_expired_code():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(
+        return_value={
+            "offer_id": "o1",
+            "expires_at": datetime.now(timezone.utc) - timedelta(days=1),
+            "redeemed_at": None,
+        }
+    )
+    with patch("services.email.churn.get_pool", return_value=pool):
+        from services.email.churn import redeem_churn_promo
+
+        ok = await redeem_churn_promo(
+            email="a@b.com",
+            promo_code="COMEBACK-OLD",
+            user_id="u1",
+        )
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_redeem_double_redeem():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(
+        return_value={
+            "offer_id": "o1",
+            "expires_at": datetime.now(timezone.utc) + timedelta(days=1),
+            "redeemed_at": datetime.now(timezone.utc),
+        }
+    )
+    with patch("services.email.churn.get_pool", return_value=pool):
+        from services.email.churn import redeem_churn_promo
+
+        ok = await redeem_churn_promo(
+            email="a@b.com",
+            promo_code="COMEBACK-USED",
+            user_id="u1",
+        )
+    assert ok is False

--- a/core/tests/test_email_campaign_overlap.py
+++ b/core/tests/test_email_campaign_overlap.py
@@ -1,0 +1,31 @@
+"""C4 vs C5 mutual exclusion tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_c4_and_c5_never_both_qualify():
+    """C4 needs keys + no events ever; C5 needs keys + events + quiet 7d."""
+    from services.email.eligibility import eligible_api_no_events, eligible_inactive_7d
+
+    # Tenant with keys but never sent real events → C4 only
+    pool_c4 = MagicMock()
+    pool_c4.fetchval = AsyncMock(side_effect=[1, None, 1, None])
+    with patch("services.email.eligibility.get_pool", return_value=pool_c4):
+        c4 = await eligible_api_no_events(tenant_id="t1")
+        c5 = await eligible_inactive_7d(tenant_id="t1")
+
+    assert c4 is True
+    assert c5 is False
+
+    # Tenant with keys, history, and quiet week → C5 only
+    pool_c5 = MagicMock()
+    pool_c5.fetchval = AsyncMock(side_effect=[1, 1, 1, 1, None])
+    with patch("services.email.eligibility.get_pool", return_value=pool_c5):
+        c4 = await eligible_api_no_events(tenant_id="t1")
+        c5 = await eligible_inactive_7d(tenant_id="t1")
+
+    assert c4 is False
+    assert c5 is True

--- a/core/tests/test_email_deletion.py
+++ b/core/tests/test_email_deletion.py
@@ -1,0 +1,117 @@
+"""Account deletion lifecycle email tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_delete_cancels_pending_and_enqueues_c7():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(
+        return_value={
+            "user_id": "u1",
+            "email": "user@example.com",
+            "tenant_id": "t1",
+        }
+    )
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    txn = MagicMock()
+    txn.__aenter__ = AsyncMock(return_value=None)
+    txn.__aexit__ = AsyncMock(return_value=None)
+    conn.transaction = MagicMock(return_value=txn)
+    pool.acquire = MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    offer = {"promo_code": "COMEBACK-ABC", "expires_at": "2026-12-31T00:00:00Z"}
+    cancel_user = AsyncMock(return_value=2)
+    cancel_tenant = AsyncMock(return_value=1)
+    enqueue = AsyncMock()
+
+    with patch("services.account.get_pool", return_value=pool):
+        with patch("services.account.managed_cloud_only", return_value=True):
+            with patch("services.email.config.lifecycle_enabled", return_value=True):
+                with patch("services.account._purge_tenant_vectors", new_callable=AsyncMock):
+                    with patch(
+                        "services.email.churn.create_churn_offer",
+                        new_callable=AsyncMock,
+                        return_value=offer,
+                    ):
+                        with patch(
+                            "services.email.outbox.cancel_pending_for_user", cancel_user
+                        ):
+                            with patch(
+                                "services.email.outbox.cancel_pending_for_tenant",
+                                cancel_tenant,
+                            ):
+                                with patch(
+                                    "services.email.triggers.on_account_deleted_enqueue",
+                                    enqueue,
+                                ):
+                                    from services.account import delete_managed_account
+
+                                    await delete_managed_account(
+                                        user_id="u1", tenant_id="t1"
+                                    )
+
+    cancel_user.assert_awaited_once_with("u1")
+    cancel_tenant.assert_awaited_once_with("t1")
+    enqueue.assert_awaited_once()
+    assert enqueue.await_args.kwargs["promo_code"] == "COMEBACK-ABC"
+
+
+@pytest.mark.asyncio
+async def test_delete_skips_churn_when_lifecycle_disabled():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(
+        return_value={
+            "user_id": "u1",
+            "email": "user@example.com",
+            "tenant_id": "t1",
+        }
+    )
+    conn = MagicMock()
+    conn.execute = AsyncMock()
+    txn = MagicMock()
+    txn.__aenter__ = AsyncMock(return_value=None)
+    txn.__aexit__ = AsyncMock(return_value=None)
+    conn.transaction = MagicMock(return_value=txn)
+    pool.acquire = MagicMock()
+    pool.acquire.return_value.__aenter__ = AsyncMock(return_value=conn)
+    pool.acquire.return_value.__aexit__ = AsyncMock(return_value=None)
+
+    cancel = AsyncMock(return_value=0)
+    cancel_tenant = AsyncMock(return_value=0)
+    create_offer = AsyncMock()
+    enqueue = AsyncMock()
+
+    with patch("services.account.get_pool", return_value=pool):
+        with patch("services.account.managed_cloud_only", return_value=True):
+            with patch("services.email.config.lifecycle_enabled", return_value=False):
+                with patch("services.account._purge_tenant_vectors", new_callable=AsyncMock):
+                    with patch(
+                        "services.email.churn.create_churn_offer", create_offer
+                    ):
+                        with patch(
+                            "services.email.outbox.cancel_pending_for_user", cancel
+                        ):
+                            with patch(
+                                "services.email.outbox.cancel_pending_for_tenant",
+                                cancel_tenant,
+                            ):
+                                with patch(
+                                    "services.email.triggers.on_account_deleted_enqueue",
+                                    enqueue,
+                                ):
+                                    from services.account import delete_managed_account
+
+                                    await delete_managed_account(
+                                        user_id="u1", tenant_id="t1"
+                                    )
+
+    cancel.assert_awaited_once_with("u1")
+    cancel_tenant.assert_awaited_once_with("t1")
+    create_offer.assert_not_awaited()
+    enqueue.assert_not_awaited()

--- a/core/tests/test_email_eligibility.py
+++ b/core/tests/test_email_eligibility.py
@@ -1,0 +1,65 @@
+"""Scheduled campaign eligibility matrix tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _pool(fetchval_side_effect):
+    pool = MagicMock()
+    pool.fetchval = AsyncMock(side_effect=fetchval_side_effect)
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_no_api_72h_requires_user_and_no_keys():
+    pool = _pool([1, 0])  # user exists, zero keys
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_no_api_72h
+
+        assert await eligible_no_api_72h(user_id="u1", tenant_id="t1") is True
+
+    pool = _pool([None])  # user deleted
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_no_api_72h
+
+        assert await eligible_no_api_72h(user_id="u1", tenant_id="t1") is False
+
+
+@pytest.mark.asyncio
+async def test_api_no_events_requires_keys_without_events():
+    pool = _pool([2, None])  # 2 keys, no real events
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_api_no_events
+
+        assert await eligible_api_no_events(tenant_id="t1") is True
+
+    pool = _pool([0])  # no keys
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_api_no_events
+
+        assert await eligible_api_no_events(tenant_id="t1") is False
+
+
+@pytest.mark.asyncio
+async def test_inactive_7d_requires_history_and_quiet_week():
+    pool = _pool([1, 1, None])  # keys, had events, no events in 7d
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_inactive_7d
+
+        assert await eligible_inactive_7d(tenant_id="t1") is True
+
+
+@pytest.mark.asyncio
+async def test_active_checkin_requires_recent_activity_and_no_recent_send():
+    pool = _pool([1, 1, None])  # user exists, events in 7d, no recent C6 send
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_active_checkin
+
+        assert await eligible_active_checkin(user_id="u1", tenant_id="t1") is True
+
+    pool = _pool([1, None])  # user exists, no recent events
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_active_checkin
+
+        assert await eligible_active_checkin(user_id="u1", tenant_id="t1") is False

--- a/core/tests/test_email_eligibility_welcome.py
+++ b/core/tests/test_email_eligibility_welcome.py
@@ -1,0 +1,39 @@
+"""Welcome / getting-started eligibility tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_eligible_welcome_when_user_exists():
+    pool = MagicMock()
+    pool.fetchval = AsyncMock(return_value=1)
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_welcome
+
+        assert await eligible_welcome(user_id="u1") is True
+
+
+@pytest.mark.asyncio
+async def test_eligible_welcome_skips_deleted_user():
+    pool = MagicMock()
+    pool.fetchval = AsyncMock(return_value=None)
+    with patch("services.email.eligibility.get_pool", return_value=pool):
+        from services.email.eligibility import eligible_welcome
+
+        assert await eligible_welcome(user_id="u1") is False
+
+
+@pytest.mark.asyncio
+async def test_check_eligibility_welcome_delegates():
+    with patch(
+        "services.email.eligibility.eligible_welcome",
+        new_callable=AsyncMock,
+        return_value=False,
+    ) as mock_fn:
+        from services.email.eligibility import check_eligibility
+
+        ok = await check_eligibility("welcome", {"user_id": "u1"})
+    assert ok is False
+    mock_fn.assert_awaited_once_with(user_id="u1")

--- a/core/tests/test_email_hardening.py
+++ b/core/tests/test_email_hardening.py
@@ -1,0 +1,69 @@
+"""Additional auth + email hardening tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import bcrypt
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from services.auth import _promo_rate, _check_promo_rate_limit, request_otp
+
+client = TestClient(app)
+
+
+@pytest.mark.asyncio
+async def test_request_otp_succeeds_when_send_fails():
+    pool = MagicMock()
+    pool.execute = AsyncMock()
+    svc = MagicMock()
+    svc.send_otp = AsyncMock(side_effect=RuntimeError("SMTP down"))
+
+    with patch("services.auth.get_pool", return_value=pool):
+        with patch("services.email.service.get_email_service", return_value=svc):
+            await request_otp("user@example.com")
+
+    assert pool.execute.await_count == 2
+    svc.send_otp.assert_awaited_once()
+
+
+def test_promo_rate_limit_raises():
+    _promo_rate.clear()
+    email = "promo-test@example.com"
+    for _ in range(10):
+        _check_promo_rate_limit(email)
+    with pytest.raises(ValueError, match="Too many promo"):
+        _check_promo_rate_limit(email)
+    _promo_rate.clear()
+
+
+@pytest.mark.asyncio
+async def test_newsletter_sync_unsubscribes_when_marketing_declined():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(
+        return_value={"subscriber_id": "s1", "unsubscribed_at": None}
+    )
+    pool.execute = AsyncMock()
+    with patch("services.email.newsletter_sync.get_pool", return_value=pool):
+        from services.email.newsletter_sync import sync_newsletter_on_signup
+
+        await sync_newsletter_on_signup(
+            email="user@example.com",
+            marketing_consent=False,
+        )
+    pool.execute.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_newsletter_sync_noop_when_no_row():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(return_value=None)
+    pool.execute = AsyncMock()
+    with patch("services.email.newsletter_sync.get_pool", return_value=pool):
+        from services.email.newsletter_sync import sync_newsletter_on_signup
+
+        await sync_newsletter_on_signup(
+            email="new@example.com",
+            marketing_consent=True,
+        )
+    pool.execute.assert_not_awaited()

--- a/core/tests/test_email_outbox.py
+++ b/core/tests/test_email_outbox.py
@@ -1,0 +1,56 @@
+"""Email outbox unit tests."""
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_pool():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock()
+    pool.execute = AsyncMock()
+    pool.acquire = MagicMock()
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_enqueue_returns_id(mock_pool):
+    mock_pool.fetchrow.return_value = ("abc-123",)
+    with patch("services.email.outbox.get_pool", return_value=mock_pool):
+        from services.email.outbox import enqueue
+
+        oid = await enqueue(
+            campaign_id="welcome",
+            recipient_key="user-1",
+            to_email="test@example.com",
+            payload={"user_id": "user-1"},
+        )
+    assert oid == "abc-123"
+    mock_pool.fetchrow.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_enqueue_duplicate_returns_none(mock_pool):
+    mock_pool.fetchrow.return_value = None
+    with patch("services.email.outbox.get_pool", return_value=mock_pool):
+        from services.email.outbox import enqueue
+
+        oid = await enqueue(
+            campaign_id="welcome",
+            recipient_key="user-1",
+            to_email="test@example.com",
+        )
+    assert oid is None
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_for_user(mock_pool):
+    mock_pool.execute.return_value = "UPDATE 3"
+    with patch("services.email.outbox.get_pool", return_value=mock_pool):
+        from services.email.outbox import cancel_pending_for_user
+
+        n = await cancel_pending_for_user("user-1")
+    assert n == 3

--- a/core/tests/test_email_processor.py
+++ b/core/tests/test_email_processor.py
@@ -1,0 +1,76 @@
+"""Email processor unit tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from datetime import datetime, timezone, timedelta
+
+
+def test_active_checkin_dedupe_key_15_day_windows():
+    from services.email.config import active_checkin_dedupe_key
+
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert active_checkin_dedupe_key(t0) == active_checkin_dedupe_key(t0)
+    t1 = t0 + timedelta(days=15)
+    assert active_checkin_dedupe_key(t0) != active_checkin_dedupe_key(t1)
+
+
+@pytest.mark.asyncio
+async def test_processor_cancels_when_send_skipped_not_mark_sent():
+    row = {
+        "outbox_id": "oid-1",
+        "campaign_id": "welcome",
+        "payload": {"user_id": "u1", "tenant_id": "t1"},
+        "to_email": "blocked@example.com",
+        "attempts": 0,
+    }
+    svc = MagicMock()
+    svc.send_template = AsyncMock(return_value="skipped")
+    cancel = AsyncMock()
+    mark_sent_fn = AsyncMock()
+
+    with patch("services.email.processor.lifecycle_enabled", return_value=True):
+        with patch("services.email.processor.claim_batch", AsyncMock(return_value=[row])):
+            with patch("services.email.processor.get_email_service", return_value=svc):
+                with patch("services.email.processor.check_eligibility", AsyncMock(return_value=True)):
+                    with patch("services.email.processor.build_context", AsyncMock(return_value={})):
+                        with patch("services.email.processor.cancel_outbox_row", cancel):
+                            with patch("services.email.processor.mark_sent", mark_sent_fn):
+                                from services.email.processor import process_outbox_batch
+
+                                n = await process_outbox_batch()
+
+    assert n == 0
+    cancel.assert_awaited_once()
+    assert "not allowed" in cancel.await_args.args[1]
+    mark_sent_fn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_processor_marks_sent_when_delivered():
+    row = {
+        "outbox_id": "oid-2",
+        "campaign_id": "welcome",
+        "payload": {"user_id": "u1", "tenant_id": "t1"},
+        "to_email": "ok@example.com",
+        "attempts": 0,
+    }
+    svc = MagicMock()
+    svc.send_template = AsyncMock(return_value="sent")
+    cancel = AsyncMock()
+    mark_sent_fn = AsyncMock()
+
+    with patch("services.email.processor.lifecycle_enabled", return_value=True):
+        with patch("services.email.processor.claim_batch", AsyncMock(return_value=[row])):
+            with patch("services.email.processor.get_email_service", return_value=svc):
+                with patch("services.email.processor.check_eligibility", AsyncMock(return_value=True)):
+                    with patch("services.email.processor.build_context", AsyncMock(return_value={})):
+                        with patch("services.email.processor.cancel_outbox_row", cancel):
+                            with patch("services.email.processor.mark_sent", mark_sent_fn):
+                                from services.email.processor import process_outbox_batch
+
+                                n = await process_outbox_batch()
+
+    assert n == 1
+    cancel.assert_not_awaited()
+    mark_sent_fn.assert_awaited_once()

--- a/core/tests/test_email_service.py
+++ b/core/tests/test_email_service.py
@@ -1,0 +1,63 @@
+"""EmailService unit tests."""
+
+from unittest.mock import patch
+
+import pytest
+
+from services.email.providers.mock import MockEmailProvider
+from services.email.service import EmailService
+
+
+@pytest.mark.asyncio
+async def test_send_otp_uses_template():
+    provider = MockEmailProvider()
+    svc = EmailService(provider)
+    await svc.send_otp("user@example.com", "123456")
+    assert len(provider.sent) == 1
+    assert provider.sent[0]["to_email"] == "user@example.com"
+    assert "123456" in provider.sent[0]["html_body"]
+
+
+@pytest.mark.asyncio
+async def test_send_template_skipped_when_not_allowed():
+    provider = MockEmailProvider()
+    svc = EmailService(provider)
+    with patch("services.email.service.is_recipient_allowed", return_value=False):
+        with patch("services.email.service.get_campaign") as mock_camp:
+            from services.email.config import CampaignConfig
+            mock_camp.return_value = CampaignConfig(
+                id="welcome",
+                subject="Welcome",
+                template="welcome",
+                category="lifecycle",
+            )
+            result = await svc.send_template(
+                campaign_id="welcome",
+                to_email="user@example.com",
+                context={"plan_name": "Pro"},
+            )
+    assert result == "skipped"
+    assert len(provider.sent) == 0
+
+
+@pytest.mark.asyncio
+async def test_dev_redirect():
+    provider = MockEmailProvider()
+    svc = EmailService(provider)
+    with patch("services.email.service.dev_redirect_email", return_value="dev@test.com"):
+        with patch("services.email.service.is_recipient_allowed", return_value=True):
+            with patch("services.email.service.get_campaign") as mock_camp:
+                from services.email.config import CampaignConfig
+                mock_camp.return_value = CampaignConfig(
+                    id="welcome",
+                    subject="Welcome {plan_name}",
+                    template="welcome",
+                    category="lifecycle",
+                )
+                result = await svc.send_template(
+                    campaign_id="welcome",
+                    to_email="user@example.com",
+                    context={"plan_name": "Pro", "dashboard_url": "http://localhost:3001"},
+                )
+    assert result == "sent"
+    assert provider.sent[0]["to_email"] == "dev@test.com"

--- a/core/tests/test_email_triggers.py
+++ b/core/tests/test_email_triggers.py
@@ -1,0 +1,33 @@
+"""Signup lifecycle trigger tests."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_on_signup_enqueues_three_campaigns():
+    enqueue = AsyncMock(side_effect=["id1", "id2", "id3"])
+    with patch("services.email.triggers.lifecycle_enabled", return_value=True):
+        with patch("services.email.triggers.enqueue", enqueue):
+            from services.email.triggers import on_signup_completed
+
+            await on_signup_completed(
+                user_id="u1",
+                email="a@b.com",
+                tenant_id="t1",
+            )
+    assert enqueue.await_count == 3
+    campaigns = [c.kwargs["campaign_id"] for c in enqueue.await_args_list]
+    assert campaigns == ["welcome", "getting_started", "no_api_72h"]
+
+
+@pytest.mark.asyncio
+async def test_on_signup_skipped_when_disabled():
+    enqueue = AsyncMock()
+    with patch("services.email.triggers.lifecycle_enabled", return_value=False):
+        with patch("services.email.triggers.enqueue", enqueue):
+            from services.email.triggers import on_signup_completed
+
+            await on_signup_completed(user_id="u1", email="a@b.com", tenant_id="t1")
+    enqueue.assert_not_awaited()

--- a/core/tests/test_newsletter.py
+++ b/core/tests/test_newsletter.py
@@ -1,0 +1,100 @@
+"""Newsletter API tests."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def mock_pool():
+    pool = MagicMock()
+    pool.fetchrow = AsyncMock(return_value=None)
+    pool.execute = AsyncMock()
+    return pool
+
+
+def test_subscribe_rejects_honeypot():
+    with patch("api.newsletter.lifecycle_enabled", return_value=True):
+        res = client.post(
+            "/v1/newsletter/subscribe",
+            json={"email": "test@example.com", "botcheck": "spam"},
+        )
+    assert res.status_code == 400
+
+
+def test_subscribe_disabled_when_lifecycle_off():
+    with patch("api.newsletter.lifecycle_enabled", return_value=False):
+        res = client.post(
+            "/v1/newsletter/subscribe",
+            json={"email": "test@example.com", "botcheck": ""},
+        )
+    assert res.status_code == 503
+
+
+def test_subscribe_success(mock_pool):
+    with patch("api.newsletter.get_pool", return_value=mock_pool):
+        with patch("api.newsletter.lifecycle_enabled", return_value=True):
+            with patch("api.newsletter.on_newsletter_subscribed", new_callable=AsyncMock):
+                res = client.post(
+                    "/v1/newsletter/subscribe",
+                    json={"email": "new@example.com", "botcheck": ""},
+                )
+    assert res.status_code == 201
+    assert "Thanks" in res.json()["message"]
+
+
+def test_subscribe_duplicate(mock_pool):
+    mock_pool.fetchrow.return_value = {
+        "subscriber_id": "s1",
+        "unsubscribed_at": None,
+    }
+    with patch("api.newsletter.get_pool", return_value=mock_pool):
+        with patch("api.newsletter.lifecycle_enabled", return_value=True):
+            res = client.post(
+                "/v1/newsletter/subscribe",
+                json={"email": "exists@example.com", "botcheck": ""},
+            )
+    assert res.status_code == 201
+    assert res.json()["already_subscribed"] is True
+
+
+def test_unsubscribe_success(mock_pool):
+    mock_pool.fetchrow = AsyncMock(
+        return_value={"email": "user@example.com"}
+    )
+    with patch("api.newsletter.get_pool", return_value=mock_pool):
+        res = client.get(
+            "/v1/newsletter/unsubscribe",
+            params={"token": "a" * 32},
+        )
+    assert res.status_code == 200
+    assert res.json()["message"] == "You have been unsubscribed."
+
+
+def test_unsubscribe_invalid_token():
+    res = client.get("/v1/newsletter/unsubscribe", params={"token": "short"})
+    assert res.status_code == 400
+
+
+def test_subscribe_rate_limit():
+    import time
+
+    with patch("api.newsletter.lifecycle_enabled", return_value=True):
+        with patch("api.newsletter.get_pool") as mock_get_pool:
+            pool = MagicMock()
+            pool.fetchrow = AsyncMock(return_value=None)
+            pool.execute = AsyncMock()
+            mock_get_pool.return_value = pool
+            now = time.time()
+            with patch("api.newsletter._client_ip", return_value="1.2.3.4"):
+                with patch("api.newsletter._rate", {"1.2.3.4": [now] * 10}):
+                    res = client.post(
+                        "/v1/newsletter/subscribe",
+                        json={"email": "rate@example.com", "botcheck": ""},
+                    )
+    assert res.status_code == 429

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -256,6 +256,58 @@ class TestDemoRequestsRateLimiting:
             })
             assert response.status_code == 201
 
+    @patch("api.demo_requests.get_pool")
+    def test_demo_requests_accepts_position_and_source(self, mock_get_pool):
+        mock_pool = MagicMock()
+        mock_pool.fetchrow = AsyncMock(return_value={"request_id": "test-uuid", "created_at": datetime.now(timezone.utc)})
+        mock_get_pool.return_value = mock_pool
+
+        response = client.post("/v1/demo-requests", json={
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "email": "jane@example.com",
+            "company_name": "Acme Corp",
+            "website": "acme.com",
+            "position": "Head of AI",
+            "source": "enterprise",
+        })
+        assert response.status_code == 201
+
+        args = mock_pool.fetchrow.call_args[0]
+        assert args[6] == "Head of AI"
+        assert args[7] == "enterprise"
+
+    @patch("api.demo_requests.get_pool")
+    def test_demo_requests_position_optional(self, mock_get_pool):
+        mock_pool = MagicMock()
+        mock_pool.fetchrow = AsyncMock(return_value={"request_id": "test-uuid", "created_at": datetime.now(timezone.utc)})
+        mock_get_pool.return_value = mock_pool
+
+        response = client.post("/v1/demo-requests", json={
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "email": "jane@example.com",
+            "company_name": "Acme Corp",
+            "website": "acme.com",
+        })
+        assert response.status_code == 201
+
+        args = mock_pool.fetchrow.call_args[0]
+        assert args[6] is None
+        assert args[7] is None
+
+    def test_demo_requests_rejects_invalid_source(self):
+        response = client.post("/v1/demo-requests", json={
+            "first_name": "Jane",
+            "last_name": "Doe",
+            "email": "jane@example.com",
+            "company_name": "Acme Corp",
+            "website": "acme.com",
+            "source": "spam",
+        })
+        assert response.status_code == 422
+        assert response.json()["detail"] == "Invalid source"
+
 
 # ──────────────────────────────────────────────────────────────────────────────
 # Community Upload/Post Rate Limiting Tests

--- a/core/workers/email_worker.py
+++ b/core/workers/email_worker.py
@@ -1,0 +1,62 @@
+"""ARQ worker for email outbox processing."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+
+from arq import cron
+from arq.connections import RedisSettings
+
+from db.connection import close_db, init_db
+from services.email.processor import process_outbox_batch, scan_scheduled_campaigns
+
+log = logging.getLogger(__name__)
+
+
+async def startup(ctx):
+    await init_db()
+    log.info("Email worker started")
+
+
+async def shutdown(ctx):
+    await close_db()
+    log.info("Email worker stopped")
+
+
+async def drain_outbox(ctx):
+    n = await process_outbox_batch()
+    if n:
+        log.info("Processed %s outbox emails", n)
+    return n
+
+
+async def scan_campaigns(ctx):
+    n = await scan_scheduled_campaigns()
+    if n:
+        log.info("Enqueued %s scheduled campaign emails", n)
+    await process_outbox_batch()
+    return n
+
+
+class WorkerSettings:
+    redis_settings = RedisSettings.from_dsn(
+        os.getenv("REDIS_URL", "redis://localhost:6379")
+    )
+    functions = [drain_outbox, scan_campaigns]
+    cron_jobs = [
+        cron(drain_outbox, minute=set(range(60))),
+        cron(scan_campaigns, minute={0, 15, 30, 45}),
+    ]
+    on_startup = startup
+    on_shutdown = shutdown
+    max_jobs = 5
+    job_timeout = 300
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
+    from arq import run_worker
+
+    run_worker(WorkerSettings)

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -631,6 +631,33 @@ flowchart TD
     D --> E["/dashboard"]
 ```
 
+### 18.8 Email lifecycle automation (`core/services/email/`)
+
+> **Definitive reference:** `.cursor/rules/email-lifecycle-knowledge-base.mdc` (campaigns, outbox, worker, eligibility, rollout).
+
+Passwordless OTP and lifecycle campaigns share `EmailService` + Jinja2 templates. **Auth never blocks on lifecycle failure** — signup/login/delete enqueue only; the ARQ worker sends asynchronously.
+
+| Campaign | ID | Trigger | Delay |
+|----------|-----|---------|-------|
+| Welcome | `welcome` | Signup complete | +5 min |
+| Getting started | `getting_started` | Signup complete | +10 min |
+| No API 72h | `no_api_72h` | Signup complete | +72h |
+| API, no events | `api_no_events` | First API key | +7d |
+| Inactive 7d | `inactive_7d` | Worker scan (every 15 min) | Rolling |
+| Active check-in | `active_checkin` | Worker scan (every 15 min) | Every 15d min |
+| Account deleted | `account_deleted` | Pre-delete hook | Immediate |
+| Newsletter welcome | `newsletter_welcome` | Popup subscribe | Immediate |
+
+**Worker:** `email_worker` service in `infra/docker-compose.yml` — ARQ cron drains `email_outbox` every 1 min and scans C5/C6 every 15 min. Idempotency via `UNIQUE(campaign_id, recipient_key, dedupe_key)`.
+
+**Env flags** (see `.env.example`): `EMAIL_LIFECYCLE_ENABLED` (default `false`), `NEXT_PUBLIC_NEWSLETTER_ENABLED` (default `false`; dashboard build-time), `EMAIL_DEV_REDIRECT`, `EMAIL_STAGING_COMPRESS_DELAYS` (dev/staging only), `EMAIL_LIFECYCLE_ALLOWLIST` (prod rollout). OTP uses `EMAIL_*` SMTP when set; otherwise codes print to API logs.
+
+**Churn recovery:** On production account delete, `churn_offers` stores `COMEBACK-{token}`; C7 email includes signup link with `?promo=`. Re-signup redeems and extends trial.
+
+**Newsletter:** `POST /v1/newsletter/subscribe`, `GET /v1/newsletter/unsubscribe?token=`; landing popup `NewsletterPopup.tsx` (15s delay, 7d dismiss). Admin monitor: `GET /v1/admin/email/stats`.
+
+**QA:** `docs/email-automation-qa.md`. Optional dev inbox: `docker compose --profile dev-mail up` → http://localhost:8025.
+
 ---
 
 ## 19. Per-Screen Functional Reference
@@ -787,6 +814,10 @@ Schema sources: `core/db/schema.sql` (base DDL, Docker init) + `core/db/migratio
 | `community_posts` | `post_id` (PK), `author_name`, `category`, `title`, `body`, `image_urls` (JSONB), `reply_count` | Public community board |
 | `community_replies` | `reply_id` (PK), `post_id` (FK cascade), `author_name`, `body` | Replies; bumps parent `reply_count` |
 | `demo_requests` | `request_id` (PK), `first_name`, `last_name`, `email`, `company_name`, `website`, `ip_address` | Landing "Book demo" submissions |
+| `email_outbox` | `outbox_id` (PK), `campaign_id`, `recipient_key`, `dedupe_key`, `to_email`, `payload` (JSONB), `scheduled_at`, `status`, `attempts` | Transactional outbox for lifecycle emails (worker drains) |
+| `email_send_log` | `log_id` (PK), `campaign_id`, `to_email`, `user_id`, `tenant_id`, `sent_at`, `metadata` (JSONB) | Audit log of sent lifecycle emails |
+| `churn_offers` | `offer_id` (PK), `email`, `promo_code`, `expires_at`, `redeemed_at` | Comeback promo codes issued on account deletion |
+| `newsletter_subscribers` | `subscriber_id` (PK), `email`, `subscribed_at`, `unsubscribed_at`, `unsubscribe_token_hash` | Marketing newsletter signups (landing popup) |
 | `sdk_telemetry` | `install_id` (PK), `sdk`, `sdk_version`, `runtime`, `os`, `mode` (`cloud`/`self-hosted`), `ping_count` | Anonymous SDK install pings (runtime-only table, not in `schema.sql`) |
 
 **Cascade:** `agents`, `api_keys`, `events`, `usage_daily` cascade from `tenants`. Account deletion explicitly deletes `users`, `auth_otps`, `tenants` and purges Qdrant vectors.
@@ -857,6 +888,7 @@ erDiagram
 | Agents home | `app/dashboard/page.tsx` |
 | Settings (keys/embeddings/account) | `app/dashboard/settings/page.tsx` |
 | Book-demo modal | `components/marketing/CalendlyBookModal.tsx` |
+| Newsletter popup | `components/marketing/NewsletterPopup.tsx` |
 | Operator admin | `app/admin/{layout,page}.tsx` |
 | Build config / rewrites / env | `next.config.mjs` |
 
@@ -870,6 +902,7 @@ erDiagram
 | Billing + trials (no payment) | `core/services/billing.py`, `core/api/billing_checkout.py` |
 | API key plan limits | `core/services/plan_limits.py`, `core/services/api_keys.py` |
 | Account (retention trial, delete) | `core/api/account.py`, `core/services/account.py` |
+| Email lifecycle (outbox, worker) | `core/services/email/`, `core/workers/email_worker.py`, `core/api/newsletter.py` |
 | Event write pipeline | `core/services/event_write.py`, `core/api/events.py` |
 | Memory (context/diff/forget) | `core/api/memory.py` |
 | Agents + baseline/drift | `core/api/agents.py` |

--- a/dashboard/app/admin/page.tsx
+++ b/dashboard/app/admin/page.tsx
@@ -103,6 +103,8 @@ interface DemoRequest {
   email: string
   company_name: string
   website: string
+  position: string | null
+  source: string | null
   ip_address: string | null
   created_at: string | null
 }
@@ -792,7 +794,7 @@ function DemoRequestsSection({ token }: { token: string }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
-        <Stat label="Total requests" value={fmt(rows?.length)} sub="from Book demo form" accent="#7c3aed" />
+        <Stat label="Total requests" value={fmt(rows?.length)} sub="from contact forms" accent="#7c3aed" />
       </div>
 
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
@@ -800,7 +802,7 @@ function DemoRequestsSection({ token }: { token: string }) {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && load()}
-          placeholder="Search name, email, company, website…"
+          placeholder="Search name, email, company, website, role, source…"
           style={{
             flex: '1 1 220px', padding: '8px 12px', background: '#0a0a0a',
             border: '1px solid #2a2a2a', borderRadius: 8, color: '#fff', fontSize: 13,
@@ -809,18 +811,20 @@ function DemoRequestsSection({ token }: { token: string }) {
         <button type="button" onClick={load} style={btnSmall()}>Refresh</button>
       </div>
 
-      <Card title="Demo requests" subtitle="Submissions from the homepage Book demo form. Newest first.">
+      <Card title="Demo requests" subtitle="Submissions from Let's connect and contact forms. Newest first.">
         {!rows ? <SkeletonBlock /> : rows.length === 0 ? (
           <Empty>No demo requests yet.</Empty>
         ) : (
           <div style={{ overflowX: 'auto' }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, minWidth: 760 }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, minWidth: 920 }}>
               <thead>
                 <tr style={{ borderBottom: '1px solid #1f1f1f', color: '#737373', fontSize: 11, textTransform: 'uppercase' }}>
                   <Th>First name</Th>
                   <Th>Last name</Th>
                   <Th>Email</Th>
                   <Th>Company</Th>
+                  <Th>Role</Th>
+                  <Th>Source</Th>
                   <Th>Website</Th>
                   <Th align="right">Submitted</Th>
                 </tr>
@@ -832,6 +836,8 @@ function DemoRequestsSection({ token }: { token: string }) {
                     <Td>{r.last_name}</Td>
                     <Td mono>{r.email}</Td>
                     <Td>{r.company_name}</Td>
+                    <Td subtle>{r.position || '—'}</Td>
+                    <Td subtle>{r.source || '—'}</Td>
                     <Td>
                       <a href={r.website.startsWith('http') ? r.website : `https://${r.website}`}
                          target="_blank" rel="noreferrer"

--- a/dashboard/app/community/page.tsx
+++ b/dashboard/app/community/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 import { SiteNav } from '@/components/SiteNav'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
 import { BRAND } from '@/components/brand'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -165,6 +166,7 @@ export default function CommunityPage() {
           </div>
         )}
       </main>
+      <MarketingFooter />
     </div>
   )
 }

--- a/dashboard/app/docs/page.tsx
+++ b/dashboard/app/docs/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import { SiteNav } from '@/components/SiteNav'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
 import {
   OverviewSection,
   PythonSection,
@@ -141,6 +142,7 @@ export default function DocsPage() {
           {section === 'concepts' && <ConceptsSection onNavigate={navigate} />}
         </main>
       </div>
+      <MarketingFooter />
     </div>
   )
 }

--- a/dashboard/app/enterprise/page.tsx
+++ b/dashboard/app/enterprise/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { EnterprisePageClient } from '@/components/marketing/enterprise/EnterprisePageClient'
+
+export const metadata: Metadata = {
+  title: 'Enterprise — VPC deployment for agent fleets',
+  description:
+    'Licensed ZizkaDB in your VPC. Fleet observability, behavioral drift, audit exports, and Week-1 install — without rebuilding your agent platform.',
+  openGraph: {
+    title: 'ZizkaDB Enterprise — VPC deployment for agent fleets',
+    description:
+      'Licensed, single-tenant ZizkaDB in your cloud. Fleet dashboard, behavioral drift, audit export, and supported Week-1 install.',
+    type: 'website',
+  },
+}
+
+export default function EnterprisePage() {
+  return <EnterprisePageClient />
+}

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -9,7 +9,9 @@ import { CompetitorCompare } from '@/components/marketing/CompetitorCompare'
 import { ConversationCompare } from '@/components/marketing/ConversationCompare'
 import { ThreeWaysConnectSection } from '@/components/marketing/ThreeWaysConnectSection'
 import { TrustBar } from '@/components/marketing/TrustBar'
-import { BrandLogo } from '@/components/BrandLogo'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
+import { MarketingPageStyles } from '@/components/marketing/MarketingPageStyles'
+import { NewsletterPopup } from '@/components/marketing/NewsletterPopup'
 import { BRAND, BRAND_DARK } from '@/components/brand'
 import { M, container, h2, lead, sectionTitle, primaryBtn, blueBtn, violetBtn, ghostBtn, outlineBtn } from '@/components/marketing/marketing-theme'
 
@@ -41,26 +43,7 @@ export default function LandingPage() {
 
   return (
     <div style={{ fontFamily: 'Inter, system-ui, sans-serif', color: M.ink, background: '#fff' }}>
-      <style>{`
-        @media (max-width: 1024px) {
-          .zdb-connect-grid { grid-template-columns: 1fr !important; }
-        }
-        @media (max-width: 768px) {
-          .zdb-section { padding-left: 20px !important; padding-right: 20px !important; }
-          .zdb-hero-title { font-size: 32px !important; }
-          .zdb-hero-value { font-size: 16px !important; }
-          .zdb-connect-grid { grid-template-columns: 1fr !important; gap: 12px !important; }
-          .zdb-section { padding-top: 48px !important; padding-bottom: 48px !important; }
-          .zdb-compare-grid { grid-template-columns: 1fr !important; }
-          .zdb-split { grid-template-columns: 1fr !important; }
-          .zdb-price-grid { grid-template-columns: 1fr !important; }
-          .zdb-trust-grid { grid-template-columns: 1fr 1fr !important; }
-          .zdb-hero-btns { flex-direction: column !important; align-items: stretch !important; }
-          .zdb-hero-btns a, .zdb-hero-btns button { justify-content: center !important; }
-          .zdb-footer { flex-direction: column !important; gap: 16px !important; align-items: flex-start !important; }
-          .zdb-footer-links { flex-wrap: wrap !important; gap: 16px !important; }
-        }
-      `}</style>
+      <MarketingPageStyles />
 
       <SiteNav />
 
@@ -89,6 +72,7 @@ export default function LandingPage() {
           </div>
 
           <CalendlyBookModal open={demoOpen} onClose={() => setDemoOpen(false)} />
+          <NewsletterPopup />
 
           <p className="zdb-hero-value" style={{
             fontSize: 18, fontWeight: 600, color: '#000', margin: 0, lineHeight: 1.55, maxWidth: 520, marginInline: 'auto',
@@ -185,13 +169,13 @@ export default function LandingPage() {
               },
               {
                 name: 'Pro', price: '€39', sub: '/ month',
-                features: ['100M events', '90-day retention', '3 projects', 'Email support'],
+                features: ['100M events', '90-day retention', '3 active API keys', 'Email support'],
                 cta: 'Start free trial', href: '/signup?plan=pro', highlight: true,
                 note: '30-day free trial · No credit card required',
               },
               {
                 name: 'Team', price: '€99', sub: '/ month',
-                features: ['Up to 1B events/mo', '1-year retention', '10 seats', 'Priority support'],
+                features: ['Up to 1B events/mo', '1-year retention', '10 active API keys', 'Priority support'],
                 cta: 'Start free trial', href: '/signup?plan=team', highlight: false,
                 note: '30-day free trial · No credit card required',
               },
@@ -238,6 +222,11 @@ export default function LandingPage() {
               </div>
             ))}
           </div>
+          <p style={{ textAlign: 'center', marginTop: 28, marginBottom: 0, fontSize: 15, fontWeight: 600, color: '#000' }}>
+            <Link href="/enterprise" style={{ color: BRAND, textDecoration: 'none' }}>
+              Enterprise — Contact sales →
+            </Link>
+          </p>
         </div>
       </section>
 
@@ -263,29 +252,7 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* ── Footer ── */}
-      <footer className="zdb-footer" style={{
-        borderTop: `1px solid ${M.line}`, padding: '32px 24px',
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        fontSize: 13, color: '#000', background: '#fff', flexWrap: 'wrap', gap: 16,
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <BrandLogo variant="mark" showWordmark={false} href="/" />
-          <span style={{ fontWeight: 700, color: '#000' }}>ZizkaDB</span>
-          <span style={{ color: '#000' }}>·</span>
-          <span style={{ fontWeight: 500, color: '#000' }}>Open source operational database for AI agents</span>
-        </div>
-        <div className="zdb-footer-links" style={{ display: 'flex', gap: 22, flexWrap: 'wrap' }}>
-          {[['Docs', '/docs'], ['Pricing', '#pricing'], ['Trust', '/trust'], ['GitHub', GITHUB_URL], ['Sign in', '/login']].map(([label, href]) =>
-            href.startsWith('http') ? (
-              <a key={label} href={href} target="_blank" rel="noreferrer" style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>{label}</a>
-            ) : (
-              <Link key={label} href={href} style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>{label}</Link>
-            )
-          )}
-          <Link href="/signup" style={{ color: '#000', fontWeight: 700, textDecoration: 'none' }}>Start free</Link>
-        </div>
-      </footer>
+      <MarketingFooter />
     </div>
   )
 }

--- a/dashboard/app/signup/page.tsx
+++ b/dashboard/app/signup/page.tsx
@@ -17,6 +17,7 @@ import {
   hasSignupConsent,
   SIGNUP_CONSENT_MARKETING_KEY,
   SIGNUP_PLAN_KEY,
+  SIGNUP_PROMO_KEY,
 } from '@/lib/signup-funnel'
 import { BrandLogo } from '@/components/BrandLogo'
 
@@ -56,6 +57,7 @@ function SignupForm() {
   // Prevents the email screen from flashing before a redirect to /signup/plan
   // or /signup/start resolves. Monotonic: only ever set true.
   const [checked, setChecked] = useState(false)
+  const [promoCode, setPromoCode] = useState<string | undefined>()
 
   useEffect(() => {
     // Always start from email step when entering /signup to avoid stale OTP view.
@@ -67,6 +69,15 @@ function SignupForm() {
     const planParam = searchParams.get('plan')
     if (planParam === 'pro' || planParam === 'team') {
       sessionStorage.setItem(SIGNUP_PLAN_KEY, planParam)
+    }
+
+    const promo = searchParams.get('promo')
+    if (promo) {
+      setPromoCode(promo.trim())
+      sessionStorage.setItem(SIGNUP_PROMO_KEY, promo.trim())
+    } else {
+      const storedPromo = sessionStorage.getItem(SIGNUP_PROMO_KEY)
+      if (storedPromo) setPromoCode(storedPromo)
     }
 
     const stored = getStoredSignupPlan()
@@ -144,6 +155,7 @@ function SignupForm() {
         intent: 'signup',
         gdprConsent,
         marketingConsent,
+        promoCode,
       })
       const plan = getStoredSignupPlan()
       setToken(data.access_token)

--- a/dashboard/app/signup/plan/page.tsx
+++ b/dashboard/app/signup/plan/page.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import { useState } from 'react'
-import { useRouter } from 'next/navigation'
+import { Suspense, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
 import { BrandLogo } from '@/components/BrandLogo'
-import { SIGNUP_PLAN_KEY } from '@/lib/signup-funnel'
+import { SIGNUP_PLAN_KEY, SIGNUP_PROMO_KEY } from '@/lib/signup-funnel'
 
 const BRAND = '#f97316'
 
@@ -14,7 +14,7 @@ const PLANS = [
     price: '€39',
     price_sub: '/ month',
     highlight: true,
-    features: ['100M events', '90-day retention', '3 projects', 'Email support'],
+    features: ['100M events', '90-day retention', '3 active API keys', 'Email support'],
   },
   {
     id: 'team' as const,
@@ -22,13 +22,29 @@ const PLANS = [
     price: '€99',
     price_sub: '/ month',
     highlight: false,
-    features: ['Up to 1B events/mo', '1-year retention', '10 seats', 'Priority support'],
+    features: ['Up to 1B events/mo', '1-year retention', '10 active API keys', 'Priority support'],
   },
 ]
 
 export default function SignupPlanPage() {
+  return (
+    <Suspense fallback={null}>
+      <SignupPlanInner />
+    </Suspense>
+  )
+}
+
+function SignupPlanInner() {
   const router = useRouter()
+  const searchParams = useSearchParams()
   const [selected, setSelected] = useState<'pro' | 'team'>('pro')
+
+  useEffect(() => {
+    const promo = searchParams.get('promo')
+    if (promo && typeof window !== 'undefined') {
+      sessionStorage.setItem(SIGNUP_PROMO_KEY, promo.trim())
+    }
+  }, [searchParams])
 
   function handleContinue() {
     if (typeof window !== 'undefined') {

--- a/dashboard/app/trust/page.tsx
+++ b/dashboard/app/trust/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import type { CSSProperties, ReactNode } from 'react'
 import { SiteNav } from '@/components/SiteNav'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
 
 export const metadata = {
   title: 'Technical reference',
@@ -274,7 +275,8 @@ docker compose -f infra/docker-compose.yml up -d`}</Code>
               <li><strong>Telemetry:</strong> one anonymous SDK/MCP startup ping — opt out with <code style={codeInline}>ZIZKADB_TELEMETRY=false</code>.</li>
             </ul>
             <p style={p}>
-              <strong>Not claimed today:</strong> SOC 2, HIPAA, or formal DPAs. For enterprise security review, contact{' '}
+              <strong>Not claimed today:</strong> SOC 2, HIPAA, or formal DPAs. For enterprise security review and VPC deployment, see{' '}
+              <Link href="/enterprise" style={link}>/enterprise</Link> or contact{' '}
               <a href="mailto:founder@zizka.ai" style={link}>founder@zizka.ai</a>.
             </p>
           </Section>
@@ -377,6 +379,7 @@ chain = await db.why(tool.event_id)`}</Code>
                   ['Self-hosted', 'Free (AGPL core)', 'Your VPC / machine'],
                   ['Managed Pro', '€39/mo', 'Zizka cloud'],
                   ['Managed Team', '€99/mo', 'Zizka cloud + higher limits'],
+                  ['Enterprise', 'Contact sales', 'Customer VPC (Model A)'],
                 ].map(([m, c, d]) => (
                   <tr key={m}><td style={td}>{m}</td><td style={td}>{c}</td><td style={td}>{d}</td></tr>
                 ))}
@@ -384,6 +387,7 @@ chain = await db.why(tool.event_id)`}</Code>
             </table>
             <p style={p}>
               Onboarding: <Link href="/signup" style={link}>signup</Link> → email OTP → Settings → API key → SDK or MCP env.
+              For Enterprise VPC deployment, see <Link href="/enterprise" style={link}>/enterprise</Link>.
             </p>
           </Section>
 
@@ -444,6 +448,7 @@ chain = await db.why(tool.event_id)`}</Code>
             </table>
             <p style={p}>
               AGPL applies when you modify and distribute the server. MCP is MIT for IDE integration. Commercial embedding requires legal review.
+              Enterprise VPC deployments use a separate commercial license — see <Link href="/enterprise" style={link}>/enterprise</Link>.
             </p>
           </Section>
 
@@ -455,6 +460,7 @@ chain = await db.why(tool.event_id)`}</Code>
                   ['Self-hosted', 'Unlimited (your hardware)', 'Operator-defined'],
                   ['Pro (€39/mo)', '100M', '90 days'],
                   ['Team (€99/mo)', 'Up to 1B (plan cap)', '1 year'],
+                  ['Enterprise', 'Contact sales', 'Custom (VPC)'],
                 ].map(([plan, ev, ret]) => (
                   <tr key={plan}><td style={td}>{plan}</td><td style={td}>{ev}</td><td style={td}>{ret}</td></tr>
                 ))}
@@ -530,6 +536,8 @@ chain = await db.why(tool.event_id)`}</Code>
           </Section>
         </main>
       </div>
+
+      <MarketingFooter />
 
       <style>{`
         @media (min-width: 900px) {

--- a/dashboard/components/SiteNav.tsx
+++ b/dashboard/components/SiteNav.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from 'react'
 import { BrandLogo } from './BrandLogo'
 import { brandCtaStyle } from './brand'
 
-export type SiteNavActive = 'docs' | 'community' | 'trust' | 'explorer' | 'home'
+export type SiteNavActive = 'docs' | 'community' | 'trust' | 'explorer' | 'home' | 'enterprise'
 
 type SiteNavProps = {
   active?: SiteNavActive
@@ -13,9 +13,20 @@ type SiteNavProps = {
 
 const linkStyle = (on: boolean): CSSProperties => ({
   fontSize: 14,
-  color: on ? '#000' : '#000',
+  color: '#000',
   fontWeight: on ? 600 : 400,
   textDecoration: 'none',
+})
+
+const enterpriseLinkStyle = (on: boolean): CSSProperties => ({
+  fontSize: 14,
+  fontWeight: 600,
+  color: '#000',
+  textDecoration: 'none',
+  padding: '6px 12px',
+  borderRadius: 8,
+  border: '1px solid #e2e8f0',
+  background: on ? '#f8fafc' : 'transparent',
 })
 
 export function SiteNav({ active, suffix }: SiteNavProps) {
@@ -41,6 +52,7 @@ export function SiteNav({ active, suffix }: SiteNavProps) {
         <Link href="/docs" style={linkStyle(active === 'docs')}>Docs</Link>
         <Link href="/community" style={linkStyle(active === 'community')}>Community</Link>
         <a href="/swagger" style={linkStyle(active === 'explorer')}>API Explorer</a>
+        <Link href="/enterprise" style={enterpriseLinkStyle(active === 'enterprise')}>Enterprise</Link>
         <Link href="/login" style={{
           fontSize: 14, fontWeight: 500, color: '#000', textDecoration: 'none',
           padding: '7px 16px', border: '1px solid #ddd', borderRadius: 8,
@@ -51,6 +63,12 @@ export function SiteNav({ active, suffix }: SiteNavProps) {
       </div>
 
       <div className="site-nav-cta" style={{ display: 'none', alignItems: 'center', gap: 8 }}>
+        <Link href="/enterprise" style={{
+          fontSize: 13, fontWeight: 600, color: '#111', textDecoration: 'none',
+          padding: '6px 10px', border: '1px solid #e2e8f0', borderRadius: 8,
+        }}>
+          Enterprise
+        </Link>
         <Link href="/login" style={{
           fontSize: 13, fontWeight: 500, color: '#111', textDecoration: 'none',
           padding: '6px 12px', border: '1px solid #ddd', borderRadius: 8,
@@ -59,7 +77,6 @@ export function SiteNav({ active, suffix }: SiteNavProps) {
         </Link>
         <Link href="/signup" style={{ ...brandCtaStyle, fontSize: 13, padding: '6px 14px' }}>Start free →</Link>
       </div>
-
     </nav>
   )
 }

--- a/dashboard/components/marketing/MarketingFooter.tsx
+++ b/dashboard/components/marketing/MarketingFooter.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+import { BrandLogo } from '@/components/BrandLogo'
+
+const GITHUB_URL = 'https://github.com/Zizka-ai/ZizkaDB'
+
+const LINKS: [string, string][] = [
+  ['Docs', '/docs'],
+  ['Enterprise', '/enterprise'],
+  ['Pricing', '/#pricing'],
+  ['Trust', '/trust'],
+  ['GitHub', GITHUB_URL],
+  ['Sign in', '/login'],
+]
+
+export function MarketingFooter() {
+  return (
+    <footer
+      className="zdb-footer"
+      style={{
+        borderTop: '1px solid #e2e8f0',
+        padding: '32px 24px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        fontSize: 13,
+        color: '#000',
+        background: '#fff',
+        flexWrap: 'wrap',
+        gap: 16,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <BrandLogo variant="mark" showWordmark={false} href="/" />
+        <span style={{ fontWeight: 700, color: '#000' }}>ZizkaDB</span>
+        <span style={{ color: '#000' }}>·</span>
+        <span style={{ fontWeight: 500, color: '#000' }}>Open source operational database for AI agents</span>
+      </div>
+      <div className="zdb-footer-links" style={{ display: 'flex', gap: 22, flexWrap: 'wrap' }}>
+        {LINKS.map(([label, href]) =>
+          href.startsWith('http') ? (
+            <a
+              key={label}
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}
+            >
+              {label}
+            </a>
+          ) : (
+            <Link key={label} href={href} style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>
+              {label}
+            </Link>
+          ),
+        )}
+        <Link href="/signup" style={{ color: '#000', fontWeight: 700, textDecoration: 'none' }}>
+          Start free
+        </Link>
+      </div>
+    </footer>
+  )
+}

--- a/dashboard/components/marketing/MarketingPageStyles.tsx
+++ b/dashboard/components/marketing/MarketingPageStyles.tsx
@@ -1,0 +1,44 @@
+export function MarketingPageStyles() {
+  return (
+    <style>{`
+      .zdb-section-anchor {
+        scroll-margin-top: 72px;
+      }
+      .zdb-faq-summary::-webkit-details-marker {
+        display: none;
+      }
+      .zdb-faq-summary:focus-visible {
+        outline: 2px solid #f97316;
+        outline-offset: -2px;
+      }
+      .zdb-connect-submit:focus-visible {
+        outline: 2px solid #f97316;
+        outline-offset: 2px;
+      }
+      @media (max-width: 1024px) {
+        .zdb-connect-grid { grid-template-columns: 1fr !important; }
+        .zdb-feature-grid { grid-template-columns: repeat(2, 1fr) !important; }
+      }
+      @media (max-width: 768px) {
+        .site-nav-links { display: none !important; }
+        .site-nav-cta { display: flex !important; }
+        .zdb-section { padding-left: 20px !important; padding-right: 20px !important; }
+        .zdb-hero-title { font-size: 32px !important; }
+        .zdb-hero-value { font-size: 16px !important; }
+        .zdb-connect-grid { grid-template-columns: 1fr !important; gap: 12px !important; }
+        .zdb-section { padding-top: 48px !important; padding-bottom: 48px !important; }
+        .zdb-compare-grid { grid-template-columns: 1fr !important; }
+        .zdb-split { grid-template-columns: 1fr !important; }
+        .zdb-price-grid { grid-template-columns: 1fr !important; }
+        .zdb-tier-grid { grid-template-columns: 1fr !important; }
+        .zdb-trust-grid { grid-template-columns: 1fr 1fr !important; }
+        .zdb-feature-grid { grid-template-columns: 1fr !important; }
+        .zdb-resource-grid { grid-template-columns: 1fr 1fr !important; }
+        .zdb-hero-btns { flex-direction: column !important; align-items: stretch !important; }
+        .zdb-hero-btns a, .zdb-hero-btns button { justify-content: center !important; }
+        .zdb-footer { flex-direction: column !important; gap: 16px !important; align-items: flex-start !important; }
+        .zdb-footer-links { flex-wrap: wrap !important; gap: 16px !important; }
+      }
+    `}</style>
+  )
+}

--- a/dashboard/components/marketing/NewsletterPopup.tsx
+++ b/dashboard/components/marketing/NewsletterPopup.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { subscribeNewsletter } from '@/lib/api'
+
+const DISMISS_KEY = 'zdb_newsletter_dismissed_until'
+const DISMISS_DAYS = 7
+const SHOW_DELAY_MS = 15000
+const NEWSLETTER_ENABLED = process.env.NEXT_PUBLIC_NEWSLETTER_ENABLED === 'true'
+
+export function NewsletterPopup() {
+  const [visible, setVisible] = useState(false)
+  const [email, setEmail] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [message, setMessage] = useState('')
+  const [error, setError] = useState('')
+
+  useEffect(() => {
+    if (!NEWSLETTER_ENABLED) return
+    if (typeof window === 'undefined') return
+    const until = localStorage.getItem(DISMISS_KEY)
+    if (until && Date.now() < Number(until)) return
+
+    const timer = window.setTimeout(() => setVisible(true), SHOW_DELAY_MS)
+    return () => window.clearTimeout(timer)
+  }, [])
+
+  function dismiss() {
+    const until = Date.now() + DISMISS_DAYS * 86400000
+    localStorage.setItem(DISMISS_KEY, String(until))
+    setVisible(false)
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    setMessage('')
+    try {
+      const res = await subscribeNewsletter(email)
+      setMessage(res.message)
+      if (!res.already_subscribed) {
+        setTimeout(dismiss, 2500)
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not subscribe')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!NEWSLETTER_ENABLED || !visible) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="newsletter-title"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 9999,
+        background: 'rgba(0,0,0,0.45)',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 16,
+      }}
+      onClick={dismiss}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: '#fff',
+          borderRadius: 16,
+          padding: '28px 24px',
+          maxWidth: 420,
+          width: '100%',
+          boxShadow: '0 20px 60px rgba(0,0,0,0.2)',
+          fontFamily: 'Inter, system-ui, sans-serif',
+        }}
+      >
+        <button
+          type="button"
+          onClick={dismiss}
+          aria-label="Close"
+          style={{
+            float: 'right',
+            border: 'none',
+            background: 'transparent',
+            fontSize: 20,
+            cursor: 'pointer',
+            color: '#888',
+            lineHeight: 1,
+          }}
+        >
+          ×
+        </button>
+        <h2 id="newsletter-title" style={{ fontSize: 20, fontWeight: 700, color: '#111', margin: '0 0 8px' }}>
+          Stay updated with the latest in Agentic AI
+        </h2>
+        <p style={{ fontSize: 14, color: '#555', lineHeight: 1.6, margin: '0 0 20px' }}>
+          Get product updates, AI engineering insights, tutorials, and new feature announcements directly in your inbox.
+        </p>
+        <form onSubmit={handleSubmit}>
+          <input
+            type="email"
+            required
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@company.com"
+            style={{
+              width: '100%',
+              padding: '11px 12px',
+              borderRadius: 8,
+              border: '1px solid #ddd',
+              fontSize: 14,
+              marginBottom: 10,
+              boxSizing: 'border-box',
+            }}
+          />
+          <input type="text" name="botcheck" tabIndex={-1} autoComplete="off" style={{ display: 'none' }} />
+          <button
+            type="submit"
+            disabled={loading}
+            style={{
+              width: '100%',
+              padding: '11px',
+              borderRadius: 8,
+              border: 'none',
+              background: '#111',
+              color: '#fff',
+              fontWeight: 600,
+              fontSize: 14,
+              cursor: loading ? 'wait' : 'pointer',
+              opacity: loading ? 0.7 : 1,
+            }}
+          >
+            {loading ? 'Subscribing…' : 'Subscribe'}
+          </button>
+        </form>
+        {message && <p style={{ color: '#16a34a', fontSize: 13, marginTop: 12 }}>{message}</p>}
+        {error && <p style={{ color: '#ef4444', fontSize: 13, marginTop: 12 }}>{error}</p>}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseCapabilitiesSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseCapabilitiesSection.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties } from 'react'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+const th: CSSProperties = {
+  textAlign: 'left',
+  padding: '10px 14px',
+  fontSize: 12,
+  fontWeight: 700,
+  color: '#666',
+  borderBottom: `1px solid ${M.line}`,
+  background: M.wash,
+}
+
+const td: CSSProperties = {
+  padding: '12px 14px',
+  fontSize: 14,
+  color: '#000',
+  fontWeight: 500,
+  borderBottom: `1px solid ${M.line}`,
+  verticalAlign: 'top',
+}
+
+export function EnterpriseCapabilitiesSection() {
+  const { capabilities } = COPY
+
+  return (
+    <section id="capabilities" className="zdb-section zdb-section-anchor" style={{ padding: '88px 40px', background: M.wash, scrollMarginTop: 72 }}>
+      <div style={container(1000)}>
+        <p style={sectionTitle}>{capabilities.sectionTitle}</p>
+        <h2 style={h2}>{capabilities.h2}</h2>
+        <p style={lead}>{capabilities.lead}</p>
+
+        <div className="zdb-split" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, marginTop: 36 }}>
+          <div style={{ ...card, padding: '24px 22px' }}>
+            <h3 style={{ fontSize: 18, fontWeight: 700, margin: '0 0 6px', color: '#000' }}>
+              {capabilities.openCore.title}
+            </h3>
+            <p style={{ fontSize: 13, color: '#666', margin: '0 0 18px', fontWeight: 500 }}>
+              {capabilities.openCore.subtitle}
+            </p>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th style={th}>Capability</th>
+                  <th style={th}>API / concept</th>
+                </tr>
+              </thead>
+              <tbody>
+                {capabilities.openCore.rows.map(([cap, api]) => (
+                  <tr key={cap}>
+                    <td style={{ ...td, fontWeight: 600 }}>{cap}</td>
+                    <td style={{ ...td, fontFamily: 'ui-monospace, monospace', fontSize: 13 }}>{api}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{
+            ...card, padding: '24px 22px', border: `2px solid ${BRAND}`,
+            boxShadow: '0 12px 40px rgba(249,115,22,0.08)',
+          }}>
+            <h3 style={{ fontSize: 18, fontWeight: 700, margin: '0 0 18px', color: '#000' }}>
+              {capabilities.enterprise.title}
+            </h3>
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {capabilities.enterprise.items.map((item) => (
+                <li key={item} style={{ fontSize: 14, color: '#000', fontWeight: 500, display: 'flex', gap: 8 }}>
+                  <span style={{ color: BRAND, fontWeight: 800 }}>✓</span> {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <p style={{
+          marginTop: 24, marginBottom: 0, fontSize: 13, lineHeight: 1.6, fontWeight: 500, color: '#666',
+        }}>
+          {capabilities.footnote}
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseConnectForm.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseConnectForm.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useState, type FormEvent } from 'react'
+import { COPY } from './enterprise-copy'
+import { submitDemoRequest } from '@/lib/demo'
+import { M } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+const inputStyle = {
+  width: '100%',
+  padding: '11px 14px',
+  borderRadius: 10,
+  border: `1px solid ${M.line}`,
+  fontSize: 14,
+  fontFamily: 'inherit',
+  boxSizing: 'border-box' as const,
+}
+
+const labelStyle = {
+  display: 'block',
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#000',
+  marginBottom: 6,
+}
+
+type Props = {
+  id?: string
+}
+
+export function EnterpriseConnectForm({ id }: Props) {
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [email, setEmail] = useState('')
+  const [company, setCompany] = useState('')
+  const [position, setPosition] = useState('')
+  const [website, setWebsite] = useState('')
+  const [botcheck, setBotcheck] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (botcheck) return
+    setLoading(true)
+    setError('')
+    try {
+      await submitDemoRequest({
+        first_name: firstName.trim(),
+        last_name: lastName.trim(),
+        email: email.trim(),
+        company_name: company.trim(),
+        website: website.trim(),
+        position: position.trim() || undefined,
+        source: 'enterprise',
+      })
+      setSuccess(true)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : COPY.form.genericError
+      setError(msg.includes('Too many') ? COPY.form.rateLimit : msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (success) {
+    return (
+      <div
+        id={id}
+        role="status"
+        aria-live="polite"
+        style={{
+          padding: '24px', borderRadius: 14, background: '#fff', border: `1px solid ${M.line}`,
+          textAlign: 'center', fontSize: 15, fontWeight: 600, color: '#000',
+        }}
+      >
+        {COPY.form.success}
+      </div>
+    )
+  }
+
+  return (
+    <form
+      id={id}
+      onSubmit={handleSubmit}
+      className="zdb-connect-form"
+      style={{
+        position: 'relative',
+        padding: '24px', borderRadius: 14, background: '#fff', border: `1px solid ${M.line}`,
+        display: 'flex', flexDirection: 'column', gap: 14, textAlign: 'left',
+      }}
+    >
+      <div className="zdb-split" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+        <div>
+          <label htmlFor="ent-first" style={labelStyle}>First name</label>
+          <input id="ent-first" required value={firstName} onChange={(e) => setFirstName(e.target.value)} style={inputStyle} />
+        </div>
+        <div>
+          <label htmlFor="ent-last" style={labelStyle}>Last name</label>
+          <input id="ent-last" required value={lastName} onChange={(e) => setLastName(e.target.value)} style={inputStyle} />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="ent-email" style={labelStyle}>Work email</label>
+        <input id="ent-email" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} style={inputStyle} />
+      </div>
+      <div>
+        <label htmlFor="ent-company" style={labelStyle}>Company</label>
+        <input id="ent-company" required value={company} onChange={(e) => setCompany(e.target.value)} style={inputStyle} />
+      </div>
+      <div>
+        <label htmlFor="ent-position" style={labelStyle}>Role / title (optional)</label>
+        <input id="ent-position" value={position} onChange={(e) => setPosition(e.target.value)} style={inputStyle} />
+      </div>
+      <div>
+        <label htmlFor="ent-website" style={labelStyle}>Company website</label>
+        <input id="ent-website" required value={website} onChange={(e) => setWebsite(e.target.value)} placeholder={COPY.form.websiteHint} style={inputStyle} />
+      </div>
+      <input
+        type="text"
+        name="botcheck"
+        value={botcheck}
+        onChange={(e) => setBotcheck(e.target.value)}
+        tabIndex={-1}
+        autoComplete="off"
+        aria-hidden="true"
+        style={{ position: 'absolute', left: '-9999px', opacity: 0, height: 0, width: 0 }}
+      />
+      {error && (
+        <p style={{ margin: 0, fontSize: 13, color: '#b91c1c', fontWeight: 600 }} role="alert">{error}</p>
+      )}
+      <button
+        type="submit"
+        disabled={loading}
+        className="zdb-connect-submit"
+        style={{
+          marginTop: 4, padding: '13px 20px', borderRadius: 10, border: 'none', cursor: loading ? 'wait' : 'pointer',
+          background: `linear-gradient(135deg, ${BRAND} 0%, #ea580c 100%)`, color: '#fff',
+          fontWeight: 700, fontSize: 15, opacity: loading ? 0.7 : 1,
+        }}
+      >
+        {loading ? 'Sending…' : "Let's connect"}
+      </button>
+    </form>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseFaqSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseFaqSection.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+export function EnterpriseFaqSection() {
+  return (
+    <section id="faq" className="zdb-section zdb-section-anchor" style={{ padding: '88px 40px', background: '#fff', scrollMarginTop: 72 }}>
+      <div style={container(760)}>
+        <p style={sectionTitle}>{COPY.faq.sectionTitle}</p>
+        <h2 style={h2}>{COPY.faq.h2}</h2>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 36 }}>
+          {COPY.faq.items.map((item) => (
+            <details key={item.q} className="zdb-faq-details" style={{ ...card, padding: 0, overflow: 'hidden' }}>
+              <summary className="zdb-faq-summary" style={{
+                padding: '18px 20px', cursor: 'pointer', fontSize: 15, fontWeight: 700, color: '#000',
+                listStyle: 'none',
+              }}>
+                {item.q}
+              </summary>
+              <div style={{
+                padding: '0 20px 18px', fontSize: 14, lineHeight: 1.65, color: '#000', fontWeight: 500,
+                borderTop: `1px solid ${M.line}`,
+              }}>
+                {item.a}
+                {'link' in item && item.link && (
+                  <>
+                    {' '}
+                    <Link href={item.link.href} style={{ color: BRAND, textDecoration: 'none', fontWeight: 600 }}>
+                      {item.link.label} →
+                    </Link>
+                  </>
+                )}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseFleetSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseFleetSection.tsx
@@ -1,0 +1,72 @@
+import dynamic from 'next/dynamic'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+const SessionReplayDemo = dynamic(
+  () => import('../SessionReplayDemo').then((m) => m.SessionReplayDemo),
+  {
+    ssr: false,
+    loading: () => (
+      <div style={{
+        height: 320, borderRadius: 16, background: M.wash, border: `1px solid ${M.line}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#666', fontSize: 14,
+      }}>
+        Loading preview…
+      </div>
+    ),
+  },
+)
+
+export function EnterpriseFleetSection() {
+  const { driftBands } = COPY.fleet
+
+  return (
+    <section id="fleet" className="zdb-section zdb-section-anchor" style={{ padding: '88px 40px', background: '#fff', scrollMarginTop: 72 }}>
+      <div style={container(980)}>
+        <p style={sectionTitle}>{COPY.fleet.sectionTitle}</p>
+        <h2 style={h2}>{COPY.fleet.h2}</h2>
+        <p style={lead}>{COPY.fleet.lead}</p>
+
+        <div className="zdb-split" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 32, alignItems: 'start' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {COPY.fleet.bullets.map((b) => (
+              <div key={b.title} style={{ ...card, padding: '20px 22px' }}>
+                <div style={{ fontSize: 15, fontWeight: 700, color: '#000', marginBottom: 6 }}>{b.title}</div>
+                <div style={{ fontSize: 14, color: '#000', lineHeight: 1.6, fontWeight: 500 }}>{b.body}</div>
+              </div>
+            ))}
+            <div style={{
+              padding: '16px 18px', borderRadius: 12, background: '#fff7ed',
+              border: `1px solid ${BRAND}44`, fontSize: 13, lineHeight: 1.6, fontWeight: 500, color: '#000',
+            }}>
+              {COPY.fleet.driftNote}
+            </div>
+            <div style={{ ...card, padding: '18px 20px' }}>
+              <div style={{ fontSize: 14, fontWeight: 700, color: '#000', marginBottom: 10 }}>{driftBands.title}</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 12 }}>
+                {driftBands.bands.map((b) => (
+                  <span key={b.label} style={{
+                    fontSize: 12, fontWeight: 600, padding: '5px 10px', borderRadius: 8,
+                    background: M.wash, border: `1px solid ${M.line}`, color: '#000',
+                  }}>
+                    {b.label} · {b.range}
+                  </span>
+                ))}
+              </div>
+              <p style={{ margin: 0, fontSize: 13, lineHeight: 1.55, color: '#666', fontWeight: 500 }}>
+                {driftBands.requirement}
+              </p>
+            </div>
+          </div>
+          <div>
+            <SessionReplayDemo />
+            <p style={{ textAlign: 'center', fontSize: 12, color: '#666', marginTop: 12, fontWeight: 500 }}>
+              {COPY.fleet.demoCaption}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseFooterCtaSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseFooterCtaSection.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import { COPY } from './enterprise-copy'
+import { EnterpriseConnectForm } from './EnterpriseConnectForm'
+import { M, container, ghostBtn, violetBtn } from '../marketing-theme'
+
+type Props = {
+  onBookDemo: () => void
+}
+
+export function EnterpriseFooterCtaSection({ onBookDemo }: Props) {
+  return (
+    <section
+      id="connect"
+      className="zdb-section"
+      style={{
+        padding: '88px 40px',
+        background: M.heroBg,
+        position: 'relative',
+        overflow: 'hidden',
+        scrollMarginTop: 72,
+      }}
+    >
+      <div style={{ position: 'absolute', inset: 0, background: M.heroGlowBlue, pointerEvents: 'none' }} />
+      <div style={{ ...container(640), position: 'relative', zIndex: 1, textAlign: 'center' }}>
+        <h2 style={{ fontSize: 32, fontWeight: 700, color: '#fff', margin: '0 0 12px', letterSpacing: -0.5 }}>
+          {COPY.footerCta.h2}
+        </h2>
+        <p style={{ fontSize: 16, color: 'rgba(255,255,255,0.88)', margin: '0 0 28px', lineHeight: 1.65, fontWeight: 500 }}>
+          {COPY.footerCta.subhead}
+        </p>
+
+        <EnterpriseConnectForm />
+
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap', marginTop: 24 }}>
+          <button type="button" onClick={onBookDemo} style={{ ...violetBtn, cursor: 'pointer', border: 'none' }}>
+            {COPY.footerCta.demoCta}
+          </button>
+          <Link href="/signup" style={ghostBtn}>{COPY.footerCta.cloudCta}</Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseHeroSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseHeroSection.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { COPY } from './enterprise-copy'
+import { M, primaryBtn, violetBtn } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+type Props = {
+  onConnectClick: () => void
+  onBookDemo: () => void
+}
+
+export function EnterpriseHeroSection({ onConnectClick, onBookDemo }: Props) {
+  return (
+    <section
+      className="zdb-section"
+      style={{
+        padding: '80px 40px 72px',
+        background: M.heroBg,
+        position: 'relative',
+        overflow: 'hidden',
+        color: '#fff',
+      }}
+    >
+      <div style={{ position: 'absolute', inset: 0, background: M.heroGlowOrange, pointerEvents: 'none' }} />
+      <div style={{ position: 'absolute', inset: 0, background: M.heroGlowBlue, pointerEvents: 'none' }} />
+      <div style={{ maxWidth: 760, margin: '0 auto', textAlign: 'center', position: 'relative', zIndex: 1 }}>
+        <div style={{
+          display: 'inline-block', marginBottom: 20, padding: '6px 14px', borderRadius: 100,
+          fontSize: 11, fontWeight: 700, letterSpacing: 0.8,
+          background: 'rgba(249,115,22,0.15)', border: '1px solid rgba(249,115,22,0.35)', color: BRAND,
+        }}>
+          {COPY.hero.eyebrow}
+        </div>
+        <h1 className="zdb-hero-title" style={{
+          fontSize: 44, fontWeight: 800, lineHeight: 1.12, margin: '0 0 20px', letterSpacing: -0.8,
+        }}>
+          {COPY.hero.h1}
+        </h1>
+        <p className="zdb-hero-value" style={{
+          fontSize: 18, fontWeight: 500, lineHeight: 1.65, margin: '0 auto 32px', maxWidth: 620,
+          color: 'rgba(255,255,255,0.88)',
+        }}>
+          {COPY.hero.subhead}
+        </p>
+        <div className="zdb-hero-btns" style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <button type="button" onClick={onConnectClick} style={{ ...primaryBtn, cursor: 'pointer', border: 'none' }}>
+            {COPY.hero.connectCta}
+          </button>
+          <button type="button" onClick={onBookDemo} style={{ ...violetBtn, cursor: 'pointer' }}>
+            {COPY.hero.demoCta}
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterprisePageClient.tsx
+++ b/dashboard/components/marketing/enterprise/EnterprisePageClient.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { SiteNav } from '@/components/SiteNav'
+import { CalendlyBookModal } from '@/components/marketing/CalendlyBookModal'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
+import { MarketingPageStyles } from '@/components/marketing/MarketingPageStyles'
+import { EnterpriseHeroSection } from './EnterpriseHeroSection'
+import { EnterpriseWhatIsSection } from './EnterpriseWhatIsSection'
+import { EnterpriseFleetSection } from './EnterpriseFleetSection'
+import { EnterpriseCapabilitiesSection } from './EnterpriseCapabilitiesSection'
+import { EnterpriseTierCompareSection } from './EnterpriseTierCompareSection'
+import { EnterpriseVpcDeploySection } from './EnterpriseVpcDeploySection'
+import { EnterprisePlatformFeaturesSection } from './EnterprisePlatformFeaturesSection'
+import { EnterpriseFaqSection } from './EnterpriseFaqSection'
+import { EnterpriseFooterCtaSection } from './EnterpriseFooterCtaSection'
+import { EnterpriseResourcesStrip } from './EnterpriseResourcesStrip'
+import { M } from '../marketing-theme'
+
+export function EnterprisePageClient() {
+  const [demoOpen, setDemoOpen] = useState(false)
+
+  const scrollToConnect = useCallback(() => {
+    document.getElementById('connect')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    window.setTimeout(() => {
+      document.getElementById('ent-first')?.focus()
+    }, 400)
+  }, [])
+
+  return (
+    <div style={{ fontFamily: 'Inter, system-ui, sans-serif', color: M.ink, background: '#fff', minHeight: '100vh' }}>
+      <MarketingPageStyles />
+      <SiteNav active="enterprise" suffix="Enterprise" />
+
+      <main>
+        <EnterpriseHeroSection onConnectClick={scrollToConnect} onBookDemo={() => setDemoOpen(true)} />
+        <EnterpriseWhatIsSection />
+        <EnterpriseFleetSection />
+        <EnterpriseCapabilitiesSection />
+        <EnterpriseTierCompareSection onConnectClick={scrollToConnect} />
+        <EnterpriseVpcDeploySection />
+        <EnterprisePlatformFeaturesSection />
+        <EnterpriseFaqSection />
+        <EnterpriseFooterCtaSection onBookDemo={() => setDemoOpen(true)} />
+        <EnterpriseResourcesStrip />
+      </main>
+
+      <CalendlyBookModal open={demoOpen} onClose={() => setDemoOpen(false)} />
+      <MarketingFooter />
+    </div>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterprisePlatformFeaturesSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterprisePlatformFeaturesSection.tsx
@@ -1,0 +1,33 @@
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+export function EnterprisePlatformFeaturesSection() {
+  return (
+    <section className="zdb-section" style={{ padding: '88px 40px', background: M.wash }}>
+      <div style={container(1000)}>
+        <p style={sectionTitle}>{COPY.platform.sectionTitle}</p>
+        <h2 style={h2}>{COPY.platform.h2}</h2>
+        <p style={lead}>{COPY.platform.lead}</p>
+
+        <div className="zdb-feature-grid" style={{
+          display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, marginBottom: 24,
+        }}>
+          {COPY.platform.features.map((f) => (
+            <div key={f.title} style={{ ...card, padding: '22px 20px' }}>
+              <div style={{ fontSize: 15, fontWeight: 700, color: '#000', marginBottom: 8 }}>{f.title}</div>
+              <div style={{ fontSize: 13.5, lineHeight: 1.6, color: '#000', fontWeight: 500 }}>{f.body}</div>
+            </div>
+          ))}
+        </div>
+
+        <p style={{
+          textAlign: 'center', fontSize: 13, color: '#000', fontWeight: 500, lineHeight: 1.6,
+          maxWidth: 640, margin: '0 auto',
+        }}>
+          {COPY.platform.footnote}
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseResourcesStrip.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseResourcesStrip.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { TECHNICAL_LINKS } from './enterprise-copy'
+import { M, container, sectionTitle, card } from '../marketing-theme'
+
+export function EnterpriseResourcesStrip() {
+  return (
+    <section className="zdb-section" style={{ padding: '64px 40px 88px', background: '#fff', borderTop: `1px solid ${M.line}` }}>
+      <div style={container(1000)}>
+        <p style={sectionTitle}>Technical resources</p>
+        <h2 style={{ fontSize: 24, fontWeight: 700, textAlign: 'center', margin: '0 0 28px', color: '#000' }}>
+          For engineering and security review
+        </h2>
+        <div className="zdb-resource-grid" style={{
+          display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12,
+        }}>
+          {TECHNICAL_LINKS.map((link) => {
+            const inner = (
+              <>
+                <div style={{ fontSize: 14, fontWeight: 700, color: '#000', marginBottom: 4 }}>{link.label}</div>
+                <div style={{ fontSize: 12, color: '#444', lineHeight: 1.5, fontWeight: 500 }}>{link.desc}</div>
+              </>
+            )
+            const boxStyle = { ...card, padding: '16px 18px', display: 'block', textDecoration: 'none' as const }
+
+            if ('external' in link && link.external) {
+              return (
+                <a key={link.label} href={link.href} target="_blank" rel="noreferrer" style={boxStyle}>
+                  {inner}
+                </a>
+              )
+            }
+            return (
+              <Link key={link.label} href={link.href} style={boxStyle}>
+                {inner}
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseTierCompareSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseTierCompareSection.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, primaryBtn, outlineBtn } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+type Props = {
+  onConnectClick: () => void
+}
+
+export function EnterpriseTierCompareSection({ onConnectClick }: Props) {
+  const { openCore, enterprise } = COPY.tierCompare
+
+  return (
+    <section className="zdb-section" style={{ padding: '88px 40px', background: M.wash }}>
+      <div style={container(1000)}>
+        <p style={sectionTitle}>{COPY.tierCompare.sectionTitle}</p>
+        <h2 style={h2}>{COPY.tierCompare.h2}</h2>
+        <p style={lead}>{COPY.tierCompare.lead}</p>
+
+        <div className="zdb-tier-grid" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+          <div style={{
+            background: '#fff', borderRadius: 16, padding: '28px 24px', border: `1px solid ${M.line}`,
+          }}>
+            <div style={{ fontSize: 11, fontWeight: 800, color: BRAND, marginBottom: 8, letterSpacing: 0.5 }}>
+              {openCore.label}
+            </div>
+            <h3 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 16px', color: '#000' }}>{openCore.title}</h3>
+            <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 24px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {openCore.features.map((f) => (
+                <li key={f} style={{ fontSize: 14, color: '#000', fontWeight: 500, display: 'flex', gap: 8 }}>
+                  <span style={{ color: BRAND, fontWeight: 800 }}>✓</span> {f}
+                </li>
+              ))}
+            </ul>
+            <Link href="/signup" style={outlineBtn}>{openCore.cta}</Link>
+          </div>
+
+          <div style={{
+            background: '#fff', borderRadius: 16, padding: '28px 24px', border: `2px solid ${BRAND}`,
+            boxShadow: '0 12px 40px rgba(249,115,22,0.1)',
+          }}>
+            <div style={{ fontSize: 11, fontWeight: 800, color: BRAND, marginBottom: 8, letterSpacing: 0.5 }}>
+              {enterprise.label}
+            </div>
+            <h3 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 16px', color: '#000' }}>{enterprise.title}</h3>
+            <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 24px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {enterprise.features.map((f) => (
+                <li key={f} style={{ fontSize: 14, color: '#000', fontWeight: 500, display: 'flex', gap: 8 }}>
+                  <span style={{ color: BRAND, fontWeight: 800 }}>✓</span> {f}
+                </li>
+              ))}
+            </ul>
+            <button type="button" onClick={onConnectClick} style={{ ...primaryBtn, cursor: 'pointer', border: 'none' }}>
+              {enterprise.cta}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseVpcDeploySection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseVpcDeploySection.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+import { COPY, INTEGRATION_SNIPPET, LOG_POINTS } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+export function EnterpriseVpcDeploySection() {
+  return (
+    <section className="zdb-section" style={{ padding: '88px 40px', background: '#fff' }}>
+      <div style={container(960)}>
+        <p style={sectionTitle}>{COPY.vpcDeploy.sectionTitle}</p>
+        <h2 style={h2}>{COPY.vpcDeploy.h2}</h2>
+        <p style={lead}>{COPY.vpcDeploy.lead}</p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14, marginBottom: 32 }}>
+          {COPY.vpcDeploy.points.map((p) => (
+            <div key={p.title} style={{ ...card, padding: '20px 22px' }}>
+              <div style={{ fontSize: 15, fontWeight: 700, marginBottom: 6, color: '#000' }}>{p.title}</div>
+              <div style={{ fontSize: 14, lineHeight: 1.65, color: '#000', fontWeight: 500 }}>{p.body}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="zdb-split" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginBottom: 28 }}>
+          <div style={{ ...card, padding: '22px' }}>
+            <div style={{ fontSize: 12, fontWeight: 800, color: BRAND, marginBottom: 12, letterSpacing: 0.5 }}>
+              WEEK TIMELINE
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {COPY.vpcDeploy.timeline.map((t) => (
+                <div key={t.day} style={{ display: 'flex', gap: 12, alignItems: 'baseline' }}>
+                  <span style={{ fontSize: 12, fontWeight: 800, color: BRAND, minWidth: 52 }}>{t.day}</span>
+                  <span style={{ fontSize: 14, fontWeight: 500, color: '#000' }}>{t.label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div style={{ ...card, padding: '22px' }}>
+            <div style={{ fontSize: 12, fontWeight: 800, color: BRAND, marginBottom: 12, letterSpacing: 0.5 }}>
+              INTEGRATION (YOUR CI/CD)
+            </div>
+            <pre style={{
+              margin: '0 0 14px', padding: '12px 14px', borderRadius: 10, background: M.wash,
+              border: `1px solid ${M.line}`, fontSize: 11, lineHeight: 1.55, overflowX: 'auto', color: '#000',
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            }}>
+              {INTEGRATION_SNIPPET}
+            </pre>
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#000', marginBottom: 8 }}>Five log points per conversation:</div>
+            <ul style={{ margin: 0, paddingLeft: 18, fontSize: 13, lineHeight: 1.7, color: '#000', fontWeight: 500 }}>
+              {LOG_POINTS.map((p) => (
+                <li key={p}>{p}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <p style={{ textAlign: 'center', margin: 0 }}>
+          <Link href="/trust#deployment" style={{ color: BRAND, fontWeight: 700, fontSize: 14, textDecoration: 'none' }}>
+            {COPY.vpcDeploy.trustLink} →
+          </Link>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseWhatIsSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseWhatIsSection.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+import type { CSSProperties } from 'react'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+const th: CSSProperties = {
+  textAlign: 'left',
+  padding: '10px 14px',
+  fontSize: 12,
+  fontWeight: 700,
+  color: '#666',
+  borderBottom: `1px solid ${M.line}`,
+  background: M.wash,
+}
+
+const td: CSSProperties = {
+  padding: '12px 14px',
+  fontSize: 14,
+  color: '#000',
+  fontWeight: 500,
+  borderBottom: `1px solid ${M.line}`,
+  verticalAlign: 'top',
+}
+
+export function EnterpriseWhatIsSection() {
+  const { whatIs } = COPY
+
+  return (
+    <section id="what-is" className="zdb-section zdb-section-anchor" style={{ padding: '88px 40px', background: M.wash, scrollMarginTop: 72 }}>
+      <div style={container(900)}>
+        <p style={sectionTitle}>{whatIs.sectionTitle}</p>
+        <h2 style={h2}>{whatIs.h2}</h2>
+        <p style={lead}>{whatIs.lead}</p>
+
+        <div style={{ ...card, padding: 0, overflow: 'hidden', marginTop: 32 }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={th}>Layer</th>
+                <th style={th}>Role</th>
+                <th style={th}>Examples</th>
+              </tr>
+            </thead>
+            <tbody>
+              {whatIs.table.map(([layer, role, examples]) => (
+                <tr key={layer}>
+                  <td style={{ ...td, fontWeight: 700 }}>{layer}</td>
+                  <td style={td}>{role}</td>
+                  <td style={td}>{examples}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p style={{ marginTop: 24, marginBottom: 0, fontSize: 14, fontWeight: 600 }}>
+          <Link href={whatIs.linkHref} style={{ color: BRAND, textDecoration: 'none' }}>
+            {whatIs.linkLabel} →
+          </Link>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/enterprise-copy.ts
+++ b/dashboard/components/marketing/enterprise/enterprise-copy.ts
@@ -1,0 +1,255 @@
+export const ENTERPRISE_CONTACT = 'mailto:founder@zizka.ai'
+export const GITHUB_URL = 'https://github.com/Zizka-ai/ZizkaDB'
+
+export const COPY = {
+  hero: {
+    eyebrow: 'ENTERPRISE',
+    h1: 'Operational control for multi-agent fleets in your cloud',
+    subhead:
+      'Licensed, single-tenant ZizkaDB in your VPC. Your agents connect via API key plus SDK, MCP, or REST. We deploy the stack — you keep your agent codebase.',
+    connectCta: "Let's connect",
+    demoCta: 'Book demo',
+  },
+  whatIs: {
+    sectionTitle: 'What ZizkaDB is',
+    h2: 'Operational database for AI agents',
+    lead:
+      'ZizkaDB stores agent decisions, tool calls, and outcomes with causal links. It is not a vector index for RAG documents and not distributed traces (OpenTelemetry). Most teams use all three alongside each other.',
+    table: [
+      ['Vector DB', 'RAG / knowledge retrieval', 'Pinecone, Qdrant'],
+      ['App DB', 'Transactional app state', 'Postgres, Redis'],
+      ['Agent ops', 'Decision history, lineage, drift', 'ZizkaDB'],
+      ['Traces', 'Spans, framework hooks', 'LangSmith, OTel'],
+    ] as const,
+    linkLabel: 'Read full technical reference',
+    linkHref: '/trust#overview',
+  },
+  fleet: {
+    sectionTitle: 'Multi-agent fleets',
+    h2: 'One ZizkaDB instance. Many agents. Full visibility.',
+    lead:
+      'Each agent logs under a distinct name. Tenant-wide API keys support SaaS patterns with thousands of logical agents.',
+    bullets: [
+      {
+        title: 'Fleet observability',
+        body: 'See all agents, last seen, and session volume in one place — included in your Enterprise VPC deployment.',
+      },
+      {
+        title: 'Behavioral drift',
+        body: 'Compare recent sessions to each agent\'s baseline. Verdicts from stable to significant — operational behavior change, not hallucination detection.',
+      },
+      {
+        title: 'Causal tracing',
+        body: 'Walk decision chains with why() and replay sessions when something breaks in production.',
+      },
+    ],
+    driftNote:
+      'Drift means operational behavior change — for example tool errors up 12 percentage points. It is not hallucination detection or truth verification.',
+    driftBands: {
+      title: 'Drift verdict bands',
+      bands: [
+        { label: 'Stable', range: 'below 0.05' },
+        { label: 'Minor', range: 'below 0.15' },
+        { label: 'Noticeable', range: 'below 0.30' },
+        { label: 'Significant', range: '0.30+' },
+      ],
+      requirement:
+        'Requires stable session_id, consistent event types, and parent_id links between related events.',
+    },
+    demoCaption: 'Fleet dashboard included in Enterprise VPC deployment.',
+  },
+  capabilities: {
+    sectionTitle: 'Capabilities',
+    h2: 'Open core today. Enterprise VPC adds fleet operations.',
+    lead:
+      'The same ZizkaDB engine runs on GitHub (AGPL), managed cloud, and Enterprise VPC. Enterprise adds commercial license, fleet UI, audit export, and supported Week-1 install.',
+    openCore: {
+      title: 'Open core — available today',
+      subtitle: 'Works on self-host and managed cloud (db.zizka.ai)',
+      rows: [
+        ['Event logging', 'POST /v1/events'],
+        ['Causal chain', 'GET /v1/events/{id}/why'],
+        ['State at time T', 'GET /v1/events/at'],
+        ['Semantic search', 'POST /v1/search'],
+        ['Behavioral baseline', 'GET /v1/agents/{id}/baseline'],
+        ['GDPR erasure', 'DELETE /v1/memory/forget'],
+        ['Checksum-backed events', 'Per-event SHA-256'],
+      ] as const,
+    },
+    enterprise: {
+      title: 'Enterprise VPC package adds',
+      items: [
+        'Fleet dashboard',
+        'Fleet ranking',
+        'Audit export (CSV/JSON + checksums)',
+        'Commercial license',
+        'Supported Week-1 install',
+      ],
+    },
+    footnote:
+      'Fleet UI and audit export are delivered in your VPC — not on public db.zizka.ai today.',
+  },
+  tierCompare: {
+    sectionTitle: 'Compare tiers',
+    h2: 'Open core and cloud vs Enterprise in your VPC',
+    lead: 'Same ZizkaDB engine. Enterprise adds commercial license, fleet operations, and a supported install in your cloud.',
+    openCore: {
+      label: 'OPEN CORE & CLOUD',
+      title: 'db.zizka.ai',
+      features: [
+        'AGPL on GitHub',
+        'Self-host Docker',
+        'Managed Pro / Team',
+        'Per-agent dashboard',
+        'Baseline / drift API',
+      ],
+      cta: 'Start free →',
+    },
+    enterprise: {
+      label: 'ENTERPRISE',
+      title: 'Your VPC',
+      features: [
+        'Commercial license',
+        'Single-tenant in your cloud',
+        'Fleet dashboard',
+        'Audit export',
+        'Week-1 install + integration workshop',
+      ],
+      cta: "Let's connect",
+    },
+  },
+  vpcDeploy: {
+    sectionTitle: 'Deployment',
+    h2: 'Production-ready in your cloud within one week',
+    lead: 'Same install package every customer. Only variables: region, sizing, DNS, secrets, and license tier.',
+    points: [
+      {
+        title: 'No platform rewrite',
+        body: 'Add ZIZKADB_HOST and ZIZKADB_API_KEY to your services. Instrument five log points per conversation — user in, tool out, tool in, model out, errors.',
+      },
+      {
+        title: 'Your CI/CD',
+        body: 'You merge and redeploy through your pipeline. Optional Launch Sprint can help instrument one or two services via pull requests.',
+      },
+      {
+        title: 'Private network',
+        body: 'Agent subnets reach ZizkaDB via same VPC, VPC peering, or PrivateLink.',
+      },
+    ],
+    timeline: [
+      { day: 'Day 0', label: 'Discovery + checklist' },
+      { day: 'Day 1', label: 'Stack live in staging' },
+      { day: 'Day 3', label: 'Integration workshop' },
+      { day: 'Day 7', label: 'Handoff + access revoked' },
+    ],
+    trustLink: 'Read deployment details',
+  },
+  platform: {
+    sectionTitle: 'Platform',
+    h2: 'Everything in the Week-1 package',
+    lead: 'Private images, license key, full stack, and integration kit — delivered in your VPC.',
+    features: [
+      {
+        title: 'VPC deploy',
+        body: 'Model A: Docker Compose stack in your cloud — Postgres, Qdrant, Redis, API, Dashboard.',
+      },
+      {
+        title: 'Commercial license',
+        body: 'Named organization, expiry, agent and event limits. One VPC per license.',
+      },
+      {
+        title: 'Fleet dashboard',
+        body: 'All agents with drift score, error change, and last seen — Enterprise UI in your VPC.',
+      },
+      {
+        title: 'Drift & error metrics',
+        body: 'Per-agent baseline plus fleet ranking. See what shifted before customers do.',
+      },
+      {
+        title: 'Audit export',
+        body: 'On-demand CSV or JSON with event checksums — not weekly certified reports.',
+      },
+      {
+        title: 'Integration workshop',
+        body: 'Five log points guide, staging checklist, backup and restore scripts.',
+      },
+    ],
+    footnote:
+      'SSO, SAML, and automated alerting are on the roadmap. Week-1 pilots use dashboard OTP plus VPN access.',
+  },
+  faq: {
+    sectionTitle: 'FAQ',
+    h2: 'Common enterprise questions',
+    items: [
+      {
+        q: 'Can you deploy inside our Kubernetes cluster?',
+        a: 'Version 1 is VM plus Docker Compose. Helm is available when a deal requires it.',
+      },
+      {
+        q: 'Do you modify our agent code?',
+        a: 'Optional Launch Sprint can open pull requests on one or two services. Default path: your developers plus our integration kit.',
+      },
+      {
+        q: 'How is this different from self-hosting from GitHub?',
+        a: 'AGPL open core vs commercial license, enterprise features, fleet dashboard, audit export, and a supported Week-1 install.',
+      },
+      {
+        q: 'How is Enterprise different from Pro or Team cloud?',
+        a: 'We host multi-tenant SaaS on db.zizka.ai. Enterprise is single-tenant in your VPC with a commercial license.',
+      },
+      {
+        q: 'Can we run a POC without a VPC?',
+        a: 'Cloud trial works for developer evaluation. Enterprise pilot expects deployment in your VPC.',
+      },
+      {
+        q: 'PII and GDPR?',
+        a: 'You control data. forget() deletes by metadata filter. Self-host and VPC deployments keep data in your infrastructure.',
+        link: { label: 'Security details', href: '/trust#security' },
+      },
+      {
+        q: 'How is this different from LangSmith / Mem0?',
+        a: 'LangSmith focuses on framework-centric tracing and evals. Mem0 optimizes long-term memory retrieval. ZizkaDB is a standalone operational store with causal trees, time travel, and fleet baselines.',
+        link: { label: 'Full comparison', href: '/trust#comparison' },
+      },
+    ],
+  },
+  footerCta: {
+    h2: 'Ready to deploy in your VPC?',
+    subhead: 'Tell us about your agent fleet. We will map a Week-1 path or point you to managed cloud.',
+    demoCta: 'Book demo',
+    cloudCta: 'ZizkaDB Cloud →',
+  },
+  form: {
+    success: 'Thanks — we will reach out within one business day.',
+    rateLimit: 'Too many requests. Try again later or email founder@zizka.ai.',
+    genericError: 'Something went wrong. Email founder@zizka.ai and we will help.',
+    websiteHint: 'Company domain or linkedin.com/company/…',
+  },
+} as const
+
+export const TECHNICAL_LINKS = [
+  { label: 'Overview', href: '/trust#overview', desc: 'What ZizkaDB is and how it fits your stack' },
+  { label: 'Technical reference', href: '/trust', desc: 'Architecture, APIs, data model' },
+  { label: 'Security', href: '/trust#security', desc: 'TLS, tenant isolation, GDPR' },
+  { label: 'Integrity', href: '/trust#integrity', desc: 'Checksums and retention' },
+  { label: 'Deployment modes', href: '/trust#deployment', desc: 'Self-host, managed, Enterprise VPC' },
+  { label: 'Plan limits', href: '/trust#limits', desc: 'Events and retention by tier' },
+  { label: 'Licensing', href: '/trust#licensing', desc: 'AGPL vs commercial' },
+  { label: 'Comparison', href: '/trust#comparison', desc: 'vs LangSmith, Mem0, Pinecone' },
+  { label: 'API reference', href: '/swagger', desc: 'REST explorer' },
+  { label: 'Documentation', href: '/docs', desc: 'SDK, MCP, integration guides' },
+  { label: 'Open source', href: GITHUB_URL, desc: 'AGPL core on GitHub', external: true },
+  { label: 'Contact', href: ENTERPRISE_CONTACT, desc: 'Security review + sales', external: true },
+  { label: 'Managed cloud', href: '/signup', desc: 'Pro / Team free trial' },
+] as const
+
+export const INTEGRATION_SNIPPET = `ZIZKADB_HOST=https://zizkadb.internal.your-company.example
+ZIZKADB_API_KEY=zizkadb_live_...`
+
+export const LOG_POINTS = [
+  'User message in',
+  'Tool call out',
+  'Tool result in',
+  'Model response out',
+  'Errors',
+]

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -298,6 +298,7 @@ export async function verifyOtp(
     intent?: 'signup' | 'login'
     gdprConsent?: boolean
     marketingConsent?: boolean
+    promoCode?: string
   },
 ) {
   const intent = opts?.intent ?? 'login'
@@ -310,6 +311,7 @@ export async function verifyOtp(
       intent,
       ...(opts?.gdprConsent ? { gdpr_consent: true } : {}),
       ...(opts?.marketingConsent ? { marketing_consent: true } : {}),
+      ...(opts?.promoCode ? { promo_code: opts.promoCode } : {}),
     }),
   })
   if (!res.ok) {
@@ -384,4 +386,20 @@ export async function grantRetentionTrial(token: string): Promise<{
 
 export async function deleteManagedAccount(token: string): Promise<{ message: string }> {
   return apiFetch('/v1/account', token, { method: 'DELETE' })
+}
+
+export async function subscribeNewsletter(email: string): Promise<{
+  message: string
+  already_subscribed?: boolean
+}> {
+  const res = await fetch(`${API}/v1/newsletter/subscribe`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ email: email.toLowerCase().trim(), botcheck: '' }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }))
+    throw new Error(formatApiError(err.detail, 'Could not subscribe'))
+  }
+  return res.json()
 }

--- a/dashboard/lib/demo.ts
+++ b/dashboard/lib/demo.ts
@@ -6,6 +6,8 @@ export interface DemoRequestPayload {
   email: string
   company_name: string
   website: string
+  position?: string
+  source?: string
 }
 
 export async function submitDemoRequest(payload: DemoRequestPayload) {

--- a/dashboard/lib/signup-funnel.ts
+++ b/dashboard/lib/signup-funnel.ts
@@ -1,12 +1,14 @@
 /** sessionStorage keys for the signup funnel (plan → consent → OTP). */
 
 export const SIGNUP_PLAN_KEY = 'signup_plan'
+export const SIGNUP_PROMO_KEY = 'signup_promo'
 export const SIGNUP_CONSENT_GDPR_KEY = 'signup_consent_gdpr'
 export const SIGNUP_CONSENT_MARKETING_KEY = 'signup_consent_marketing'
 
 export function clearSignupSession(): void {
   if (typeof window === 'undefined') return
   sessionStorage.removeItem(SIGNUP_PLAN_KEY)
+  sessionStorage.removeItem(SIGNUP_PROMO_KEY)
   sessionStorage.removeItem(SIGNUP_CONSENT_GDPR_KEY)
   sessionStorage.removeItem(SIGNUP_CONSENT_MARKETING_KEY)
 }

--- a/docs/email-automation-qa.md
+++ b/docs/email-automation-qa.md
@@ -1,0 +1,83 @@
+# Email Automation — Manual QA Checklist
+
+## Production deploy (lifecycle OFF — safe default)
+
+On EC2, ensure `infra/.env` contains:
+
+```bash
+EMAIL_LIFECYCLE_ENABLED=false
+NEXT_PUBLIC_NEWSLETTER_ENABLED=false
+```
+
+Deploy:
+
+```bash
+bash infra/deploy-production.sh
+```
+
+Verify after deploy:
+
+- [ ] `curl -sf http://127.0.0.1:8000/health`
+- [ ] OTP login works for existing account
+- [ ] No newsletter popup on landing (flag off)
+- [ ] `docker compose -f infra/docker-compose.yml ps email_worker` — running (idle OK)
+
+## Enable lifecycle (allowlist first)
+
+```bash
+EMAIL_LIFECYCLE_ENABLED=true
+EMAIL_LIFECYCLE_ALLOWLIST=founder@zizka.ai
+NEXT_PUBLIC_NEWSLETTER_ENABLED=true
+
+docker compose -f infra/docker-compose.yml restart api email_worker
+bash infra/deploy-dashboard.sh
+```
+
+## Local / staging QA
+
+```bash
+EMAIL_LIFECYCLE_ENABLED=true
+EMAIL_STAGING_COMPRESS_DELAYS=true  # optional: 72h/7d → ~5min
+NEXT_PUBLIC_NEWSLETTER_ENABLED=true
+docker compose -f infra/docker-compose.yml up email_worker api
+# Optional visual inbox: docker compose -f infra/docker-compose.yml --profile dev-mail up -d
+# → http://localhost:8025 (set EMAIL_HOST=mailhog, EMAIL_PORT=1025 for capture)
+```
+
+## Phase 0 — Foundation
+
+- [ ] OTP login/signup works (with and without `EMAIL_*`)
+- [ ] Outbox row processes via worker
+
+## Campaigns
+
+- [ ] **C1 Welcome** — after signup (~5 min with compress)
+- [ ] **C2 Getting started** — after signup (~10 min)
+- [ ] **C3 No API 72h** — user with no keys
+- [ ] **C4 API no events** — key created, no real events
+- [ ] **C5 Inactive 7d** — had events, quiet 7 days
+- [ ] **C6 Active check-in** — active user, not more than every 15d
+- [ ] **C7 Account deleted** — promo code in email, re-signup extends trial
+- [ ] **C8 Newsletter** — popup at 15s, subscribe, dedupe, unsubscribe
+
+## Safety
+
+- [ ] `EMAIL_LIFECYCLE_ENABLED=false` — no lifecycle sends; OTP works; popup hidden
+- [ ] Signup completes when SMTP down (OTP saved; request returns 200)
+- [ ] Worker restart — no duplicate sends
+- [ ] `GET /v1/admin/email/stats` (admin JWT) shows pending/failed counts
+
+## Instant rollback
+
+```bash
+EMAIL_LIFECYCLE_ENABLED=false
+NEXT_PUBLIC_NEWSLETTER_ENABLED=false
+docker compose -f infra/docker-compose.yml restart api email_worker
+bash infra/deploy-dashboard.sh
+```
+
+## Production rollout
+
+1. Deploy with `EMAIL_LIFECYCLE_ENABLED=false`
+2. Enable with `EMAIL_LIFECYCLE_ALLOWLIST` for founder emails — 24h
+3. Enable globally — monitor 48h

--- a/docs/enterprise-page-qa.md
+++ b/docs/enterprise-page-qa.md
@@ -1,0 +1,42 @@
+# Enterprise page — production QA checklist
+
+Use this checklist before merging or after deploying `/enterprise` and related backend changes.
+
+## Automated gates
+
+Run from repo root:
+
+```bash
+cd dashboard && npm run lint && npm run build
+cd ../core && pytest tests/test_rate_limiting.py -q
+```
+
+Copy guardrails (must return no matches except explicit negations):
+
+```bash
+rg -i 'SOC 2|HIPAA|SAML|SCIM|PagerDuty|Slack alert|SLA guarantee|detects hallucination' \
+  dashboard/components/marketing/enterprise dashboard/app/enterprise
+```
+
+## Manual smoke (~5 min)
+
+- [ ] `/enterprise` — all sections render in order: Hero → What is → Fleet → Capabilities → Tier compare → VPC deploy → Platform → FAQ → Connect form → Resources
+- [ ] Nav highlights **Enterprise** on desktop and mobile
+- [ ] **Let's connect** scrolls to `#connect` and focuses first name field
+- [ ] Submit connect form → **201**; admin demo requests tab shows `source=enterprise` and role when filled
+- [ ] Invalid `source` rejected server-side (422) — covered by pytest
+- [ ] **Book demo** opens Calendly modal; **ESC** closes
+- [ ] Mobile **375px**: nav CTA row visible, no horizontal overflow
+- [ ] All `TECHNICAL_LINKS` in resources strip resolve (no 404)
+- [ ] Trust `#limits` shows Enterprise row; landing `#pricing` links to `/enterprise`
+- [ ] `/trust`, `/docs`, `/community` show shared marketing footer with Enterprise link
+
+## Rate limiting note
+
+Demo request rate limits use the same in-memory pattern as auth OTP and community posts (`core/api/demo_requests.py`). In multi-worker deployments, effective limit is multiplied by worker count — consistent with the rest of the API today.
+
+## Lead form contract
+
+- Frontend: `EnterpriseConnectForm` sends `source: 'enterprise'` via `submitDemoRequest`; honeypot field is `botcheck` (off-screen)
+- Backend: `POST /v1/demo-requests` stores optional `position`, allowlisted `source`, client IP
+- Admin: search includes name, email, company, website, role, source

--- a/infra/deploy-dashboard.sh
+++ b/infra/deploy-dashboard.sh
@@ -5,6 +5,7 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
 export NEXT_PUBLIC_API_URL="${NEXT_PUBLIC_API_URL:-https://db.zizka.ai}"
 export NEXT_PUBLIC_DEV_MODE="${NEXT_PUBLIC_DEV_MODE:-false}"
+export NEXT_PUBLIC_NEWSLETTER_ENABLED="${NEXT_PUBLIC_NEWSLETTER_ENABLED:-false}"
 
 # Docker dashboard fights for ports — do not run it in production
 docker rm -f zizkadb_dashboard 2>/dev/null || true
@@ -14,6 +15,9 @@ npm ci
 
 # Stale .next causes blank site (HTML references missing webpack chunks → 400)
 rm -rf .next
+NEXT_PUBLIC_API_URL="$NEXT_PUBLIC_API_URL" \
+NEXT_PUBLIC_DEV_MODE="$NEXT_PUBLIC_DEV_MODE" \
+NEXT_PUBLIC_NEWSLETTER_ENABLED="$NEXT_PUBLIC_NEWSLETTER_ENABLED" \
 npm run build
 
 WEBPACK=$(ls .next/static/chunks/webpack-*.js 2>/dev/null | head -1 || true)

--- a/infra/deploy-production.sh
+++ b/infra/deploy-production.sh
@@ -43,7 +43,14 @@ git pull origin main
 
 echo "→ Step 3/5: Rebuild & restart API stack (no -v)"
 "${COMPOSE[@]}" up -d --build
-"${COMPOSE[@]}" restart api
+"${COMPOSE[@]}" restart api email_worker
+
+echo "→ Step 3b: Email worker"
+if "${COMPOSE[@]}" ps --status running email_worker 2>/dev/null | grep -q email_worker; then
+  echo "   email_worker running"
+else
+  echo "   WARNING: email_worker not running — lifecycle emails will not send" >&2
+fi
 
 echo "→ Step 4/5: Wait for API health"
 for i in $(seq 1 30); do

--- a/infra/deploy-selfhost.sh
+++ b/infra/deploy-selfhost.sh
@@ -62,5 +62,9 @@ else
   echo "  SDK:       use API key from Dashboard → Settings"
 fi
 echo "  API:       ensure infra/docker-compose.yml is up on :8000"
+echo "  Email:     docker compose -f infra/docker-compose.yml up -d email_worker"
+echo "             (set EMAIL_LIFECYCLE_ENABLED=true + EMAIL_* in infra/.env)"
+echo "  Mailhog:   docker compose -f infra/docker-compose.yml --profile dev-mail up -d"
+echo "             Web UI http://localhost:8025 (dev only)"
 echo "  Nginx:     see infra/nginx.conf for routing / → :3001, /v1/ → :8000"
 echo ""

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -73,6 +73,10 @@ services:
       PUBLIC_API_URL: ${PUBLIC_API_URL:-https://db.zizka.ai}
       DASHBOARD_URL: ${DASHBOARD_URL:-https://db.zizka.ai}
       TRIAL_DAYS: ${TRIAL_DAYS:-30}
+      EMAIL_LIFECYCLE_ENABLED: ${EMAIL_LIFECYCLE_ENABLED:-false}
+      EMAIL_DEV_REDIRECT: ${EMAIL_DEV_REDIRECT:-}
+      EMAIL_STAGING_COMPRESS_DELAYS: ${EMAIL_STAGING_COMPRESS_DELAYS:-false}
+      EMAIL_LIFECYCLE_ALLOWLIST: ${EMAIL_LIFECYCLE_ALLOWLIST:-}
       COMMUNITY_UPLOAD_DIR: /data/community_uploads
     depends_on:
       postgres:
@@ -83,6 +87,44 @@ services:
       - ../core:/app
       - community_uploads:/data/community_uploads
     command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+
+  email_worker:
+    build:
+      context: ../core
+      dockerfile: Dockerfile
+    container_name: zizkadb_email_worker
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-zizkadb}:${POSTGRES_PASSWORD:-zizkadb}@postgres:5432/${POSTGRES_DB:-zizkadb}
+      REDIS_URL: redis://redis:6379
+      ENV: ${ENV:-development}
+      EMAIL_HOST: ${EMAIL_HOST}
+      EMAIL_PORT: ${EMAIL_PORT:-465}
+      EMAIL_USER: ${EMAIL_USER}
+      EMAIL_PASS: ${EMAIL_PASS}
+      EMAIL_FROM: "${EMAIL_FROM}"
+      DASHBOARD_URL: ${DASHBOARD_URL:-https://db.zizka.ai}
+      TRIAL_DAYS: ${TRIAL_DAYS:-30}
+      EMAIL_LIFECYCLE_ENABLED: ${EMAIL_LIFECYCLE_ENABLED:-false}
+      EMAIL_DEV_REDIRECT: ${EMAIL_DEV_REDIRECT:-}
+      EMAIL_STAGING_COMPRESS_DELAYS: ${EMAIL_STAGING_COMPRESS_DELAYS:-false}
+      EMAIL_LIFECYCLE_ALLOWLIST: ${EMAIL_LIFECYCLE_ALLOWLIST:-}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    volumes:
+      - ../core:/app
+    command: python -m workers.email_worker
+
+  # Optional local SMTP inbox — docker compose --profile dev-mail up
+  mailhog:
+    profiles: ["dev-mail"]
+    image: mailhog/mailhog:latest
+    container_name: zizkadb_mailhog
+    ports:
+      - "1025:1025"
+      - "8025:8025"
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Email: 8-campaign outbox worker behind EMAIL_LIFECYCLE_ENABLED (default off), newsletter popup, churn recovery, ARQ processing, and email lifecycle KB.

Enterprise: /enterprise marketing page, demo request source/position fields, shared footer/styles, and enterprise page KB. Docs cross-linked across rules.