### PR TITLE
Add enterprise marketing page and demo request lead capture.

### DIFF
--- a/.cursor/rules/backend-dashboard-contract.mdc
+++ b/.cursor/rules/backend-dashboard-contract.mdc
@@ -16,9 +16,10 @@ The dashboard (`dashboard/`) is a client of this FastAPI backend. Before changin
 - **Event schema** (`core/api/events.py`, `event_write.py`): `POST /v1/events` is written by SDKs/MCP/integrations AND read back by the dashboard. Field renames affect both sides.
 - **Route paths/prefixes** (`core/main.py`): the dashboard calls fixed `/v1/...` paths via `dashboard/lib/api.ts`. Renaming a route breaks the client.
 - **API key plan limits** (`core/services/plan_limits.py` = single source of truth; `core/services/api_keys.py::assert_and_reserve_api_key_slot`): active keys per tenant capped by plan (Pro 3 / Team 10; else unlimited). Guard runs in a per-tenant advisory-locked txn before insert. Behind kill switch `API_KEY_LIMITS_ENFORCED` (default OFF). Usage: `GET /v1/auth/api-keys/usage` → `{plan, limit, used, unlimited, at_limit}`.
+- **Demo requests** (`core/api/demo_requests.py`): public `POST /v1/demo-requests` — no auth; optional `position`, allowlisted `source` (`enterprise`|`landing`|`newsletter`, else 422); honeypot `botcheck` → 400; 8/hr/IP in-memory rate limit. Admin: `GET /v1/admin/demo-requests` returns `position` + `source`. Dashboard: `lib/demo.ts`, Enterprise form sends `source: 'enterprise'`.
 
 ## Data model
-Schema in `core/db/schema.sql` + `migrations/002-006` + runtime DDL in `core/db/connection.py`. Plan/trial state lives on `users` (`stripe_*` columns retained but unused). Qdrant `agent_events` is 1536-dim COSINE; embeddings are dual-written to Postgres `events.embedding` + Qdrant. See §21.
+Schema in `core/db/schema.sql` + `migrations/002-007` + runtime DDL in `core/db/connection.py`. Plan/trial state lives on `users` (`stripe_*` columns retained but unused). Qdrant `agent_events` is 1536-dim COSINE; embeddings are dual-written to Postgres `events.embedding` + Qdrant. See §21.
 
 ## Keep the KB in sync
 If you change any contract above, a route, the billing/auth logic, or the DB schema, update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` (§17.3, §18, §21) in the same change — and the matching `dashboard/lib/api.ts` types/callers if the response shape changed.

--- a/.cursor/rules/enterprise-page-knowledge-base.mdc
+++ b/.cursor/rules/enterprise-page-knowledge-base.mdc
@@ -1,0 +1,47 @@
+---
+description: Enterprise marketing page — copy guardrails, lead capture, QA, and cross-links
+globs: dashboard/app/enterprise/**,dashboard/components/marketing/enterprise/**,dashboard/components/marketing/MarketingFooter.tsx,dashboard/components/marketing/MarketingPageStyles.tsx,dashboard/components/SiteNav.tsx,dashboard/lib/demo.ts,core/api/demo_requests.py,core/db/migrations/007_demo_requests_enterprise.sql,docs/enterprise-page-qa.md,docs/enterprise-product-overview.md
+alwaysApply: false
+---
+
+# Enterprise Page — Agent Guide
+
+**Route:** `/enterprise` · **QA checklist:** `docs/enterprise-page-qa.md` · **Product overview:** `docs/enterprise-product-overview.md` · **Dashboard KB:** §20.6 · **Copy source:** `dashboard/components/marketing/enterprise/enterprise-copy.ts`
+
+## Page composition (order)
+
+Hero → What ZizkaDB is → Multi-agent fleets (drift bands) → Capabilities (open core vs VPC) → Tier compare → VPC deploy → Platform → FAQ → Footer CTA (`#connect`) → Resources strip.
+
+Shared shell: `SiteNav active="enterprise"`, `MarketingPageStyles`, `MarketingFooter`, `CalendlyBookModal`.
+
+## Lead capture
+
+- Form: `EnterpriseConnectForm` → `submitDemoRequest` (`lib/demo.ts`) → `POST /v1/demo-requests`
+- Always sends `source: 'enterprise'`; optional `position` (role/title)
+- Honeypot field name: **`botcheck`** (not `website`); client silently drops if filled
+- Backend allowlist: `enterprise`, `landing`, `newsletter` — else **422**
+- Admin demo tab shows Role + Source; search includes both
+- DB: nullable `position VARCHAR(120)`, `source VARCHAR(64)` — migration `007_demo_requests_enterprise.sql` + runtime DDL in `connection.py`
+
+## Copy guardrails (must NOT claim on `/enterprise`)
+
+SOC 2, HIPAA, SSO/SAML/SCIM **as shipped**, Slack/PagerDuty alerts, SLA guarantees, hallucination **detection** (negation OK).
+
+**Must stay honest:** behavioral drift (not hallucination detection), VPC deployment (Model A), commercial license, Week-1 install package, fleet UI + audit export **in customer VPC** (not on public cloud today). SSO/SAML only as **roadmap** footnote in platform section.
+
+## Cross-page consistency
+
+- Trust `#deployment`, `#limits`, `#licensing`: Enterprise row + links to `/enterprise`
+- Landing `#pricing`: "Enterprise — Contact sales →" link
+- `MarketingFooter` includes Enterprise on landing, trust, enterprise (docs/community when wired)
+
+## Before merge
+
+```bash
+cd dashboard && npm run lint && npm run build
+cd ../core && pytest tests/test_demo_requests.py tests/test_rate_limiting.py::TestDemoRequestsRateLimiting -q
+rg -i 'SOC 2|HIPAA|SAML|SCIM|PagerDuty|Slack alert|SLA guarantee|detects hallucination' \
+  dashboard/components/marketing/enterprise dashboard/app/enterprise
+```
+
+Update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` §20.6, `wiki/REST-API.md`, and `backend-dashboard-contract.mdc` if demo-requests contract changes.

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ build/
 node_modules/
 .next/
 .turbo/
+*.tsbuildinfo
 *.log
 
 # macOS

--- a/core/api/admin.py
+++ b/core/api/admin.py
@@ -501,6 +501,8 @@ async def admin_demo_requests(
                 OR company_name ILIKE ${n}
                 OR website ILIKE ${n}
                 OR email ILIKE ${n}
+                OR COALESCE(position, '') ILIKE ${n}
+                OR COALESCE(source, '') ILIKE ${n}
             )
         """
 
@@ -509,7 +511,7 @@ async def admin_demo_requests(
 
     rows = await pool.fetch(
         f"""
-        SELECT request_id, first_name, last_name, email, company_name, website, ip_address, created_at
+        SELECT request_id, first_name, last_name, email, company_name, website, position, source, ip_address, created_at
         FROM demo_requests
         {where}
         ORDER BY created_at DESC
@@ -526,6 +528,8 @@ async def admin_demo_requests(
             "email":        r["email"],
             "company_name": r["company_name"],
             "website":      r["website"],
+            "position":     r["position"],
+            "source":       r["source"],
             "ip_address":   r["ip_address"],
             "created_at":   r["created_at"].isoformat() if r["created_at"] else None,
         }

--- a/core/api/demo_requests.py
+++ b/core/api/demo_requests.py
@@ -18,6 +18,7 @@ log = logging.getLogger(__name__)
 _rate: dict[str, list[float]] = {}
 RATE_WINDOW_SEC = 3600
 RATE_MAX = 8
+VALID_SOURCES = frozenset({"enterprise", "landing", "newsletter"})
 
 
 class CreateDemoRequestBody(BaseModel):
@@ -26,6 +27,8 @@ class CreateDemoRequestBody(BaseModel):
     email: EmailStr
     company_name: str = Field(min_length=1, max_length=255)
     website: str = Field(min_length=1, max_length=500)
+    position: str | None = Field(default=None, max_length=120)
+    source: str | None = Field(default=None, max_length=64)
     botcheck: str | None = None  # honeypot — must be empty
 
 
@@ -53,11 +56,15 @@ async def create_demo_request(body: CreateDemoRequestBody, request: Request):
     ip = _client_ip(request)
     _check_rate(ip)
 
+    source = (body.source.strip() or None) if body.source else None
+    if source and source not in VALID_SOURCES:
+        raise HTTPException(status_code=422, detail="Invalid source")
+
     pool = get_pool()
     row = await pool.fetchrow(
         """
-        INSERT INTO demo_requests (first_name, last_name, email, company_name, website, ip_address)
-        VALUES ($1, $2, $3, $4, $5, $6)
+        INSERT INTO demo_requests (first_name, last_name, email, company_name, website, position, source, ip_address)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         RETURNING request_id, created_at
         """,
         body.first_name.strip(),
@@ -65,6 +72,8 @@ async def create_demo_request(body: CreateDemoRequestBody, request: Request):
         str(body.email).strip().lower(),
         body.company_name.strip(),
         body.website.strip(),
+        (body.position.strip() or None) if body.position else None,
+        source,
         ip,
     )
     log.info("demo request from %s (%s %s)", ip, body.first_name, body.company_name)

--- a/core/db/connection.py
+++ b/core/db/connection.py
@@ -152,6 +152,11 @@ async def init_db():
         ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS email VARCHAR(255) NOT NULL DEFAULT '';
     """)
 
+    await _pg_pool.execute("""
+        ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS position VARCHAR(120);
+        ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS source VARCHAR(64);
+    """)
+
     _redis = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379"))
     logger.info("Redis connected")
 

--- a/core/db/migrations/007_demo_requests_enterprise.sql
+++ b/core/db/migrations/007_demo_requests_enterprise.sql
@@ -1,0 +1,3 @@
+-- Enterprise contact form: optional role/title and lead source
+ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS position VARCHAR(120);
+ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS source VARCHAR(64);

--- a/core/db/schema.sql
+++ b/core/db/schema.sql
@@ -148,6 +148,8 @@ CREATE TABLE demo_requests (
     email         VARCHAR(255) NOT NULL,
     company_name  VARCHAR(255) NOT NULL,
     website       VARCHAR(500) NOT NULL,
+    position      VARCHAR(120),
+    source        VARCHAR(64),
     ip_address    VARCHAR(64),
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );

--- a/core/services/billing.py
+++ b/core/services/billing.py
@@ -18,7 +18,7 @@ PLAN_CATALOG: list[dict[str, Any]] = [
         "price": "€39",
         "price_sub": "/ month",
         "highlight": True,
-        "features": ["100M events", "90-day retention", "3 projects", "Email support"],
+        "features": ["100M events", "90-day retention", "3 active API keys", "Email support"],
     },
     {
         "id": "team",
@@ -26,7 +26,7 @@ PLAN_CATALOG: list[dict[str, Any]] = [
         "price": "€99",
         "price_sub": "/ month",
         "highlight": False,
-        "features": ["Up to 1B events/mo", "1-year retention", "10 seats", "Priority support"],
+        "features": ["Up to 1B events/mo", "1-year retention", "10 active API keys", "Priority support"],
     },
 ]
 

--- a/core/tests/test_demo_requests.py
+++ b/core/tests/test_demo_requests.py
@@ -1,0 +1,153 @@
+"""
+Unit tests for POST /v1/demo-requests — source validation, position, honeypot.
+Rate limiting is covered in test_rate_limiting.py.
+"""
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from api.demo_requests import _rate as demo_rate
+from main import app
+
+client = TestClient(app)
+
+VALID_PAYLOAD = {
+    "first_name": "Ada",
+    "last_name": "Lovelace",
+    "email": "ada@example.com",
+    "company_name": "Analytical Engines Ltd",
+    "website": "https://example.com",
+    "botcheck": "",
+}
+
+
+def _mock_pool_row():
+    mock_pool = MagicMock()
+    mock_row = {
+        "request_id": "11111111-1111-1111-1111-111111111111",
+        "created_at": datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc),
+    }
+    mock_pool.fetchrow = AsyncMock(return_value=mock_row)
+    return mock_pool
+
+
+class TestDemoRequests:
+    def setup_method(self):
+        demo_rate.clear()
+
+    @patch("api.demo_requests.get_pool")
+    def test_create_minimal_fields(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        response = client.post("/v1/demo-requests", json=VALID_PAYLOAD)
+        assert response.status_code == 201
+        body = response.json()
+        assert "id" in body
+        assert "created_at" in body
+
+    @patch("api.demo_requests.get_pool")
+    def test_create_with_enterprise_source_and_position(self, mock_get_pool):
+        mock_pool = _mock_pool_row()
+        mock_get_pool.return_value = mock_pool
+        response = client.post(
+            "/v1/demo-requests",
+            json={
+                **VALID_PAYLOAD,
+                "source": "enterprise",
+                "position": "Head of Platform",
+            },
+        )
+        assert response.status_code == 201
+        call_args = mock_pool.fetchrow.call_args[0]
+        # position is 6th positional arg ($6), source is 7th ($7)
+        assert call_args[6] == "Head of Platform"
+        assert call_args[7] == "enterprise"
+
+    @patch("api.demo_requests.get_pool")
+    def test_valid_sources_accepted(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        for source in ("enterprise", "landing", "newsletter"):
+            demo_rate.clear()
+            response = client.post(
+                "/v1/demo-requests",
+                json={**VALID_PAYLOAD, "source": source},
+            )
+            assert response.status_code == 201, source
+
+    @patch("api.demo_requests.get_pool")
+    def test_invalid_source_rejected(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        response = client.post(
+            "/v1/demo-requests",
+            json={**VALID_PAYLOAD, "source": "spam"},
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"] == "Invalid source"
+
+    @patch("api.demo_requests.get_pool")
+    def test_empty_source_treated_as_null(self, mock_get_pool):
+        mock_pool = _mock_pool_row()
+        mock_get_pool.return_value = mock_pool
+        response = client.post(
+            "/v1/demo-requests",
+            json={**VALID_PAYLOAD, "source": "   "},
+        )
+        assert response.status_code == 201
+        call_args = mock_pool.fetchrow.call_args[0]
+        assert call_args[7] is None
+
+    @patch("api.demo_requests.get_pool")
+    def test_honeypot_rejected(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        response = client.post(
+            "/v1/demo-requests",
+            json={**VALID_PAYLOAD, "botcheck": "bot"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid submission"
+
+    @patch("api.demo_requests.get_pool")
+    def test_whitespace_trimmed(self, mock_get_pool):
+        mock_pool = _mock_pool_row()
+        mock_get_pool.return_value = mock_pool
+        response = client.post(
+            "/v1/demo-requests",
+            json={
+                **VALID_PAYLOAD,
+                "first_name": "  Ada  ",
+                "last_name": "  Lovelace  ",
+                "email": "  Ada@Example.COM  ",
+                "company_name": "  Analytical Engines  ",
+                "website": "  https://example.com  ",
+                "position": "  CTO  ",
+                "source": "enterprise",
+            },
+        )
+        assert response.status_code == 201
+        args = mock_pool.fetchrow.call_args[0]
+        assert args[1] == "Ada"
+        assert args[2] == "Lovelace"
+        assert args[3] == "ada@example.com"
+        assert args[4] == "Analytical Engines"
+        assert args[5] == "https://example.com"
+        assert args[6] == "CTO"
+        assert args[7] == "enterprise"
+
+    @patch("api.demo_requests.get_pool")
+    def test_optional_position_omitted(self, mock_get_pool):
+        mock_pool = _mock_pool_row()
+        mock_get_pool.return_value = mock_pool
+        response = client.post("/v1/demo-requests", json=VALID_PAYLOAD)
+        assert response.status_code == 201
+        args = mock_pool.fetchrow.call_args[0]
+        assert args[6] is None
+        assert args[7] is None
+
+    @patch("api.demo_requests.get_pool")
+    def test_missing_required_field_rejected(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        payload = {**VALID_PAYLOAD}
+        del payload["company_name"]
+        response = client.post("/v1/demo-requests", json=payload)
+        assert response.status_code == 422

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -757,7 +757,7 @@ These live in the same Next app but are separate from the tenant `/dashboard/*` 
 
 ### 20.4 Trust — `app/trust/page.tsx`
 
-- **Server Component** (static, SEO `metadata` set). 17 anchor sections (overview, architecture, data model, integrity, performance, security, API, deployment, comparison, licensing, limits, FAQ, contact, …). Desktop-only sticky sidebar (`@media min-width: 900px`). Links to `/docs`, `/swagger`, `/signup`, GitHub, `mailto:founder@zizka.ai`. No state/API.
+- **Server Component** (static, SEO `metadata` set). 17 anchor sections (overview, architecture, data model, integrity, performance, security, API, deployment, comparison, licensing, limits, FAQ, contact, …). Desktop-only sticky sidebar (`@media min-width: 900px`). Links to `/docs`, `/swagger`, `/signup`, `/enterprise`, GitHub, `mailto:founder@zizka.ai`. Includes `MarketingFooter`; deployment/limits tables include Enterprise row; security section links to `/enterprise` for VPC review. No state/API.
 
 ### 20.5 Admin console — `app/admin/page.tsx` (+ `layout.tsx`)
 
@@ -765,13 +765,23 @@ These live in the same Next app but are separate from the tenant `/dashboard/*` 
 - **Three tiers:** `AdminPage` boot gate (reads `getAdminToken()`, shows Loading → Login → Dashboard) → `Login` (founder-only `ADMIN_EMAIL = 'founder@zizka.ai'`, OTP via `adminRequestOtp` with 30s `AbortSignal` + `adminVerifyOtp`) → `Dashboard`.
 - **Dashboard:** `OverviewRow` stats + 4 tabs — `subscribers` (`SubscribersSection`), `managed` (`ManagedSection`), `telemetry` (`TelemetrySection`), `demo_requests` (`DemoRequestsSection`). `adminOverview` polls every **10s**; **401/"Not Found" → auto `onLogout()`**.
 - **Data calls** (all admin JWT via `apiFetch`): `adminOverview`, `adminTelemetrySummary` + `adminTelemetryRecent(100)`, `adminManagedOverview`, `adminManagedSubscribers`, `adminManagedUsers`, `adminManagedUsage`, `adminDemoRequests({limit:200})`. Subscriber/managed/demo tabs also poll 10s.
-- **Behaviors:** most tab fetches `.catch(()=>…)` **silently**; **search reloads only on Enter/Refresh** (search text is not in effect deps); subscriber filters `trialing|active|past_due`; managed filters `all|active|keys|no_keys` (→ `has_keys`/`active_7d` query params); empty subscribers message references migration `002_user_billing.sql`. No `NEXT_PUBLIC_DEV_MODE` bypass.
+- **Behaviors:** most tab fetches `.catch(()=>…)` **silently**; **search reloads only on Enter/Refresh** (search text is not in effect deps); subscriber filters `trialing|active|past_due`; managed filters `all|active|keys|no_keys` (→ `has_keys`/`active_7d` query params); demo requests search includes name, email, company, website, **role** (`position`), **source**; empty subscribers message references migration `002_user_billing.sql`. No `NEXT_PUBLIC_DEV_MODE` bypass.
+
+### 20.6 Enterprise marketing — `app/enterprise/page.tsx`
+
+- **Server shell** with SEO `metadata`; client body in `EnterprisePageClient`.
+- **10 sections** (order): Hero → What is → Fleet (drift) → Capabilities → Tier compare → VPC deploy → Platform → FAQ → Footer CTA (`#connect`) → Resources strip.
+- **Copy:** single source `components/marketing/enterprise/enterprise-copy.ts` — no false SOC 2 / SSO-as-shipped / hallucination-detection claims.
+- **Lead capture:** `EnterpriseConnectForm` → `submitDemoRequest` (`lib/demo.ts`) with `source: 'enterprise'`, optional `position`; honeypot `botcheck`.
+- **Shared marketing shell:** `SiteNav active="enterprise"`, `MarketingPageStyles`, `MarketingFooter`, `CalendlyBookModal` for Book demo.
+- **Cross-links:** landing `#pricing` → `/enterprise`; trust `#deployment`, `#limits`, `#licensing` → `/enterprise`.
+- **QA:** `docs/enterprise-page-qa.md` · agent rule `.cursor/rules/enterprise-page-knowledge-base.mdc`.
 
 ---
 
 ## 21. Data Model (backend)
 
-Schema sources: `core/db/schema.sql` (base DDL, Docker init) + `core/db/migrations/002-006` + **runtime idempotent DDL** in `core/db/connection.py` (production relies primarily on this). Extensions: `vector`, `uuid-ossp`. There is no migration `001`.
+Schema sources: `core/db/schema.sql` (base DDL, Docker init) + `core/db/migrations/002-007` + **runtime idempotent DDL** in `core/db/connection.py` (production relies primarily on this). Extensions: `vector`, `uuid-ossp`. There is no migration `001`.
 
 ### 21.1 Postgres tables (key columns)
 
@@ -786,7 +796,7 @@ Schema sources: `core/db/schema.sql` (base DDL, Docker init) + `core/db/migratio
 | `usage_daily` | `(tenant_id, date)` (PK), `events_written`, `queries_run`, `searches_run` | Daily metering (only `events_written` is incremented today) |
 | `community_posts` | `post_id` (PK), `author_name`, `category`, `title`, `body`, `image_urls` (JSONB), `reply_count` | Public community board |
 | `community_replies` | `reply_id` (PK), `post_id` (FK cascade), `author_name`, `body` | Replies; bumps parent `reply_count` |
-| `demo_requests` | `request_id` (PK), `first_name`, `last_name`, `email`, `company_name`, `website`, `ip_address` | Landing "Book demo" submissions |
+| `demo_requests` | `request_id` (PK), `first_name`, `last_name`, `email`, `company_name`, `website`, `position`, `source`, `ip_address` | Landing Book demo + Enterprise Let's connect submissions |
 | `sdk_telemetry` | `install_id` (PK), `sdk`, `sdk_version`, `runtime`, `os`, `mode` (`cloud`/`self-hosted`), `ping_count` | Anonymous SDK install pings (runtime-only table, not in `schema.sql`) |
 
 **Cascade:** `agents`, `api_keys`, `events`, `usage_daily` cascade from `tenants`. Account deletion explicitly deletes `users`, `auth_otps`, `tenants` and purges Qdrant vectors.

--- a/dashboard/app/admin/page.tsx
+++ b/dashboard/app/admin/page.tsx
@@ -103,6 +103,8 @@ interface DemoRequest {
   email: string
   company_name: string
   website: string
+  position: string | null
+  source: string | null
   ip_address: string | null
   created_at: string | null
 }
@@ -792,7 +794,7 @@ function DemoRequestsSection({ token }: { token: string }) {
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12 }}>
-        <Stat label="Total requests" value={fmt(rows?.length)} sub="from Book demo form" accent="#7c3aed" />
+        <Stat label="Total requests" value={fmt(rows?.length)} sub="from contact forms" accent="#7c3aed" />
       </div>
 
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, alignItems: 'center' }}>
@@ -800,7 +802,7 @@ function DemoRequestsSection({ token }: { token: string }) {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           onKeyDown={(e) => e.key === 'Enter' && load()}
-          placeholder="Search name, email, company, website…"
+          placeholder="Search name, email, company, website, role, source…"
           style={{
             flex: '1 1 220px', padding: '8px 12px', background: '#0a0a0a',
             border: '1px solid #2a2a2a', borderRadius: 8, color: '#fff', fontSize: 13,
@@ -809,18 +811,20 @@ function DemoRequestsSection({ token }: { token: string }) {
         <button type="button" onClick={load} style={btnSmall()}>Refresh</button>
       </div>
 
-      <Card title="Demo requests" subtitle="Submissions from the homepage Book demo form. Newest first.">
+      <Card title="Demo requests" subtitle="Submissions from Let's connect and contact forms. Newest first.">
         {!rows ? <SkeletonBlock /> : rows.length === 0 ? (
           <Empty>No demo requests yet.</Empty>
         ) : (
           <div style={{ overflowX: 'auto' }}>
-            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, minWidth: 760 }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13, minWidth: 920 }}>
               <thead>
                 <tr style={{ borderBottom: '1px solid #1f1f1f', color: '#737373', fontSize: 11, textTransform: 'uppercase' }}>
                   <Th>First name</Th>
                   <Th>Last name</Th>
                   <Th>Email</Th>
                   <Th>Company</Th>
+                  <Th>Role</Th>
+                  <Th>Source</Th>
                   <Th>Website</Th>
                   <Th align="right">Submitted</Th>
                 </tr>
@@ -832,6 +836,8 @@ function DemoRequestsSection({ token }: { token: string }) {
                     <Td>{r.last_name}</Td>
                     <Td mono>{r.email}</Td>
                     <Td>{r.company_name}</Td>
+                    <Td subtle>{r.position || '—'}</Td>
+                    <Td subtle>{r.source || '—'}</Td>
                     <Td>
                       <a href={r.website.startsWith('http') ? r.website : `https://${r.website}`}
                          target="_blank" rel="noreferrer"

--- a/dashboard/app/community/page.tsx
+++ b/dashboard/app/community/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 import { SiteNav } from '@/components/SiteNav'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
 import { BRAND } from '@/components/brand'
 import { formatDistanceToNow } from 'date-fns'
 import {
@@ -165,6 +166,7 @@ export default function CommunityPage() {
           </div>
         )}
       </main>
+      <MarketingFooter />
     </div>
   )
 }

--- a/dashboard/app/docs/page.tsx
+++ b/dashboard/app/docs/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useState } from 'react'
 import { SiteNav } from '@/components/SiteNav'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
 import {
   OverviewSection,
   PythonSection,
@@ -141,6 +142,7 @@ export default function DocsPage() {
           {section === 'concepts' && <ConceptsSection onNavigate={navigate} />}
         </main>
       </div>
+      <MarketingFooter />
     </div>
   )
 }

--- a/dashboard/app/enterprise/page.tsx
+++ b/dashboard/app/enterprise/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next'
+import { EnterprisePageClient } from '@/components/marketing/enterprise/EnterprisePageClient'
+
+export const metadata: Metadata = {
+  title: 'Enterprise — VPC deployment for agent fleets',
+  description:
+    'Licensed ZizkaDB in your VPC. Fleet observability, behavioral drift, audit exports, and Week-1 install — without rebuilding your agent platform.',
+  openGraph: {
+    title: 'ZizkaDB Enterprise — VPC deployment for agent fleets',
+    description:
+      'Licensed, single-tenant ZizkaDB in your cloud. Fleet dashboard, behavioral drift, audit export, and supported Week-1 install.',
+    type: 'website',
+  },
+}
+
+export default function EnterprisePage() {
+  return <EnterprisePageClient />
+}

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -9,7 +9,8 @@ import { CompetitorCompare } from '@/components/marketing/CompetitorCompare'
 import { ConversationCompare } from '@/components/marketing/ConversationCompare'
 import { ThreeWaysConnectSection } from '@/components/marketing/ThreeWaysConnectSection'
 import { TrustBar } from '@/components/marketing/TrustBar'
-import { BrandLogo } from '@/components/BrandLogo'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
+import { MarketingPageStyles } from '@/components/marketing/MarketingPageStyles'
 import { BRAND, BRAND_DARK } from '@/components/brand'
 import { M, container, h2, lead, sectionTitle, primaryBtn, blueBtn, violetBtn, ghostBtn, outlineBtn } from '@/components/marketing/marketing-theme'
 
@@ -41,26 +42,7 @@ export default function LandingPage() {
 
   return (
     <div style={{ fontFamily: 'Inter, system-ui, sans-serif', color: M.ink, background: '#fff' }}>
-      <style>{`
-        @media (max-width: 1024px) {
-          .zdb-connect-grid { grid-template-columns: 1fr !important; }
-        }
-        @media (max-width: 768px) {
-          .zdb-section { padding-left: 20px !important; padding-right: 20px !important; }
-          .zdb-hero-title { font-size: 32px !important; }
-          .zdb-hero-value { font-size: 16px !important; }
-          .zdb-connect-grid { grid-template-columns: 1fr !important; gap: 12px !important; }
-          .zdb-section { padding-top: 48px !important; padding-bottom: 48px !important; }
-          .zdb-compare-grid { grid-template-columns: 1fr !important; }
-          .zdb-split { grid-template-columns: 1fr !important; }
-          .zdb-price-grid { grid-template-columns: 1fr !important; }
-          .zdb-trust-grid { grid-template-columns: 1fr 1fr !important; }
-          .zdb-hero-btns { flex-direction: column !important; align-items: stretch !important; }
-          .zdb-hero-btns a, .zdb-hero-btns button { justify-content: center !important; }
-          .zdb-footer { flex-direction: column !important; gap: 16px !important; align-items: flex-start !important; }
-          .zdb-footer-links { flex-wrap: wrap !important; gap: 16px !important; }
-        }
-      `}</style>
+      <MarketingPageStyles />
 
       <SiteNav />
 
@@ -185,13 +167,13 @@ export default function LandingPage() {
               },
               {
                 name: 'Pro', price: '€39', sub: '/ month',
-                features: ['100M events', '90-day retention', '3 projects', 'Email support'],
+                features: ['100M events', '90-day retention', '3 active API keys', 'Email support'],
                 cta: 'Start free trial', href: '/signup?plan=pro', highlight: true,
                 note: '30-day free trial · No credit card required',
               },
               {
                 name: 'Team', price: '€99', sub: '/ month',
-                features: ['Up to 1B events/mo', '1-year retention', '10 seats', 'Priority support'],
+                features: ['Up to 1B events/mo', '1-year retention', '10 active API keys', 'Priority support'],
                 cta: 'Start free trial', href: '/signup?plan=team', highlight: false,
                 note: '30-day free trial · No credit card required',
               },
@@ -238,6 +220,11 @@ export default function LandingPage() {
               </div>
             ))}
           </div>
+          <p style={{ textAlign: 'center', marginTop: 28, marginBottom: 0, fontSize: 15, fontWeight: 600, color: '#000' }}>
+            <Link href="/enterprise" style={{ color: BRAND, textDecoration: 'none' }}>
+              Enterprise — Contact sales →
+            </Link>
+          </p>
         </div>
       </section>
 
@@ -263,29 +250,7 @@ export default function LandingPage() {
         </div>
       </section>
 
-      {/* ── Footer ── */}
-      <footer className="zdb-footer" style={{
-        borderTop: `1px solid ${M.line}`, padding: '32px 24px',
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        fontSize: 13, color: '#000', background: '#fff', flexWrap: 'wrap', gap: 16,
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <BrandLogo variant="mark" showWordmark={false} href="/" />
-          <span style={{ fontWeight: 700, color: '#000' }}>ZizkaDB</span>
-          <span style={{ color: '#000' }}>·</span>
-          <span style={{ fontWeight: 500, color: '#000' }}>Open source operational database for AI agents</span>
-        </div>
-        <div className="zdb-footer-links" style={{ display: 'flex', gap: 22, flexWrap: 'wrap' }}>
-          {[['Docs', '/docs'], ['Pricing', '#pricing'], ['Trust', '/trust'], ['GitHub', GITHUB_URL], ['Sign in', '/login']].map(([label, href]) =>
-            href.startsWith('http') ? (
-              <a key={label} href={href} target="_blank" rel="noreferrer" style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>{label}</a>
-            ) : (
-              <Link key={label} href={href} style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>{label}</Link>
-            )
-          )}
-          <Link href="/signup" style={{ color: '#000', fontWeight: 700, textDecoration: 'none' }}>Start free</Link>
-        </div>
-      </footer>
+      <MarketingFooter />
     </div>
   )
 }

--- a/dashboard/app/signup/plan/page.tsx
+++ b/dashboard/app/signup/plan/page.tsx
@@ -14,7 +14,7 @@ const PLANS = [
     price: '€39',
     price_sub: '/ month',
     highlight: true,
-    features: ['100M events', '90-day retention', '3 projects', 'Email support'],
+    features: ['100M events', '90-day retention', '3 active API keys', 'Email support'],
   },
   {
     id: 'team' as const,
@@ -22,7 +22,7 @@ const PLANS = [
     price: '€99',
     price_sub: '/ month',
     highlight: false,
-    features: ['Up to 1B events/mo', '1-year retention', '10 seats', 'Priority support'],
+    features: ['Up to 1B events/mo', '1-year retention', '10 active API keys', 'Priority support'],
   },
 ]
 

--- a/dashboard/app/trust/page.tsx
+++ b/dashboard/app/trust/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import type { CSSProperties, ReactNode } from 'react'
 import { SiteNav } from '@/components/SiteNav'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
 
 export const metadata = {
   title: 'Technical reference',
@@ -274,7 +275,8 @@ docker compose -f infra/docker-compose.yml up -d`}</Code>
               <li><strong>Telemetry:</strong> one anonymous SDK/MCP startup ping — opt out with <code style={codeInline}>ZIZKADB_TELEMETRY=false</code>.</li>
             </ul>
             <p style={p}>
-              <strong>Not claimed today:</strong> SOC 2, HIPAA, or formal DPAs. For enterprise security review, contact{' '}
+              <strong>Not claimed today:</strong> SOC 2, HIPAA, or formal DPAs. For enterprise security review and VPC deployment, see{' '}
+              <Link href="/enterprise" style={link}>/enterprise</Link> or contact{' '}
               <a href="mailto:founder@zizka.ai" style={link}>founder@zizka.ai</a>.
             </p>
           </Section>
@@ -377,6 +379,7 @@ chain = await db.why(tool.event_id)`}</Code>
                   ['Self-hosted', 'Free (AGPL core)', 'Your VPC / machine'],
                   ['Managed Pro', '€39/mo', 'Zizka cloud'],
                   ['Managed Team', '€99/mo', 'Zizka cloud + higher limits'],
+                  ['Enterprise', 'Contact sales', 'Customer VPC (Model A)'],
                 ].map(([m, c, d]) => (
                   <tr key={m}><td style={td}>{m}</td><td style={td}>{c}</td><td style={td}>{d}</td></tr>
                 ))}
@@ -384,6 +387,7 @@ chain = await db.why(tool.event_id)`}</Code>
             </table>
             <p style={p}>
               Onboarding: <Link href="/signup" style={link}>signup</Link> → email OTP → Settings → API key → SDK or MCP env.
+              For Enterprise VPC deployment, see <Link href="/enterprise" style={link}>/enterprise</Link>.
             </p>
           </Section>
 
@@ -444,6 +448,7 @@ chain = await db.why(tool.event_id)`}</Code>
             </table>
             <p style={p}>
               AGPL applies when you modify and distribute the server. MCP is MIT for IDE integration. Commercial embedding requires legal review.
+              Enterprise VPC deployments use a separate commercial license — see <Link href="/enterprise" style={link}>/enterprise</Link>.
             </p>
           </Section>
 
@@ -455,6 +460,7 @@ chain = await db.why(tool.event_id)`}</Code>
                   ['Self-hosted', 'Unlimited (your hardware)', 'Operator-defined'],
                   ['Pro (€39/mo)', '100M', '90 days'],
                   ['Team (€99/mo)', 'Up to 1B (plan cap)', '1 year'],
+                  ['Enterprise', 'Contact sales', 'Custom (VPC)'],
                 ].map(([plan, ev, ret]) => (
                   <tr key={plan}><td style={td}>{plan}</td><td style={td}>{ev}</td><td style={td}>{ret}</td></tr>
                 ))}
@@ -530,6 +536,8 @@ chain = await db.why(tool.event_id)`}</Code>
           </Section>
         </main>
       </div>
+
+      <MarketingFooter />
 
       <style>{`
         @media (min-width: 900px) {

--- a/dashboard/components/SiteNav.tsx
+++ b/dashboard/components/SiteNav.tsx
@@ -3,7 +3,7 @@ import type { CSSProperties } from 'react'
 import { BrandLogo } from './BrandLogo'
 import { brandCtaStyle } from './brand'
 
-export type SiteNavActive = 'docs' | 'community' | 'trust' | 'explorer' | 'home'
+export type SiteNavActive = 'docs' | 'community' | 'trust' | 'explorer' | 'home' | 'enterprise'
 
 type SiteNavProps = {
   active?: SiteNavActive
@@ -13,9 +13,20 @@ type SiteNavProps = {
 
 const linkStyle = (on: boolean): CSSProperties => ({
   fontSize: 14,
-  color: on ? '#000' : '#000',
+  color: '#000',
   fontWeight: on ? 600 : 400,
   textDecoration: 'none',
+})
+
+const enterpriseLinkStyle = (on: boolean): CSSProperties => ({
+  fontSize: 14,
+  fontWeight: 600,
+  color: '#000',
+  textDecoration: 'none',
+  padding: '6px 12px',
+  borderRadius: 8,
+  border: '1px solid #e2e8f0',
+  background: on ? '#f8fafc' : 'transparent',
 })
 
 export function SiteNav({ active, suffix }: SiteNavProps) {
@@ -41,6 +52,7 @@ export function SiteNav({ active, suffix }: SiteNavProps) {
         <Link href="/docs" style={linkStyle(active === 'docs')}>Docs</Link>
         <Link href="/community" style={linkStyle(active === 'community')}>Community</Link>
         <a href="/swagger" style={linkStyle(active === 'explorer')}>API Explorer</a>
+        <Link href="/enterprise" style={enterpriseLinkStyle(active === 'enterprise')}>Enterprise</Link>
         <Link href="/login" style={{
           fontSize: 14, fontWeight: 500, color: '#000', textDecoration: 'none',
           padding: '7px 16px', border: '1px solid #ddd', borderRadius: 8,
@@ -51,6 +63,12 @@ export function SiteNav({ active, suffix }: SiteNavProps) {
       </div>
 
       <div className="site-nav-cta" style={{ display: 'none', alignItems: 'center', gap: 8 }}>
+        <Link href="/enterprise" style={{
+          fontSize: 13, fontWeight: 600, color: '#111', textDecoration: 'none',
+          padding: '6px 10px', border: '1px solid #e2e8f0', borderRadius: 8,
+        }}>
+          Enterprise
+        </Link>
         <Link href="/login" style={{
           fontSize: 13, fontWeight: 500, color: '#111', textDecoration: 'none',
           padding: '6px 12px', border: '1px solid #ddd', borderRadius: 8,
@@ -59,7 +77,6 @@ export function SiteNav({ active, suffix }: SiteNavProps) {
         </Link>
         <Link href="/signup" style={{ ...brandCtaStyle, fontSize: 13, padding: '6px 14px' }}>Start free →</Link>
       </div>
-
     </nav>
   )
 }

--- a/dashboard/components/marketing/MarketingFooter.tsx
+++ b/dashboard/components/marketing/MarketingFooter.tsx
@@ -1,0 +1,62 @@
+import Link from 'next/link'
+import { BrandLogo } from '@/components/BrandLogo'
+
+const GITHUB_URL = 'https://github.com/Zizka-ai/ZizkaDB'
+
+const LINKS: [string, string][] = [
+  ['Docs', '/docs'],
+  ['Enterprise', '/enterprise'],
+  ['Pricing', '/#pricing'],
+  ['Trust', '/trust'],
+  ['GitHub', GITHUB_URL],
+  ['Sign in', '/login'],
+]
+
+export function MarketingFooter() {
+  return (
+    <footer
+      className="zdb-footer"
+      style={{
+        borderTop: '1px solid #e2e8f0',
+        padding: '32px 24px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        fontSize: 13,
+        color: '#000',
+        background: '#fff',
+        flexWrap: 'wrap',
+        gap: 16,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <BrandLogo variant="mark" showWordmark={false} href="/" />
+        <span style={{ fontWeight: 700, color: '#000' }}>ZizkaDB</span>
+        <span style={{ color: '#000' }}>·</span>
+        <span style={{ fontWeight: 500, color: '#000' }}>Open source operational database for AI agents</span>
+      </div>
+      <div className="zdb-footer-links" style={{ display: 'flex', gap: 22, flexWrap: 'wrap' }}>
+        {LINKS.map(([label, href]) =>
+          href.startsWith('http') ? (
+            <a
+              key={label}
+              href={href}
+              target="_blank"
+              rel="noreferrer"
+              style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}
+            >
+              {label}
+            </a>
+          ) : (
+            <Link key={label} href={href} style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>
+              {label}
+            </Link>
+          ),
+        )}
+        <Link href="/signup" style={{ color: '#000', fontWeight: 700, textDecoration: 'none' }}>
+          Start free
+        </Link>
+      </div>
+    </footer>
+  )
+}

--- a/dashboard/components/marketing/MarketingPageStyles.tsx
+++ b/dashboard/components/marketing/MarketingPageStyles.tsx
@@ -1,0 +1,44 @@
+export function MarketingPageStyles() {
+  return (
+    <style>{`
+      .zdb-section-anchor {
+        scroll-margin-top: 72px;
+      }
+      .zdb-faq-summary::-webkit-details-marker {
+        display: none;
+      }
+      .zdb-faq-summary:focus-visible {
+        outline: 2px solid #f97316;
+        outline-offset: -2px;
+      }
+      .zdb-connect-submit:focus-visible {
+        outline: 2px solid #f97316;
+        outline-offset: 2px;
+      }
+      @media (max-width: 1024px) {
+        .zdb-connect-grid { grid-template-columns: 1fr !important; }
+        .zdb-feature-grid { grid-template-columns: repeat(2, 1fr) !important; }
+      }
+      @media (max-width: 768px) {
+        .site-nav-links { display: none !important; }
+        .site-nav-cta { display: flex !important; }
+        .zdb-section { padding-left: 20px !important; padding-right: 20px !important; }
+        .zdb-hero-title { font-size: 32px !important; }
+        .zdb-hero-value { font-size: 16px !important; }
+        .zdb-connect-grid { grid-template-columns: 1fr !important; gap: 12px !important; }
+        .zdb-section { padding-top: 48px !important; padding-bottom: 48px !important; }
+        .zdb-compare-grid { grid-template-columns: 1fr !important; }
+        .zdb-split { grid-template-columns: 1fr !important; }
+        .zdb-price-grid { grid-template-columns: 1fr !important; }
+        .zdb-tier-grid { grid-template-columns: 1fr !important; }
+        .zdb-trust-grid { grid-template-columns: 1fr 1fr !important; }
+        .zdb-feature-grid { grid-template-columns: 1fr !important; }
+        .zdb-resource-grid { grid-template-columns: 1fr 1fr !important; }
+        .zdb-hero-btns { flex-direction: column !important; align-items: stretch !important; }
+        .zdb-hero-btns a, .zdb-hero-btns button { justify-content: center !important; }
+        .zdb-footer { flex-direction: column !important; gap: 16px !important; align-items: flex-start !important; }
+        .zdb-footer-links { flex-wrap: wrap !important; gap: 16px !important; }
+      }
+    `}</style>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseCapabilitiesSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseCapabilitiesSection.tsx
@@ -1,0 +1,86 @@
+import type { CSSProperties } from 'react'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+const th: CSSProperties = {
+  textAlign: 'left',
+  padding: '10px 14px',
+  fontSize: 12,
+  fontWeight: 700,
+  color: '#666',
+  borderBottom: `1px solid ${M.line}`,
+  background: M.wash,
+}
+
+const td: CSSProperties = {
+  padding: '12px 14px',
+  fontSize: 14,
+  color: '#000',
+  fontWeight: 500,
+  borderBottom: `1px solid ${M.line}`,
+  verticalAlign: 'top',
+}
+
+export function EnterpriseCapabilitiesSection() {
+  const { capabilities } = COPY
+
+  return (
+    <section id="capabilities" className="zdb-section zdb-section-anchor" style={{ padding: '88px 40px', background: M.wash, scrollMarginTop: 72 }}>
+      <div style={container(1000)}>
+        <p style={sectionTitle}>{capabilities.sectionTitle}</p>
+        <h2 style={h2}>{capabilities.h2}</h2>
+        <p style={lead}>{capabilities.lead}</p>
+
+        <div className="zdb-split" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 24, marginTop: 36 }}>
+          <div style={{ ...card, padding: '24px 22px' }}>
+            <h3 style={{ fontSize: 18, fontWeight: 700, margin: '0 0 6px', color: '#000' }}>
+              {capabilities.openCore.title}
+            </h3>
+            <p style={{ fontSize: 13, color: '#666', margin: '0 0 18px', fontWeight: 500 }}>
+              {capabilities.openCore.subtitle}
+            </p>
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th style={th}>Capability</th>
+                  <th style={th}>API / concept</th>
+                </tr>
+              </thead>
+              <tbody>
+                {capabilities.openCore.rows.map(([cap, api]) => (
+                  <tr key={cap}>
+                    <td style={{ ...td, fontWeight: 600 }}>{cap}</td>
+                    <td style={{ ...td, fontFamily: 'ui-monospace, monospace', fontSize: 13 }}>{api}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div style={{
+            ...card, padding: '24px 22px', border: `2px solid ${BRAND}`,
+            boxShadow: '0 12px 40px rgba(249,115,22,0.08)',
+          }}>
+            <h3 style={{ fontSize: 18, fontWeight: 700, margin: '0 0 18px', color: '#000' }}>
+              {capabilities.enterprise.title}
+            </h3>
+            <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 12 }}>
+              {capabilities.enterprise.items.map((item) => (
+                <li key={item} style={{ fontSize: 14, color: '#000', fontWeight: 500, display: 'flex', gap: 8 }}>
+                  <span style={{ color: BRAND, fontWeight: 800 }}>✓</span> {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <p style={{
+          marginTop: 24, marginBottom: 0, fontSize: 13, lineHeight: 1.6, fontWeight: 500, color: '#666',
+        }}>
+          {capabilities.footnote}
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseConnectForm.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseConnectForm.tsx
@@ -1,0 +1,147 @@
+'use client'
+
+import { useState, type FormEvent } from 'react'
+import { COPY } from './enterprise-copy'
+import { submitDemoRequest } from '@/lib/demo'
+import { M } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+const inputStyle = {
+  width: '100%',
+  padding: '11px 14px',
+  borderRadius: 10,
+  border: `1px solid ${M.line}`,
+  fontSize: 14,
+  fontFamily: 'inherit',
+  boxSizing: 'border-box' as const,
+}
+
+const labelStyle = {
+  display: 'block',
+  fontSize: 13,
+  fontWeight: 600,
+  color: '#000',
+  marginBottom: 6,
+}
+
+type Props = {
+  id?: string
+}
+
+export function EnterpriseConnectForm({ id }: Props) {
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [email, setEmail] = useState('')
+  const [company, setCompany] = useState('')
+  const [position, setPosition] = useState('')
+  const [website, setWebsite] = useState('')
+  const [botcheck, setBotcheck] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [success, setSuccess] = useState(false)
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault()
+    if (botcheck) return
+    setLoading(true)
+    setError('')
+    try {
+      await submitDemoRequest({
+        first_name: firstName.trim(),
+        last_name: lastName.trim(),
+        email: email.trim(),
+        company_name: company.trim(),
+        website: website.trim(),
+        position: position.trim() || undefined,
+        source: 'enterprise',
+      })
+      setSuccess(true)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : COPY.form.genericError
+      setError(msg.includes('Too many') ? COPY.form.rateLimit : msg)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (success) {
+    return (
+      <div
+        id={id}
+        role="status"
+        aria-live="polite"
+        style={{
+          padding: '24px', borderRadius: 14, background: '#fff', border: `1px solid ${M.line}`,
+          textAlign: 'center', fontSize: 15, fontWeight: 600, color: '#000',
+        }}
+      >
+        {COPY.form.success}
+      </div>
+    )
+  }
+
+  return (
+    <form
+      id={id}
+      onSubmit={handleSubmit}
+      className="zdb-connect-form"
+      style={{
+        position: 'relative',
+        padding: '24px', borderRadius: 14, background: '#fff', border: `1px solid ${M.line}`,
+        display: 'flex', flexDirection: 'column', gap: 14, textAlign: 'left',
+      }}
+    >
+      <div className="zdb-split" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+        <div>
+          <label htmlFor="ent-first" style={labelStyle}>First name</label>
+          <input id="ent-first" required value={firstName} onChange={(e) => setFirstName(e.target.value)} style={inputStyle} />
+        </div>
+        <div>
+          <label htmlFor="ent-last" style={labelStyle}>Last name</label>
+          <input id="ent-last" required value={lastName} onChange={(e) => setLastName(e.target.value)} style={inputStyle} />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="ent-email" style={labelStyle}>Work email</label>
+        <input id="ent-email" type="email" required value={email} onChange={(e) => setEmail(e.target.value)} style={inputStyle} />
+      </div>
+      <div>
+        <label htmlFor="ent-company" style={labelStyle}>Company</label>
+        <input id="ent-company" required value={company} onChange={(e) => setCompany(e.target.value)} style={inputStyle} />
+      </div>
+      <div>
+        <label htmlFor="ent-position" style={labelStyle}>Role / title (optional)</label>
+        <input id="ent-position" value={position} onChange={(e) => setPosition(e.target.value)} style={inputStyle} />
+      </div>
+      <div>
+        <label htmlFor="ent-website" style={labelStyle}>Company website</label>
+        <input id="ent-website" required value={website} onChange={(e) => setWebsite(e.target.value)} placeholder={COPY.form.websiteHint} style={inputStyle} />
+      </div>
+      <input
+        type="text"
+        name="botcheck"
+        value={botcheck}
+        onChange={(e) => setBotcheck(e.target.value)}
+        tabIndex={-1}
+        autoComplete="off"
+        aria-hidden="true"
+        style={{ position: 'absolute', left: '-9999px', opacity: 0, height: 0, width: 0 }}
+      />
+      {error && (
+        <p style={{ margin: 0, fontSize: 13, color: '#b91c1c', fontWeight: 600 }} role="alert">{error}</p>
+      )}
+      <button
+        type="submit"
+        disabled={loading}
+        className="zdb-connect-submit"
+        style={{
+          marginTop: 4, padding: '13px 20px', borderRadius: 10, border: 'none', cursor: loading ? 'wait' : 'pointer',
+          background: `linear-gradient(135deg, ${BRAND} 0%, #ea580c 100%)`, color: '#fff',
+          fontWeight: 700, fontSize: 15, opacity: loading ? 0.7 : 1,
+        }}
+      >
+        {loading ? 'Sending…' : "Let's connect"}
+      </button>
+    </form>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseFaqSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseFaqSection.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+export function EnterpriseFaqSection() {
+  return (
+    <section id="faq" className="zdb-section zdb-section-anchor" style={{ padding: '88px 40px', background: '#fff', scrollMarginTop: 72 }}>
+      <div style={container(760)}>
+        <p style={sectionTitle}>{COPY.faq.sectionTitle}</p>
+        <h2 style={h2}>{COPY.faq.h2}</h2>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 36 }}>
+          {COPY.faq.items.map((item) => (
+            <details key={item.q} className="zdb-faq-details" style={{ ...card, padding: 0, overflow: 'hidden' }}>
+              <summary className="zdb-faq-summary" style={{
+                padding: '18px 20px', cursor: 'pointer', fontSize: 15, fontWeight: 700, color: '#000',
+                listStyle: 'none',
+              }}>
+                {item.q}
+              </summary>
+              <div style={{
+                padding: '0 20px 18px', fontSize: 14, lineHeight: 1.65, color: '#000', fontWeight: 500,
+                borderTop: `1px solid ${M.line}`,
+              }}>
+                {item.a}
+                {'link' in item && item.link && (
+                  <>
+                    {' '}
+                    <Link href={item.link.href} style={{ color: BRAND, textDecoration: 'none', fontWeight: 600 }}>
+                      {item.link.label} →
+                    </Link>
+                  </>
+                )}
+              </div>
+            </details>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseFleetSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseFleetSection.tsx
@@ -1,0 +1,72 @@
+import dynamic from 'next/dynamic'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+const SessionReplayDemo = dynamic(
+  () => import('../SessionReplayDemo').then((m) => m.SessionReplayDemo),
+  {
+    ssr: false,
+    loading: () => (
+      <div style={{
+        height: 320, borderRadius: 16, background: M.wash, border: `1px solid ${M.line}`,
+        display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#666', fontSize: 14,
+      }}>
+        Loading preview…
+      </div>
+    ),
+  },
+)
+
+export function EnterpriseFleetSection() {
+  const { driftBands } = COPY.fleet
+
+  return (
+    <section id="fleet" className="zdb-section zdb-section-anchor" style={{ padding: '88px 40px', background: '#fff', scrollMarginTop: 72 }}>
+      <div style={container(980)}>
+        <p style={sectionTitle}>{COPY.fleet.sectionTitle}</p>
+        <h2 style={h2}>{COPY.fleet.h2}</h2>
+        <p style={lead}>{COPY.fleet.lead}</p>
+
+        <div className="zdb-split" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 32, alignItems: 'start' }}>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {COPY.fleet.bullets.map((b) => (
+              <div key={b.title} style={{ ...card, padding: '20px 22px' }}>
+                <div style={{ fontSize: 15, fontWeight: 700, color: '#000', marginBottom: 6 }}>{b.title}</div>
+                <div style={{ fontSize: 14, color: '#000', lineHeight: 1.6, fontWeight: 500 }}>{b.body}</div>
+              </div>
+            ))}
+            <div style={{
+              padding: '16px 18px', borderRadius: 12, background: '#fff7ed',
+              border: `1px solid ${BRAND}44`, fontSize: 13, lineHeight: 1.6, fontWeight: 500, color: '#000',
+            }}>
+              {COPY.fleet.driftNote}
+            </div>
+            <div style={{ ...card, padding: '18px 20px' }}>
+              <div style={{ fontSize: 14, fontWeight: 700, color: '#000', marginBottom: 10 }}>{driftBands.title}</div>
+              <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginBottom: 12 }}>
+                {driftBands.bands.map((b) => (
+                  <span key={b.label} style={{
+                    fontSize: 12, fontWeight: 600, padding: '5px 10px', borderRadius: 8,
+                    background: M.wash, border: `1px solid ${M.line}`, color: '#000',
+                  }}>
+                    {b.label} · {b.range}
+                  </span>
+                ))}
+              </div>
+              <p style={{ margin: 0, fontSize: 13, lineHeight: 1.55, color: '#666', fontWeight: 500 }}>
+                {driftBands.requirement}
+              </p>
+            </div>
+          </div>
+          <div>
+            <SessionReplayDemo />
+            <p style={{ textAlign: 'center', fontSize: 12, color: '#666', marginTop: 12, fontWeight: 500 }}>
+              {COPY.fleet.demoCaption}
+            </p>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseFooterCtaSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseFooterCtaSection.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link'
+import { COPY } from './enterprise-copy'
+import { EnterpriseConnectForm } from './EnterpriseConnectForm'
+import { M, container, ghostBtn, violetBtn } from '../marketing-theme'
+
+type Props = {
+  onBookDemo: () => void
+}
+
+export function EnterpriseFooterCtaSection({ onBookDemo }: Props) {
+  return (
+    <section
+      id="connect"
+      className="zdb-section"
+      style={{
+        padding: '88px 40px',
+        background: M.heroBg,
+        position: 'relative',
+        overflow: 'hidden',
+        scrollMarginTop: 72,
+      }}
+    >
+      <div style={{ position: 'absolute', inset: 0, background: M.heroGlowBlue, pointerEvents: 'none' }} />
+      <div style={{ ...container(640), position: 'relative', zIndex: 1, textAlign: 'center' }}>
+        <h2 style={{ fontSize: 32, fontWeight: 700, color: '#fff', margin: '0 0 12px', letterSpacing: -0.5 }}>
+          {COPY.footerCta.h2}
+        </h2>
+        <p style={{ fontSize: 16, color: 'rgba(255,255,255,0.88)', margin: '0 0 28px', lineHeight: 1.65, fontWeight: 500 }}>
+          {COPY.footerCta.subhead}
+        </p>
+
+        <EnterpriseConnectForm />
+
+        <div style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap', marginTop: 24 }}>
+          <button type="button" onClick={onBookDemo} style={{ ...violetBtn, cursor: 'pointer', border: 'none' }}>
+            {COPY.footerCta.demoCta}
+          </button>
+          <Link href="/signup" style={ghostBtn}>{COPY.footerCta.cloudCta}</Link>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseHeroSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseHeroSection.tsx
@@ -1,0 +1,56 @@
+'use client'
+
+import { COPY } from './enterprise-copy'
+import { M, primaryBtn, violetBtn } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+type Props = {
+  onConnectClick: () => void
+  onBookDemo: () => void
+}
+
+export function EnterpriseHeroSection({ onConnectClick, onBookDemo }: Props) {
+  return (
+    <section
+      className="zdb-section"
+      style={{
+        padding: '80px 40px 72px',
+        background: M.heroBg,
+        position: 'relative',
+        overflow: 'hidden',
+        color: '#fff',
+      }}
+    >
+      <div style={{ position: 'absolute', inset: 0, background: M.heroGlowOrange, pointerEvents: 'none' }} />
+      <div style={{ position: 'absolute', inset: 0, background: M.heroGlowBlue, pointerEvents: 'none' }} />
+      <div style={{ maxWidth: 760, margin: '0 auto', textAlign: 'center', position: 'relative', zIndex: 1 }}>
+        <div style={{
+          display: 'inline-block', marginBottom: 20, padding: '6px 14px', borderRadius: 100,
+          fontSize: 11, fontWeight: 700, letterSpacing: 0.8,
+          background: 'rgba(249,115,22,0.15)', border: '1px solid rgba(249,115,22,0.35)', color: BRAND,
+        }}>
+          {COPY.hero.eyebrow}
+        </div>
+        <h1 className="zdb-hero-title" style={{
+          fontSize: 44, fontWeight: 800, lineHeight: 1.12, margin: '0 0 20px', letterSpacing: -0.8,
+        }}>
+          {COPY.hero.h1}
+        </h1>
+        <p className="zdb-hero-value" style={{
+          fontSize: 18, fontWeight: 500, lineHeight: 1.65, margin: '0 auto 32px', maxWidth: 620,
+          color: 'rgba(255,255,255,0.88)',
+        }}>
+          {COPY.hero.subhead}
+        </p>
+        <div className="zdb-hero-btns" style={{ display: 'flex', gap: 12, justifyContent: 'center', flexWrap: 'wrap' }}>
+          <button type="button" onClick={onConnectClick} style={{ ...primaryBtn, cursor: 'pointer', border: 'none' }}>
+            {COPY.hero.connectCta}
+          </button>
+          <button type="button" onClick={onBookDemo} style={{ ...violetBtn, cursor: 'pointer' }}>
+            {COPY.hero.demoCta}
+          </button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterprisePageClient.tsx
+++ b/dashboard/components/marketing/enterprise/EnterprisePageClient.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { useCallback, useState } from 'react'
+import { SiteNav } from '@/components/SiteNav'
+import { CalendlyBookModal } from '@/components/marketing/CalendlyBookModal'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
+import { MarketingPageStyles } from '@/components/marketing/MarketingPageStyles'
+import { EnterpriseHeroSection } from './EnterpriseHeroSection'
+import { EnterpriseWhatIsSection } from './EnterpriseWhatIsSection'
+import { EnterpriseFleetSection } from './EnterpriseFleetSection'
+import { EnterpriseCapabilitiesSection } from './EnterpriseCapabilitiesSection'
+import { EnterpriseTierCompareSection } from './EnterpriseTierCompareSection'
+import { EnterpriseVpcDeploySection } from './EnterpriseVpcDeploySection'
+import { EnterprisePlatformFeaturesSection } from './EnterprisePlatformFeaturesSection'
+import { EnterpriseFaqSection } from './EnterpriseFaqSection'
+import { EnterpriseFooterCtaSection } from './EnterpriseFooterCtaSection'
+import { EnterpriseResourcesStrip } from './EnterpriseResourcesStrip'
+import { M } from '../marketing-theme'
+
+export function EnterprisePageClient() {
+  const [demoOpen, setDemoOpen] = useState(false)
+
+  const scrollToConnect = useCallback(() => {
+    document.getElementById('connect')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+    window.setTimeout(() => {
+      document.getElementById('ent-first')?.focus()
+    }, 400)
+  }, [])
+
+  return (
+    <div style={{ fontFamily: 'Inter, system-ui, sans-serif', color: M.ink, background: '#fff', minHeight: '100vh' }}>
+      <MarketingPageStyles />
+      <SiteNav active="enterprise" suffix="Enterprise" />
+
+      <main>
+        <EnterpriseHeroSection onConnectClick={scrollToConnect} onBookDemo={() => setDemoOpen(true)} />
+        <EnterpriseWhatIsSection />
+        <EnterpriseFleetSection />
+        <EnterpriseCapabilitiesSection />
+        <EnterpriseTierCompareSection onConnectClick={scrollToConnect} />
+        <EnterpriseVpcDeploySection />
+        <EnterprisePlatformFeaturesSection />
+        <EnterpriseFaqSection />
+        <EnterpriseFooterCtaSection onBookDemo={() => setDemoOpen(true)} />
+        <EnterpriseResourcesStrip />
+      </main>
+
+      <CalendlyBookModal open={demoOpen} onClose={() => setDemoOpen(false)} />
+      <MarketingFooter />
+    </div>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterprisePlatformFeaturesSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterprisePlatformFeaturesSection.tsx
@@ -1,0 +1,33 @@
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+export function EnterprisePlatformFeaturesSection() {
+  return (
+    <section className="zdb-section" style={{ padding: '88px 40px', background: M.wash }}>
+      <div style={container(1000)}>
+        <p style={sectionTitle}>{COPY.platform.sectionTitle}</p>
+        <h2 style={h2}>{COPY.platform.h2}</h2>
+        <p style={lead}>{COPY.platform.lead}</p>
+
+        <div className="zdb-feature-grid" style={{
+          display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, marginBottom: 24,
+        }}>
+          {COPY.platform.features.map((f) => (
+            <div key={f.title} style={{ ...card, padding: '22px 20px' }}>
+              <div style={{ fontSize: 15, fontWeight: 700, color: '#000', marginBottom: 8 }}>{f.title}</div>
+              <div style={{ fontSize: 13.5, lineHeight: 1.6, color: '#000', fontWeight: 500 }}>{f.body}</div>
+            </div>
+          ))}
+        </div>
+
+        <p style={{
+          textAlign: 'center', fontSize: 13, color: '#000', fontWeight: 500, lineHeight: 1.6,
+          maxWidth: 640, margin: '0 auto',
+        }}>
+          {COPY.platform.footnote}
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseResourcesStrip.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseResourcesStrip.tsx
@@ -1,0 +1,42 @@
+import Link from 'next/link'
+import { TECHNICAL_LINKS } from './enterprise-copy'
+import { M, container, sectionTitle, card } from '../marketing-theme'
+
+export function EnterpriseResourcesStrip() {
+  return (
+    <section className="zdb-section" style={{ padding: '64px 40px 88px', background: '#fff', borderTop: `1px solid ${M.line}` }}>
+      <div style={container(1000)}>
+        <p style={sectionTitle}>Technical resources</p>
+        <h2 style={{ fontSize: 24, fontWeight: 700, textAlign: 'center', margin: '0 0 28px', color: '#000' }}>
+          For engineering and security review
+        </h2>
+        <div className="zdb-resource-grid" style={{
+          display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 12,
+        }}>
+          {TECHNICAL_LINKS.map((link) => {
+            const inner = (
+              <>
+                <div style={{ fontSize: 14, fontWeight: 700, color: '#000', marginBottom: 4 }}>{link.label}</div>
+                <div style={{ fontSize: 12, color: '#444', lineHeight: 1.5, fontWeight: 500 }}>{link.desc}</div>
+              </>
+            )
+            const boxStyle = { ...card, padding: '16px 18px', display: 'block', textDecoration: 'none' as const }
+
+            if ('external' in link && link.external) {
+              return (
+                <a key={link.label} href={link.href} target="_blank" rel="noreferrer" style={boxStyle}>
+                  {inner}
+                </a>
+              )
+            }
+            return (
+              <Link key={link.label} href={link.href} style={boxStyle}>
+                {inner}
+              </Link>
+            )
+          })}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseTierCompareSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseTierCompareSection.tsx
@@ -1,0 +1,61 @@
+import Link from 'next/link'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, primaryBtn, outlineBtn } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+type Props = {
+  onConnectClick: () => void
+}
+
+export function EnterpriseTierCompareSection({ onConnectClick }: Props) {
+  const { openCore, enterprise } = COPY.tierCompare
+
+  return (
+    <section className="zdb-section" style={{ padding: '88px 40px', background: M.wash }}>
+      <div style={container(1000)}>
+        <p style={sectionTitle}>{COPY.tierCompare.sectionTitle}</p>
+        <h2 style={h2}>{COPY.tierCompare.h2}</h2>
+        <p style={lead}>{COPY.tierCompare.lead}</p>
+
+        <div className="zdb-tier-grid" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20 }}>
+          <div style={{
+            background: '#fff', borderRadius: 16, padding: '28px 24px', border: `1px solid ${M.line}`,
+          }}>
+            <div style={{ fontSize: 11, fontWeight: 800, color: BRAND, marginBottom: 8, letterSpacing: 0.5 }}>
+              {openCore.label}
+            </div>
+            <h3 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 16px', color: '#000' }}>{openCore.title}</h3>
+            <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 24px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {openCore.features.map((f) => (
+                <li key={f} style={{ fontSize: 14, color: '#000', fontWeight: 500, display: 'flex', gap: 8 }}>
+                  <span style={{ color: BRAND, fontWeight: 800 }}>✓</span> {f}
+                </li>
+              ))}
+            </ul>
+            <Link href="/signup" style={outlineBtn}>{openCore.cta}</Link>
+          </div>
+
+          <div style={{
+            background: '#fff', borderRadius: 16, padding: '28px 24px', border: `2px solid ${BRAND}`,
+            boxShadow: '0 12px 40px rgba(249,115,22,0.1)',
+          }}>
+            <div style={{ fontSize: 11, fontWeight: 800, color: BRAND, marginBottom: 8, letterSpacing: 0.5 }}>
+              {enterprise.label}
+            </div>
+            <h3 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 16px', color: '#000' }}>{enterprise.title}</h3>
+            <ul style={{ listStyle: 'none', padding: 0, margin: '0 0 24px', display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {enterprise.features.map((f) => (
+                <li key={f} style={{ fontSize: 14, color: '#000', fontWeight: 500, display: 'flex', gap: 8 }}>
+                  <span style={{ color: BRAND, fontWeight: 800 }}>✓</span> {f}
+                </li>
+              ))}
+            </ul>
+            <button type="button" onClick={onConnectClick} style={{ ...primaryBtn, cursor: 'pointer', border: 'none' }}>
+              {enterprise.cta}
+            </button>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseVpcDeploySection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseVpcDeploySection.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+import { COPY, INTEGRATION_SNIPPET, LOG_POINTS } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+export function EnterpriseVpcDeploySection() {
+  return (
+    <section className="zdb-section" style={{ padding: '88px 40px', background: '#fff' }}>
+      <div style={container(960)}>
+        <p style={sectionTitle}>{COPY.vpcDeploy.sectionTitle}</p>
+        <h2 style={h2}>{COPY.vpcDeploy.h2}</h2>
+        <p style={lead}>{COPY.vpcDeploy.lead}</p>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 14, marginBottom: 32 }}>
+          {COPY.vpcDeploy.points.map((p) => (
+            <div key={p.title} style={{ ...card, padding: '20px 22px' }}>
+              <div style={{ fontSize: 15, fontWeight: 700, marginBottom: 6, color: '#000' }}>{p.title}</div>
+              <div style={{ fontSize: 14, lineHeight: 1.65, color: '#000', fontWeight: 500 }}>{p.body}</div>
+            </div>
+          ))}
+        </div>
+
+        <div className="zdb-split" style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 20, marginBottom: 28 }}>
+          <div style={{ ...card, padding: '22px' }}>
+            <div style={{ fontSize: 12, fontWeight: 800, color: BRAND, marginBottom: 12, letterSpacing: 0.5 }}>
+              WEEK TIMELINE
+            </div>
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {COPY.vpcDeploy.timeline.map((t) => (
+                <div key={t.day} style={{ display: 'flex', gap: 12, alignItems: 'baseline' }}>
+                  <span style={{ fontSize: 12, fontWeight: 800, color: BRAND, minWidth: 52 }}>{t.day}</span>
+                  <span style={{ fontSize: 14, fontWeight: 500, color: '#000' }}>{t.label}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+          <div style={{ ...card, padding: '22px' }}>
+            <div style={{ fontSize: 12, fontWeight: 800, color: BRAND, marginBottom: 12, letterSpacing: 0.5 }}>
+              INTEGRATION (YOUR CI/CD)
+            </div>
+            <pre style={{
+              margin: '0 0 14px', padding: '12px 14px', borderRadius: 10, background: M.wash,
+              border: `1px solid ${M.line}`, fontSize: 11, lineHeight: 1.55, overflowX: 'auto', color: '#000',
+              fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            }}>
+              {INTEGRATION_SNIPPET}
+            </pre>
+            <div style={{ fontSize: 13, fontWeight: 600, color: '#000', marginBottom: 8 }}>Five log points per conversation:</div>
+            <ul style={{ margin: 0, paddingLeft: 18, fontSize: 13, lineHeight: 1.7, color: '#000', fontWeight: 500 }}>
+              {LOG_POINTS.map((p) => (
+                <li key={p}>{p}</li>
+              ))}
+            </ul>
+          </div>
+        </div>
+
+        <p style={{ textAlign: 'center', margin: 0 }}>
+          <Link href="/trust#deployment" style={{ color: BRAND, fontWeight: 700, fontSize: 14, textDecoration: 'none' }}>
+            {COPY.vpcDeploy.trustLink} →
+          </Link>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseWhatIsSection.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseWhatIsSection.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+import type { CSSProperties } from 'react'
+import { COPY } from './enterprise-copy'
+import { M, container, h2, lead, sectionTitle, card } from '../marketing-theme'
+import { BRAND } from '@/components/brand'
+
+const th: CSSProperties = {
+  textAlign: 'left',
+  padding: '10px 14px',
+  fontSize: 12,
+  fontWeight: 700,
+  color: '#666',
+  borderBottom: `1px solid ${M.line}`,
+  background: M.wash,
+}
+
+const td: CSSProperties = {
+  padding: '12px 14px',
+  fontSize: 14,
+  color: '#000',
+  fontWeight: 500,
+  borderBottom: `1px solid ${M.line}`,
+  verticalAlign: 'top',
+}
+
+export function EnterpriseWhatIsSection() {
+  const { whatIs } = COPY
+
+  return (
+    <section id="what-is" className="zdb-section zdb-section-anchor" style={{ padding: '88px 40px', background: M.wash, scrollMarginTop: 72 }}>
+      <div style={container(900)}>
+        <p style={sectionTitle}>{whatIs.sectionTitle}</p>
+        <h2 style={h2}>{whatIs.h2}</h2>
+        <p style={lead}>{whatIs.lead}</p>
+
+        <div style={{ ...card, padding: 0, overflow: 'hidden', marginTop: 32 }}>
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={th}>Layer</th>
+                <th style={th}>Role</th>
+                <th style={th}>Examples</th>
+              </tr>
+            </thead>
+            <tbody>
+              {whatIs.table.map(([layer, role, examples]) => (
+                <tr key={layer}>
+                  <td style={{ ...td, fontWeight: 700 }}>{layer}</td>
+                  <td style={td}>{role}</td>
+                  <td style={td}>{examples}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p style={{ marginTop: 24, marginBottom: 0, fontSize: 14, fontWeight: 600 }}>
+          <Link href={whatIs.linkHref} style={{ color: BRAND, textDecoration: 'none' }}>
+            {whatIs.linkLabel} →
+          </Link>
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/dashboard/components/marketing/enterprise/enterprise-copy.ts
+++ b/dashboard/components/marketing/enterprise/enterprise-copy.ts
@@ -1,0 +1,255 @@
+export const ENTERPRISE_CONTACT = 'mailto:founder@zizka.ai'
+export const GITHUB_URL = 'https://github.com/Zizka-ai/ZizkaDB'
+
+export const COPY = {
+  hero: {
+    eyebrow: 'ENTERPRISE',
+    h1: 'Operational control for multi-agent fleets in your cloud',
+    subhead:
+      'Licensed, single-tenant ZizkaDB in your VPC. Your agents connect via API key plus SDK, MCP, or REST. We deploy the stack — you keep your agent codebase.',
+    connectCta: "Let's connect",
+    demoCta: 'Book demo',
+  },
+  whatIs: {
+    sectionTitle: 'What ZizkaDB is',
+    h2: 'Operational database for AI agents',
+    lead:
+      'ZizkaDB stores agent decisions, tool calls, and outcomes with causal links. It is not a vector index for RAG documents and not distributed traces (OpenTelemetry). Most teams use all three alongside each other.',
+    table: [
+      ['Vector DB', 'RAG / knowledge retrieval', 'Pinecone, Qdrant'],
+      ['App DB', 'Transactional app state', 'Postgres, Redis'],
+      ['Agent ops', 'Decision history, lineage, drift', 'ZizkaDB'],
+      ['Traces', 'Spans, framework hooks', 'LangSmith, OTel'],
+    ] as const,
+    linkLabel: 'Read full technical reference',
+    linkHref: '/trust#overview',
+  },
+  fleet: {
+    sectionTitle: 'Multi-agent fleets',
+    h2: 'One ZizkaDB instance. Many agents. Full visibility.',
+    lead:
+      'Each agent logs under a distinct name. Tenant-wide API keys support SaaS patterns with thousands of logical agents.',
+    bullets: [
+      {
+        title: 'Fleet observability',
+        body: 'See all agents, last seen, and session volume in one place — included in your Enterprise VPC deployment.',
+      },
+      {
+        title: 'Behavioral drift',
+        body: 'Compare recent sessions to each agent\'s baseline. Verdicts from stable to significant — operational behavior change, not hallucination detection.',
+      },
+      {
+        title: 'Causal tracing',
+        body: 'Walk decision chains with why() and replay sessions when something breaks in production.',
+      },
+    ],
+    driftNote:
+      'Drift means operational behavior change — for example tool errors up 12 percentage points. It is not hallucination detection or truth verification.',
+    driftBands: {
+      title: 'Drift verdict bands',
+      bands: [
+        { label: 'Stable', range: 'below 0.05' },
+        { label: 'Minor', range: 'below 0.15' },
+        { label: 'Noticeable', range: 'below 0.30' },
+        { label: 'Significant', range: '0.30+' },
+      ],
+      requirement:
+        'Requires stable session_id, consistent event types, and parent_id links between related events.',
+    },
+    demoCaption: 'Fleet dashboard included in Enterprise VPC deployment.',
+  },
+  capabilities: {
+    sectionTitle: 'Capabilities',
+    h2: 'Open core today. Enterprise VPC adds fleet operations.',
+    lead:
+      'The same ZizkaDB engine runs on GitHub (AGPL), managed cloud, and Enterprise VPC. Enterprise adds commercial license, fleet UI, audit export, and supported Week-1 install.',
+    openCore: {
+      title: 'Open core — available today',
+      subtitle: 'Works on self-host and managed cloud (db.zizka.ai)',
+      rows: [
+        ['Event logging', 'POST /v1/events'],
+        ['Causal chain', 'GET /v1/events/{id}/why'],
+        ['State at time T', 'GET /v1/events/at'],
+        ['Semantic search', 'POST /v1/search'],
+        ['Behavioral baseline', 'GET /v1/agents/{id}/baseline'],
+        ['GDPR erasure', 'DELETE /v1/memory/forget'],
+        ['Checksum-backed events', 'Per-event SHA-256'],
+      ] as const,
+    },
+    enterprise: {
+      title: 'Enterprise VPC package adds',
+      items: [
+        'Fleet dashboard',
+        'Fleet ranking',
+        'Audit export (CSV/JSON + checksums)',
+        'Commercial license',
+        'Supported Week-1 install',
+      ],
+    },
+    footnote:
+      'Fleet UI and audit export are delivered in your VPC — not on public db.zizka.ai today.',
+  },
+  tierCompare: {
+    sectionTitle: 'Compare tiers',
+    h2: 'Open core and cloud vs Enterprise in your VPC',
+    lead: 'Same ZizkaDB engine. Enterprise adds commercial license, fleet operations, and a supported install in your cloud.',
+    openCore: {
+      label: 'OPEN CORE & CLOUD',
+      title: 'db.zizka.ai',
+      features: [
+        'AGPL on GitHub',
+        'Self-host Docker',
+        'Managed Pro / Team',
+        'Per-agent dashboard',
+        'Baseline / drift API',
+      ],
+      cta: 'Start free →',
+    },
+    enterprise: {
+      label: 'ENTERPRISE',
+      title: 'Your VPC',
+      features: [
+        'Commercial license',
+        'Single-tenant in your cloud',
+        'Fleet dashboard',
+        'Audit export',
+        'Week-1 install + integration workshop',
+      ],
+      cta: "Let's connect",
+    },
+  },
+  vpcDeploy: {
+    sectionTitle: 'Deployment',
+    h2: 'Production-ready in your cloud within one week',
+    lead: 'Same install package every customer. Only variables: region, sizing, DNS, secrets, and license tier.',
+    points: [
+      {
+        title: 'No platform rewrite',
+        body: 'Add ZIZKADB_HOST and ZIZKADB_API_KEY to your services. Instrument five log points per conversation — user in, tool out, tool in, model out, errors.',
+      },
+      {
+        title: 'Your CI/CD',
+        body: 'You merge and redeploy through your pipeline. Optional Launch Sprint can help instrument one or two services via pull requests.',
+      },
+      {
+        title: 'Private network',
+        body: 'Agent subnets reach ZizkaDB via same VPC, VPC peering, or PrivateLink.',
+      },
+    ],
+    timeline: [
+      { day: 'Day 0', label: 'Discovery + checklist' },
+      { day: 'Day 1', label: 'Stack live in staging' },
+      { day: 'Day 3', label: 'Integration workshop' },
+      { day: 'Day 7', label: 'Handoff + access revoked' },
+    ],
+    trustLink: 'Read deployment details',
+  },
+  platform: {
+    sectionTitle: 'Platform',
+    h2: 'Everything in the Week-1 package',
+    lead: 'Private images, license key, full stack, and integration kit — delivered in your VPC.',
+    features: [
+      {
+        title: 'VPC deploy',
+        body: 'Model A: Docker Compose stack in your cloud — Postgres, Qdrant, Redis, API, Dashboard.',
+      },
+      {
+        title: 'Commercial license',
+        body: 'Named organization, expiry, agent and event limits. One VPC per license.',
+      },
+      {
+        title: 'Fleet dashboard',
+        body: 'All agents with drift score, error change, and last seen — Enterprise UI in your VPC.',
+      },
+      {
+        title: 'Drift & error metrics',
+        body: 'Per-agent baseline plus fleet ranking. See what shifted before customers do.',
+      },
+      {
+        title: 'Audit export',
+        body: 'On-demand CSV or JSON with event checksums — not weekly certified reports.',
+      },
+      {
+        title: 'Integration workshop',
+        body: 'Five log points guide, staging checklist, backup and restore scripts.',
+      },
+    ],
+    footnote:
+      'SSO, SAML, and automated alerting are on the roadmap. Week-1 pilots use dashboard OTP plus VPN access.',
+  },
+  faq: {
+    sectionTitle: 'FAQ',
+    h2: 'Common enterprise questions',
+    items: [
+      {
+        q: 'Can you deploy inside our Kubernetes cluster?',
+        a: 'Version 1 is VM plus Docker Compose. Helm is available when a deal requires it.',
+      },
+      {
+        q: 'Do you modify our agent code?',
+        a: 'Optional Launch Sprint can open pull requests on one or two services. Default path: your developers plus our integration kit.',
+      },
+      {
+        q: 'How is this different from self-hosting from GitHub?',
+        a: 'AGPL open core vs commercial license, enterprise features, fleet dashboard, audit export, and a supported Week-1 install.',
+      },
+      {
+        q: 'How is Enterprise different from Pro or Team cloud?',
+        a: 'We host multi-tenant SaaS on db.zizka.ai. Enterprise is single-tenant in your VPC with a commercial license.',
+      },
+      {
+        q: 'Can we run a POC without a VPC?',
+        a: 'Cloud trial works for developer evaluation. Enterprise pilot expects deployment in your VPC.',
+      },
+      {
+        q: 'PII and GDPR?',
+        a: 'You control data. forget() deletes by metadata filter. Self-host and VPC deployments keep data in your infrastructure.',
+        link: { label: 'Security details', href: '/trust#security' },
+      },
+      {
+        q: 'How is this different from LangSmith / Mem0?',
+        a: 'LangSmith focuses on framework-centric tracing and evals. Mem0 optimizes long-term memory retrieval. ZizkaDB is a standalone operational store with causal trees, time travel, and fleet baselines.',
+        link: { label: 'Full comparison', href: '/trust#comparison' },
+      },
+    ],
+  },
+  footerCta: {
+    h2: 'Ready to deploy in your VPC?',
+    subhead: 'Tell us about your agent fleet. We will map a Week-1 path or point you to managed cloud.',
+    demoCta: 'Book demo',
+    cloudCta: 'ZizkaDB Cloud →',
+  },
+  form: {
+    success: 'Thanks — we will reach out within one business day.',
+    rateLimit: 'Too many requests. Try again later or email founder@zizka.ai.',
+    genericError: 'Something went wrong. Email founder@zizka.ai and we will help.',
+    websiteHint: 'Company domain or linkedin.com/company/…',
+  },
+} as const
+
+export const TECHNICAL_LINKS = [
+  { label: 'Overview', href: '/trust#overview', desc: 'What ZizkaDB is and how it fits your stack' },
+  { label: 'Technical reference', href: '/trust', desc: 'Architecture, APIs, data model' },
+  { label: 'Security', href: '/trust#security', desc: 'TLS, tenant isolation, GDPR' },
+  { label: 'Integrity', href: '/trust#integrity', desc: 'Checksums and retention' },
+  { label: 'Deployment modes', href: '/trust#deployment', desc: 'Self-host, managed, Enterprise VPC' },
+  { label: 'Plan limits', href: '/trust#limits', desc: 'Events and retention by tier' },
+  { label: 'Licensing', href: '/trust#licensing', desc: 'AGPL vs commercial' },
+  { label: 'Comparison', href: '/trust#comparison', desc: 'vs LangSmith, Mem0, Pinecone' },
+  { label: 'API reference', href: '/swagger', desc: 'REST explorer' },
+  { label: 'Documentation', href: '/docs', desc: 'SDK, MCP, integration guides' },
+  { label: 'Open source', href: GITHUB_URL, desc: 'AGPL core on GitHub', external: true },
+  { label: 'Contact', href: ENTERPRISE_CONTACT, desc: 'Security review + sales', external: true },
+  { label: 'Managed cloud', href: '/signup', desc: 'Pro / Team free trial' },
+] as const
+
+export const INTEGRATION_SNIPPET = `ZIZKADB_HOST=https://zizkadb.internal.your-company.example
+ZIZKADB_API_KEY=zizkadb_live_...`
+
+export const LOG_POINTS = [
+  'User message in',
+  'Tool call out',
+  'Tool result in',
+  'Model response out',
+  'Errors',
+]

--- a/dashboard/lib/demo.ts
+++ b/dashboard/lib/demo.ts
@@ -6,6 +6,8 @@ export interface DemoRequestPayload {
   email: string
   company_name: string
   website: string
+  position?: string
+  source?: 'enterprise' | 'landing' | 'newsletter'
 }
 
 export async function submitDemoRequest(payload: DemoRequestPayload) {

--- a/docs/enterprise-page-qa.md
+++ b/docs/enterprise-page-qa.md
@@ -1,0 +1,42 @@
+# Enterprise page — production QA checklist
+
+Use this checklist before merging or after deploying `/enterprise` and related backend changes.
+
+## Automated gates
+
+Run from repo root:
+
+```bash
+cd dashboard && npm run lint && npm run build
+cd ../core && pytest tests/test_demo_requests.py tests/test_rate_limiting.py::TestDemoRequestsRateLimiting -q
+```
+
+Copy guardrails (must return no matches except explicit negations):
+
+```bash
+rg -i 'SOC 2|HIPAA|SAML|SCIM|PagerDuty|Slack alert|SLA guarantee|detects hallucination' \
+  dashboard/components/marketing/enterprise dashboard/app/enterprise
+```
+
+## Manual smoke (~5 min)
+
+- [ ] `/enterprise` — all sections render in order: Hero → What is → Fleet → Capabilities → Tier compare → VPC deploy → Platform → FAQ → Connect form → Resources
+- [ ] Nav highlights **Enterprise** on desktop and mobile
+- [ ] **Let's connect** scrolls to `#connect` and focuses first name field
+- [ ] Submit connect form → **201**; admin demo requests tab shows `source=enterprise` and role when filled
+- [ ] Invalid `source` rejected server-side (422) — covered by pytest
+- [ ] **Book demo** opens Calendly modal; **ESC** closes
+- [ ] Mobile **375px**: nav CTA row visible, no horizontal overflow
+- [ ] All `TECHNICAL_LINKS` in resources strip resolve (no 404)
+- [ ] Trust `#limits` shows Enterprise row; landing `#pricing` links to `/enterprise`
+- [ ] `/trust`, `/docs`, `/community` show shared marketing footer with Enterprise link
+
+## Rate limiting note
+
+Demo request rate limits use the same in-memory pattern as auth OTP and community posts (`core/api/demo_requests.py`). In multi-worker deployments, effective limit is multiplied by worker count — consistent with the rest of the API today.
+
+## Lead form contract
+
+- Frontend: `EnterpriseConnectForm` sends `source: 'enterprise'` via `submitDemoRequest`; honeypot field is `botcheck` (off-screen)
+- Backend: `POST /v1/demo-requests` stores optional `position`, allowlisted `source`, client IP
+- Admin: search includes name, email, company, website, role, source

--- a/docs/enterprise-product-overview.md
+++ b/docs/enterprise-product-overview.md
@@ -1,0 +1,38 @@
+# ZizkaDB Enterprise — Product Overview
+
+Internal reference for the `/enterprise` marketing page. **This is marketing + lead capture**, not the Enterprise product codebase.
+
+## What we sell
+
+**Model A — Licensed VPC deployment:** ZizkaDB Core + Postgres + Qdrant + Redis run in the customer's cloud (single-tenant). Commercial license replaces AGPL obligations for internal use. Week-1 install package includes supported docker-compose, env template, and onboarding call.
+
+## What exists today (honest)
+
+| Capability | Public cloud (Pro/Team) | Enterprise VPC |
+|------------|-------------------------|----------------|
+| Event logging, causal `why()`, time travel | ✓ | ✓ |
+| Semantic search, drift baselines | ✓ | ✓ |
+| Fleet dashboard UI | — | ✓ (customer VPC) |
+| Audit export bundle | — | ✓ (customer VPC) |
+| Data residency | Zizka cloud | Customer VPC |
+| Commercial license | — | ✓ |
+
+## What is NOT shipped (do not claim)
+
+- SOC 2, HIPAA, formal DPAs
+- SSO / SAML / SCIM (roadmap only)
+- Slack / PagerDuty alerting integrations
+- SLA guarantees
+- Hallucination **detection** (drift = operational behavior change)
+
+## Lead flow
+
+1. Visitor submits **Let's connect** on `/enterprise#connect`
+2. `POST /v1/demo-requests` with `source=enterprise`, optional `position`
+3. Admin → Demo requests tab shows source + role; founder follows up manually
+
+## Related docs
+
+- QA checklist: `docs/enterprise-page-qa.md`
+- Agent rule: `.cursor/rules/enterprise-page-knowledge-base.mdc`
+- Copy strings: `dashboard/components/marketing/enterprise/enterprise-copy.ts`

--- a/wiki/REST-API.md
+++ b/wiki/REST-API.md
@@ -92,3 +92,34 @@ GET /health
 | 401 | Invalid/revoked API key |
 | 403 | Agent-scoped key used with wrong agent name |
 | 404 | Agent or event not found |
+| 422 | Validation error (e.g. invalid demo request source) |
+| 429 | Rate limit exceeded |
+
+## Demo requests (public, no auth)
+
+Landing **Book demo** and Enterprise **Let's connect** forms.
+
+```http
+POST /v1/demo-requests
+Content-Type: application/json
+
+{
+  "first_name": "Ada",
+  "last_name": "Lovelace",
+  "email": "ada@example.com",
+  "company_name": "Example Corp",
+  "website": "https://example.com",
+  "position": "Head of Platform",
+  "source": "enterprise",
+  "botcheck": ""
+}
+```
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `first_name`, `last_name`, `email`, `company_name`, `website` | yes | Trimmed server-side |
+| `position` | no | Role/title (max 120 chars) |
+| `source` | no | Allowlist: `enterprise`, `landing`, `newsletter` — invalid → **422** |
+| `botcheck` | no | Honeypot; non-empty → **400** |
+
+Response **201:** `{ "id": "<uuid>", "created_at": "<iso>" }`. Rate limit: 8 requests / hour / IP (**429**). Admin list: `GET /v1/admin/demo-requests` (JWT, founder OTP).


### PR DESCRIPTION
Introduce /enterprise with VPC-focused marketing content, shared footer/styles, and a contact form that posts to POST /v1/demo-requests with source=enterprise and optional position. Extend admin demo list, idempotent DB columns, tests, docs, and REST API wiki.