### PR TITLE
Feat/centralized exceptions

### DIFF
--- a/core/api/account.py
+++ b/core/api/account.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
+from services.exceptions import bad_request, forbidden, internal_error
 
 from api.deps import dashboard_session_dependency
 from services.account import account_options, delete_managed_account, grant_retention_trial
@@ -27,10 +28,10 @@ async def retention_trial(session: dict = Depends(require_dashboard_session)):
     try:
         return await grant_retention_trial(user_id=session["user_id"])
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise bad_request(str(e))
     except Exception as e:
         log.error("retention trial failed: %s", e)
-        raise HTTPException(status_code=500, detail="Could not extend trial")
+        raise internal_error("Could not extend trial")
 
 
 @router.delete("")
@@ -42,9 +43,9 @@ async def delete_account(session: dict = Depends(require_dashboard_session)):
         )
         return {"message": "Account deleted"}
     except PermissionError:
-        raise HTTPException(status_code=403, detail="Invalid session")
+        raise forbidden("Invalid session")
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise bad_request(str(e))
     except Exception as e:
         log.error("account delete failed: %s", e)
-        raise HTTPException(status_code=500, detail="Could not delete account")
+        raise internal_error("Could not delete account")

--- a/core/api/admin.py
+++ b/core/api/admin.py
@@ -22,7 +22,8 @@ import logging
 from datetime import datetime, timedelta, timezone
 
 import jwt
-from fastapi import APIRouter, Depends, HTTPException, Query, Security
+from fastapi import APIRouter, Depends, Query, Security
+from services.exceptions import not_found, internal_error, unauthorized
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 
@@ -74,14 +75,14 @@ async def require_admin(
     credentials: HTTPAuthorizationCredentials = Security(bearer),
 ) -> dict:
     if not credentials:
-        raise HTTPException(status_code=404, detail="Not Found")
+        raise not_found("Not Found")
     try:
         payload = jwt.decode(credentials.credentials, JWT_SECRET, algorithms=["HS256"])
     except Exception:
-        raise HTTPException(status_code=404, detail="Not Found")
+        raise not_found("Not Found")
 
     if not payload.get("is_admin") or not _is_admin_email(payload.get("email", "")):
-        raise HTTPException(status_code=404, detail="Not Found")
+        raise not_found("Not Found")
     return payload
 
 
@@ -90,27 +91,27 @@ async def require_admin(
 @router.post("/auth/request-otp")
 async def admin_request_otp(body: AdminOTPRequest):
     if not _is_admin_email(body.email):
-        raise HTTPException(status_code=404, detail="Not Found")
+        raise not_found("Not Found")
     await otp_limiter.check(ADMIN_EMAIL)
     try:
         await request_otp(ADMIN_EMAIL)
     except Exception as e:
         log.error(f"admin OTP send failed: {e}")
-        raise HTTPException(status_code=500, detail="Failed to send code")
+        raise internal_error("Failed to send code")
     return {"message": "Code sent"}
 
 
 @router.post("/auth/verify-otp")
 async def admin_verify_otp(body: AdminOTPVerify):
     if not _is_admin_email(body.email):
-        raise HTTPException(status_code=404, detail="Not Found")
+        raise not_found("Not Found")
     try:
         # We reuse verify_otp() to validate + consume the OTP record.
         # We discard its returned tokens; admin gets a separately minted
         # token with is_admin=true and no tenant context.
         await verify_otp(ADMIN_EMAIL, body.otp, intent="login")
     except ValueError as e:
-        raise HTTPException(status_code=401, detail=str(e))
+        raise unauthorized(str(e))
 
     return {"access_token": _issue_admin_token(), "token_type": "bearer"}
 

--- a/core/api/admin.py
+++ b/core/api/admin.py
@@ -27,7 +27,7 @@ from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from pydantic import BaseModel, EmailStr
 
 from db.connection import get_pool
-from api.auth import _check_otp_rate_limit
+from api.auth import otp_limiter
 from services.auth import JWT_SECRET, request_otp, verify_otp
 
 router = APIRouter()
@@ -91,7 +91,7 @@ async def require_admin(
 async def admin_request_otp(body: AdminOTPRequest):
     if not _is_admin_email(body.email):
         raise HTTPException(status_code=404, detail="Not Found")
-    _check_otp_rate_limit(ADMIN_EMAIL)
+    await otp_limiter.check(ADMIN_EMAIL)
     try:
         await request_otp(ADMIN_EMAIL)
     except Exception as e:

--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -692,12 +692,12 @@ async def agent_behavior_change(
         win_end   = now
     else:
         if not from_ts or not to_ts:
-            raise HTTPException(status_code=400, detail="from_ts and to_ts are required for custom window")
+            raise bad_request(detail="from_ts and to_ts are required for custom window")
         try:
             win_start = datetime.fromisoformat(from_ts.replace("Z", "+00:00")).replace(tzinfo=None)
             win_end   = datetime.fromisoformat(to_ts.replace("Z", "+00:00")).replace(tzinfo=None)
         except ValueError:
-            raise HTTPException(status_code=400, detail="from_ts / to_ts must be ISO 8601 timestamps")
+            raise bad_request(detail="from_ts / to_ts must be ISO 8601 timestamps")
 
     baseline_count = await pool.fetchval(
         "SELECT COUNT(*) FROM events WHERE tenant_id = $1 AND agent_id = $2 AND timestamp < $3",

--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -2,7 +2,8 @@ import json
 import re
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
+from services.exceptions import bad_request, conflict, not_found
 from pydantic import BaseModel, Field
 
 from api.deps import assert_agent_allowed, get_tenant, require_dashboard_session
@@ -23,9 +24,8 @@ _AGENT_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,254}$")
 def _validate_agent_id(agent_id: str) -> str:
     agent_id = agent_id.strip()
     if not agent_id or not _AGENT_ID_RE.match(agent_id):
-        raise HTTPException(
-            status_code=400,
-            detail="agent_id must be 1–255 chars: letters, numbers, dots, dashes, underscores",
+        raise bad_request(
+            "agent_id must be 1–255 chars: letters, numbers, dots, dashes, underscores"
         )
     return agent_id
 
@@ -95,7 +95,7 @@ async def create_agent(
                 tenant_id, agent_id,
             )
             if existing:
-                raise HTTPException(status_code=409, detail="Agent already exists")
+                raise conflict("Agent already exists")
 
             await assert_and_reserve_api_key_slot(conn, tenant_id=tenant_id)
 
@@ -137,7 +137,7 @@ async def delete_agent(
         tenant_id, agent_id,
     )
     if not row:
-        raise HTTPException(status_code=404, detail="Agent not found")
+        raise not_found("Agent not found")
 
     async with pool.acquire() as conn:
         async with conn.transaction():
@@ -175,7 +175,7 @@ async def test_agent_event(
         tenant_id, agent_id,
     )
     if not exists:
-        raise HTTPException(status_code=404, detail="Agent not found")
+        raise not_found("Agent not found")
 
     result = await write_event(
         tenant_id=tenant_id,
@@ -204,7 +204,7 @@ async def list_agent_api_keys(
         tenant_id, agent_id,
     )
     if not exists:
-        raise HTTPException(status_code=404, detail="Agent not found")
+        raise not_found("Agent not found")
 
     return await list_api_keys_for_agent(pool, tenant_id, agent_id)
 
@@ -226,7 +226,7 @@ async def create_agent_api_key(
                 tenant_id, agent_id,
             )
             if not exists:
-                raise HTTPException(status_code=404, detail="Agent not found")
+                raise not_found("Agent not found")
 
             await assert_and_reserve_api_key_slot(conn, tenant_id=tenant_id)
 
@@ -249,7 +249,7 @@ async def revoke_agent_api_key(
     tenant_id = tenant["tenant_id"]
 
     if not await revoke_api_key_record(pool, tenant_id, key_id, agent_id):
-        raise HTTPException(status_code=404, detail="API key not found")
+        raise not_found("API key not found")
     return {"revoked": True, "key_id": key_id, "agent": agent_id}
 
 

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -3,7 +3,7 @@ import time
 import logging
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException, Response
+from fastapi import APIRouter, HTTPException, Response, Depends
 from pydantic import BaseModel, EmailStr
 from services.auth import request_otp, verify_otp, _issue_tokens, email_exists
 from services.api_keys import (
@@ -13,8 +13,8 @@ from services.api_keys import (
     revoke_api_key_record,
 )
 from api.deps import get_tenant, require_dashboard_session
-from fastapi import Depends
 from db.connection import get_pool
+from services.rate_limiter import RateLimiter, InMemoryStorage, SlidingWindowStrategy
 from services.event_write import write_event
 
 router = APIRouter()
@@ -23,21 +23,15 @@ log = logging.getLogger(__name__)
 # Per-email OTP request limits (in-memory; resets after window)
 _OTP_RATE_WINDOW_SEC = 15 * 60   # 15 minutes
 _OTP_RATE_MAX = 10               # max requests per email per window
-_otp_rate: dict[str, list[float]] = {}
 
+otp_limiter = RateLimiter(
+    limit=_OTP_RATE_MAX,
+    window_sec=_OTP_RATE_WINDOW_SEC,
+    storage=InMemoryStorage(),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many code requests. Wait 15 minutes and try again."
+)
 
-def _check_otp_rate_limit(email: str) -> None:
-    key = email.lower().strip()
-    now = time.time()
-    window_start = now - _OTP_RATE_WINDOW_SEC
-    hits = [t for t in _otp_rate.get(key, []) if t > window_start]
-    if len(hits) >= _OTP_RATE_MAX:
-        raise HTTPException(
-            status_code=429,
-            detail="Too many code requests. Wait 15 minutes and try again.",
-        )
-    hits.append(now)
-    _otp_rate[key] = hits
 
 _DEV_TENANT_ID = "00000000-0000-0000-0000-000000000001"
 _DEV_USER_ID   = "00000000-0000-0000-0000-000000000001"
@@ -64,7 +58,7 @@ class CreateAPIKeyBody(BaseModel):
 @router.post("/request-otp")
 async def request_otp_route(body: RequestOTPBody):
     email = body.email.lower().strip()
-    _check_otp_rate_limit(email)
+    await otp_limiter.check(email)
 
     if body.intent == "signup" and await email_exists(email):
         raise HTTPException(

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -3,7 +3,14 @@ import time
 import logging
 from typing import Literal
 
-from fastapi import APIRouter, HTTPException, Response, Depends
+from fastapi import APIRouter, Response, Depends
+from services.exceptions import (
+    conflict,
+    not_found,
+    internal_error,
+    unauthorized,
+    forbidden,
+)
 from pydantic import BaseModel, EmailStr
 from services.auth import request_otp, verify_otp, _issue_tokens, email_exists
 from services.api_keys import (
@@ -61,15 +68,13 @@ async def request_otp_route(body: RequestOTPBody):
     await otp_limiter.check(email)
 
     if body.intent == "signup" and await email_exists(email):
-        raise HTTPException(
-            status_code=409,
-            detail="This email is already registered. Please sign in instead.",
+        raise conflict(
+            "This email is already registered. Please sign in instead."
         )
 
     if body.intent == "login" and not await email_exists(email):
-        raise HTTPException(
-            status_code=404,
-            detail="No account found for this email. Create an account to get started.",
+        raise not_found(
+            "No account found for this email. Create an account to get started."
         )
 
     try:
@@ -77,7 +82,7 @@ async def request_otp_route(body: RequestOTPBody):
         return {"message": "Code sent"}
     except Exception as e:
         log.error(f"request_otp failed for {email}: {e}")
-        raise HTTPException(status_code=500, detail="Failed to send code. Check server logs.")
+        raise internal_error("Failed to send code. Check server logs.")
 
 
 @router.post("/verify-otp")
@@ -92,12 +97,11 @@ async def verify_otp_route(body: VerifyOTPBody, response: Response):
             marketing_consent=body.marketing_consent,
         )
     except ValueError as e:
-        raise HTTPException(status_code=401, detail=str(e))
+        raise unauthorized(str(e))
     except Exception as e:
         log.exception("verify_otp failed for %s: %s", email, e)
-        raise HTTPException(
-            status_code=500,
-            detail="Could not complete account setup. Please request a new code and try again.",
+        raise internal_error(
+            "Could not complete account setup. Please request a new code and try again."
         )
 
     from services.billing import billing_status_payload, fetch_user_billing
@@ -190,7 +194,7 @@ async def revoke_api_key(
     """Revoke an API key. The key stops working immediately."""
     pool = get_pool()
     if not await revoke_api_key_record(pool, tenant["tenant_id"], key_id):
-        raise HTTPException(status_code=404, detail="API key not found")
+        raise not_found("API key not found")
     return {"revoked": True, "key_id": key_id}
 
 
@@ -202,7 +206,7 @@ async def dev_token_route():
     is accessible without email / signup.
     """
     if os.getenv("ENV", "development") != "development":
-        raise HTTPException(status_code=403, detail="Not available in production")
+        raise forbidden("Not available in production")
 
     pool = get_pool()
     await _ensure_dev_tenant(pool)

--- a/core/api/billing_checkout.py
+++ b/core/api/billing_checkout.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
+from services.exceptions import bad_request, internal_error
 from pydantic import BaseModel, field_validator
 
 from api.deps import require_dashboard_session
@@ -43,7 +44,7 @@ async def choose_plan(body: SelectPlanBody, tenant: dict = Depends(require_dashb
         row = await select_plan(user_id=tenant["user_id"], plan=body.plan)
         return billing_status_payload(row)
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise bad_request(str(e))
     except Exception as e:
         log.error("select plan failed: %s", e)
-        raise HTTPException(status_code=500, detail="Could not save plan. Try again.")
+        raise internal_error("Could not save plan. Try again.")

--- a/core/api/community.py
+++ b/core/api/community.py
@@ -11,7 +11,8 @@ import re
 import uuid
 from pathlib import Path
 
-from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
+from fastapi import APIRouter, File, Query, Request, UploadFile
+from services.exceptions import bad_request, not_found
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
@@ -114,7 +115,7 @@ async def get_post(post_id: str, request: Request):
     try:
         pid = uuid.UUID(post_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Post not found")
+        raise not_found("Post not found")
 
     post = await pool.fetchrow(
         """
@@ -125,7 +126,7 @@ async def get_post(post_id: str, request: Request):
         pid,
     )
     if not post:
-        raise HTTPException(status_code=404, detail="Post not found")
+        raise not_found("Post not found")
 
     replies = await pool.fetch(
         """
@@ -161,9 +162,9 @@ async def get_post(post_id: str, request: Request):
 @router.post("/posts", status_code=201)
 async def create_post(body: CreatePostBody, request: Request):
     if body.website:
-        raise HTTPException(status_code=400, detail="Invalid submission")
+        raise bad_request("Invalid submission")
     if body.category not in CATEGORIES:
-        raise HTTPException(status_code=400, detail="Invalid category")
+        raise bad_request("Invalid category")
     await community_limiter.check(client_ip(request))
     pool = get_pool()
     urls = [u for u in body.image_urls if isinstance(u, str) and u.startswith("/v1/community/media/")][:6]
@@ -189,19 +190,19 @@ async def create_post(body: CreatePostBody, request: Request):
 @router.post("/posts/{post_id}/replies", status_code=201)
 async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
     if body.website:
-        raise HTTPException(status_code=400, detail="Invalid submission")
+        raise bad_request("Invalid submission")
     await community_limiter.check(client_ip(request))
     pool = get_pool()
     try:
         pid = uuid.UUID(post_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Post not found")
+        raise not_found("Post not found")
 
     exists = await pool.fetchval(
         "SELECT 1 FROM community_posts WHERE post_id = $1", pid,
     )
     if not exists:
-        raise HTTPException(status_code=404, detail="Post not found")
+        raise not_found("Post not found")
 
     row = await pool.fetchrow(
         """
@@ -230,15 +231,15 @@ async def upload_image(request: Request, file: UploadFile = File(...)):
     await community_limiter.check(client_ip(request) + ":upload")
 
     if not file.filename:
-        raise HTTPException(status_code=400, detail="No file")
+        raise bad_request("No file")
 
     ext = Path(file.filename).suffix.lower()
     if ext not in ALLOWED_EXT:
-        raise HTTPException(status_code=400, detail="Use PNG, JPG, WEBP, or GIF")
+        raise bad_request("Use PNG, JPG, WEBP, or GIF")
 
     data = await file.read()
     if len(data) > MAX_UPLOAD_BYTES:
-        raise HTTPException(status_code=400, detail="Image must be under 3MB")
+        raise bad_request("Image must be under 3MB")
 
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
     name = f"{uuid.uuid4().hex}{ext}"
@@ -252,10 +253,10 @@ async def upload_image(request: Request, file: UploadFile = File(...)):
 async def serve_media(filename: str):
     safe = re.sub(r"[^a-zA-Z0-9._-]", "", filename)
     if not safe or safe != filename:
-        raise HTTPException(status_code=404, detail="Not found")
+        raise not_found("Not found")
     path = UPLOAD_DIR / safe
     if not path.is_file():
-        raise HTTPException(status_code=404, detail="Not found")
+        raise not_found("Not found")
     media = {
         ".png": "image/png",
         ".jpg": "image/jpeg",

--- a/core/api/community.py
+++ b/core/api/community.py
@@ -9,7 +9,6 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime, timezone
 from pathlib import Path
 
 from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
@@ -18,6 +17,7 @@ from pydantic import BaseModel, Field
 
 from api.utils import check_rate, client_ip
 from db.connection import get_pool
+from services.rate_limiter import RateLimiter, InMemoryStorage, SlidingWindowStrategy
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -27,10 +27,17 @@ MAX_UPLOAD_BYTES = 3 * 1024 * 1024
 ALLOWED_EXT = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 CATEGORIES = {"question", "experience", "showcase"}
 
-# Simple in-memory rate limit: IP -> list of timestamps
-_rate: dict[str, list[float]] = {}
+
 RATE_WINDOW_SEC = 3600
 RATE_MAX_POSTS = 10
+
+community_limiter = RateLimiter(
+    limit=RATE_MAX_POSTS,
+    window_sec=RATE_WINDOW_SEC,
+    storage=InMemoryStorage(),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many posts. Try again later."
+)
 
 
 class CreatePostBody(BaseModel):
@@ -48,7 +55,6 @@ class CreateReplyBody(BaseModel):
     author_email: str | None = Field(default=None, max_length=255)
     body: str = Field(min_length=2, max_length=8000)
     website: str | None = None
-
 
 
 
@@ -158,8 +164,7 @@ async def create_post(body: CreatePostBody, request: Request):
         raise HTTPException(status_code=400, detail="Invalid submission")
     if body.category not in CATEGORIES:
         raise HTTPException(status_code=400, detail="Invalid category")
-
-    check_rate(_rate, client_ip(request), RATE_WINDOW_SEC, RATE_MAX_POSTS, "Too many posts. Try again later.")
+    await community_limiter.check(client_ip(request))
     pool = get_pool()
     urls = [u for u in body.image_urls if isinstance(u, str) and u.startswith("/v1/community/media/")][:6]
 
@@ -185,8 +190,7 @@ async def create_post(body: CreatePostBody, request: Request):
 async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
     if body.website:
         raise HTTPException(status_code=400, detail="Invalid submission")
-
-    check_rate(_rate, client_ip(request), RATE_WINDOW_SEC, RATE_MAX_POSTS, "Too many posts. Try again later.")
+    await community_limiter.check(client_ip(request))
     pool = get_pool()
     try:
         pid = uuid.UUID(post_id)
@@ -223,7 +227,7 @@ async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
 
 @router.post("/upload")
 async def upload_image(request: Request, file: UploadFile = File(...)):
-    check_rate(_rate, client_ip(request) + ":upload", RATE_WINDOW_SEC, RATE_MAX_POSTS, "Too many uploads. Try again later.")
+    await community_limiter.check(client_ip(request) + ":upload")
 
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file")

--- a/core/api/demo_requests.py
+++ b/core/api/demo_requests.py
@@ -5,7 +5,8 @@ Public demo request form — landing page "Book demo" submissions.
 from __future__ import annotations
 
 import logging
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Request, status
+from services.exceptions import make_exception, bad_request
 from pydantic import BaseModel, EmailStr, Field
 
 from api.utils import client_ip
@@ -46,14 +47,14 @@ class CreateDemoRequestBody(BaseModel):
 @router.post("", status_code=201)
 async def create_demo_request(body: CreateDemoRequestBody, request: Request):
     if body.botcheck:
-        raise HTTPException(status_code=400, detail="Invalid submission")
+        raise bad_request("Invalid submission")
 
     ip = client_ip(request)
     await demo_limiter.check(ip)
 
     source = (body.source.strip() or None) if body.source else None
     if source and source not in VALID_SOURCES:
-        raise HTTPException(status_code=422, detail="Invalid source")
+        raise make_exception(status.HTTP_422_UNPROCESSABLE_ENTITY, "Invalid source")
 
     pool = get_pool()
     row = await pool.fetchrow(

--- a/core/api/demo_requests.py
+++ b/core/api/demo_requests.py
@@ -5,20 +5,28 @@ Public demo request form — landing page "Book demo" submissions.
 from __future__ import annotations
 
 import logging
-
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 
-from api.utils import check_rate, client_ip
+from api.utils import client_ip
 from db.connection import get_pool
+from services.rate_limiter import RateLimiter, InMemoryStorage, SlidingWindowStrategy
 
 router = APIRouter()
 log = logging.getLogger(__name__)
 
-_rate: dict[str, list[float]] = {}
+
 RATE_WINDOW_SEC = 3600
 RATE_MAX = 8
 VALID_SOURCES = frozenset({"enterprise", "landing", "newsletter"})
+
+demo_limiter = RateLimiter(
+    limit=RATE_MAX,
+    window_sec=RATE_WINDOW_SEC,
+    storage=InMemoryStorage(),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many requests. Try again later."
+)
 
 
 class CreateDemoRequestBody(BaseModel):
@@ -34,13 +42,14 @@ class CreateDemoRequestBody(BaseModel):
 
 
 
+
 @router.post("", status_code=201)
 async def create_demo_request(body: CreateDemoRequestBody, request: Request):
     if body.botcheck:
         raise HTTPException(status_code=400, detail="Invalid submission")
 
     ip = client_ip(request)
-    check_rate(_rate, ip, RATE_WINDOW_SEC, RATE_MAX)
+    await demo_limiter.check(ip)
 
     source = (body.source.strip() or None) if body.source else None
     if source and source not in VALID_SOURCES:

--- a/core/api/deps.py
+++ b/core/api/deps.py
@@ -1,5 +1,6 @@
 import os
-from fastapi import HTTPException, Security, status
+from fastapi import Security
+from services.exceptions import forbidden, unauthorized
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from services.auth import verify_api_key, decode_access_token
 
@@ -44,8 +45,7 @@ def assert_agent_allowed(tenant: dict, agent_id: str) -> None:
     """Agent-scoped API keys may only access their bound agent."""
     scoped = tenant.get("agent_id")
     if scoped and scoped != agent_id:
-        raise HTTPException(
-            status_code=status.HTTP_403_FORBIDDEN,
+        raise forbidden(
             detail=(
                 f"This API key is scoped to agent '{scoped}' only, but the request used "
                 f"'{agent_id}'. Use agent='{scoped}' in db.log() / POST /v1/events, or create "
@@ -84,10 +84,7 @@ def dashboard_session_dependency(forbid_detail: str):
     ) -> dict:
         token = credentials.credentials
         if await resolve_api_key_tenant(token):
-            raise HTTPException(
-                status_code=status.HTTP_403_FORBIDDEN,
-                detail=forbid_detail,
-            )
+            raise forbidden(detail=forbid_detail)
         try:
             payload = decode_access_token(token)
             return {
@@ -95,10 +92,7 @@ def dashboard_session_dependency(forbid_detail: str):
                 "user_id": payload["sub"],
             }
         except Exception:
-            raise HTTPException(
-                status_code=status.HTTP_401_UNAUTHORIZED,
-                detail="Invalid token",
-            )
+            raise unauthorized(detail="Invalid token")
 
     return _require_dashboard_session
 
@@ -125,10 +119,7 @@ async def get_tenant(
         return tenant
 
     if not looks_like_jwt(token):
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid or revoked API key",
-        )
+        raise unauthorized(detail="Invalid or revoked API key")
 
     # JWT (dashboard sessions)
     try:
@@ -138,7 +129,4 @@ async def get_tenant(
             "user_id": payload["sub"],
         }
     except Exception:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="Invalid token",
-        )
+        raise unauthorized(detail="Invalid token")

--- a/core/api/events.py
+++ b/core/api/events.py
@@ -1,5 +1,6 @@
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from pydantic import BaseModel, Field
+from services.exceptions import not_found
 from typing import Any
 from uuid import UUID
 from datetime import datetime
@@ -121,7 +122,7 @@ async def why(
     try:
         UUID(event_id)
     except ValueError:
-        raise HTTPException(status_code=404, detail="Event not found")
+        raise not_found("Event not found")
 
     rows = await pool.fetch(
         """
@@ -150,7 +151,7 @@ async def why(
     )
 
     if not rows:
-        raise HTTPException(status_code=404, detail="Event not found")
+        raise not_found("Event not found")
 
     return {
         "event_id": event_id,

--- a/core/api/memory.py
+++ b/core/api/memory.py
@@ -7,7 +7,8 @@ replacement for LLM-provided memory:
   DELETE /v1/memory/forget →  GDPR forget by any metadata field
 """
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
+from services.exceptions import not_found
 from pydantic import BaseModel
 from typing import Any
 import json
@@ -223,7 +224,7 @@ async def session_diff(
     )
 
     if not rows:
-        raise HTTPException(status_code=404, detail="Session not found")
+        raise not_found("Session not found")
 
     agent_id = rows[0]["agent_id"]
     events = []

--- a/core/api/memory.py
+++ b/core/api/memory.py
@@ -8,7 +8,7 @@ replacement for LLM-provided memory:
 """
 
 from fastapi import APIRouter, Depends
-from services.exceptions import not_found
+from services.exceptions import bad_request, not_found
 from pydantic import BaseModel
 from typing import Any
 import json
@@ -79,8 +79,7 @@ async def get_context(
     semantic_rows = []
     embedding = await generate_embedding(body.task, tenant_id)
     if not embedding:
-        raise HTTPException(
-            status_code=400,
+        raise bad_request(
             detail=(
                 "Embedding generation failed. Configure embeddings in Dashboard → Settings "
                 "(platform key or your OpenAI API key)."

--- a/core/api/search.py
+++ b/core/api/search.py
@@ -1,6 +1,7 @@
 import json
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
+from services.exceptions import bad_request
 from pydantic import BaseModel
 from qdrant_client.models import FieldCondition, Filter, MatchValue
 
@@ -29,12 +30,9 @@ async def semantic_search(
 
     embedding = await generate_embedding(body.query, tenant_id)
     if not embedding:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Embedding generation failed. Configure embeddings in Dashboard → Settings "
-                "(platform key or your OpenAI API key)."
-            ),
+        raise bad_request(
+            "Embedding generation failed. Configure embeddings in Dashboard → Settings "
+            "(platform key or your OpenAI API key)."
         )
 
     qdrant = get_qdrant()

--- a/core/api/settings.py
+++ b/core/api/settings.py
@@ -1,6 +1,7 @@
 """Dashboard settings — embedding provider/model (managed cloud)."""
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
+from services.exceptions import bad_request
 from pydantic import BaseModel, Field
 
 from api.deps import dashboard_session_dependency, get_tenant
@@ -52,12 +53,11 @@ async def put_embeddings(
             api_key=body.api_key,
         )
     except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise bad_request(str(e))
 
     out = embedding_config_for_response(config)
     if not out["ready"]:
-        raise HTTPException(
-            status_code=400,
-            detail="Embedding not configured. Use platform key or provide a valid API key.",
+        raise bad_request(
+            "Embedding not configured. Use platform key or provide a valid API key."
         )
     return {**out, "message": "Embedding settings saved. New events will use this model."}

--- a/core/requirements-dev.txt
+++ b/core/requirements-dev.txt
@@ -3,3 +3,4 @@ pytest>=8.2.0
 pytest-asyncio>=0.23.0
 httpx>=0.27.0
 ruff>=0.8.0
+fakeredis>=2.20.0

--- a/core/services/api_keys.py
+++ b/core/services/api_keys.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import HTTPException
+from services.exceptions import conflict
 
 from services.auth import generate_api_key
 from services.billing import fetch_effective_plan
@@ -62,8 +62,7 @@ async def assert_and_reserve_api_key_slot(conn, *, tenant_id: str) -> None:
 
     used = await count_active_api_keys(conn, tenant_id)
     if used >= limit:
-        raise HTTPException(
-            status_code=409,
+        raise conflict(
             detail={
                 "msg": (
                     "You've reached the maximum number of API keys allowed for your "

--- a/core/services/exceptions.py
+++ b/core/services/exceptions.py
@@ -1,0 +1,66 @@
+"""
+Centralized exception helpers for ZizkaDB.
+
+Provides a unified factory function `make_exception` and semantic wrapper functions
+for raising FastAPI HTTPExceptions across routers and services.
+"""
+
+from typing import Any, Dict, Optional
+from fastapi import HTTPException, status
+
+def make_exception(
+    status_code: int,
+    detail: Any,
+    headers: Optional[Dict[str, str]] = None,
+    **kwargs: Any
+) -> HTTPException:
+    """
+    Centralized factory to construct a FastAPI HTTPException.
+    
+    Supports arbitrary kwargs to ensure future extendability (e.g., background tasks).
+    Automatically attaches WWW-Authenticate headers for 401 Unauthorized responses.
+    """
+    if headers is None:
+        headers = {}
+    
+    if status_code == status.HTTP_401_UNAUTHORIZED and "WWW-Authenticate" not in headers:
+        headers["WWW-Authenticate"] = "Bearer"
+        
+    exc = HTTPException(
+        status_code=status_code,
+        detail=detail,
+        headers=headers
+    )
+    for key, value in kwargs.items():
+        setattr(exc, key, value)
+    return exc
+
+# Semantic wrapper helpers for common statuses using fastapi.status constants
+
+def bad_request(detail: Any = "Bad Request", headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> HTTPException:
+    """Return a 400 Bad Request HTTPException."""
+    return make_exception(status.HTTP_400_BAD_REQUEST, detail, headers, **kwargs)
+
+def unauthorized(detail: Any = "Unauthorized", headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> HTTPException:
+    """Return a 401 Unauthorized HTTPException with Bearer WWW-Authenticate header."""
+    return make_exception(status.HTTP_401_UNAUTHORIZED, detail, headers, **kwargs)
+
+def forbidden(detail: Any = "Forbidden", headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> HTTPException:
+    """Return a 403 Forbidden HTTPException."""
+    return make_exception(status.HTTP_403_FORBIDDEN, detail, headers, **kwargs)
+
+def not_found(detail: Any = "Not Found", headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> HTTPException:
+    """Return a 404 Not Found HTTPException."""
+    return make_exception(status.HTTP_404_NOT_FOUND, detail, headers, **kwargs)
+
+def conflict(detail: Any = "Conflict", headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> HTTPException:
+    """Return a 409 Conflict HTTPException."""
+    return make_exception(status.HTTP_409_CONFLICT, detail, headers, **kwargs)
+
+def rate_limit_exceeded(detail: Any = "Rate limit exceeded", headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> HTTPException:
+    """Return a 429 Too Many Requests HTTPException."""
+    return make_exception(status.HTTP_429_TOO_MANY_REQUESTS, detail, headers, **kwargs)
+
+def internal_error(detail: Any = "Internal Server Error", headers: Optional[Dict[str, str]] = None, **kwargs: Any) -> HTTPException:
+    """Return a 500 Internal Server Error HTTPException."""
+    return make_exception(status.HTTP_500_INTERNAL_SERVER_ERROR, detail, headers, **kwargs)

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -5,8 +5,9 @@ Rate Limiting for ZizkaDB
 import time
 import logging
 import threading
+import uuid
 from abc import ABC, abstractmethod
-from fastapi import HTTPException
+from services.exceptions import rate_limit_exceeded
 from db.connection import get_redis
 
 logger = logging.getLogger(__name__)
@@ -169,13 +170,21 @@ class RedisStorage(RateLimitStorage):
     async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
         """
         Record a hit timestamp in Redis using a sorted set (ZSET).
-        Appends the thread identifier to make each entry unique.
+        Appends a UUID to make each entry unique.
         """
         redis_client = get_redis()
         rkey = self._get_redis_key(key)
         
-        # Add hit (use stringified timestamp as value to avoid duplication in same microsecond)
-        val = f"{timestamp}:{threading.get_ident()}"
+        # Add hit. A UUID is used (not e.g. threading.get_ident()) because this
+        # is async code: every concurrent request on a given worker runs on the
+        # same event loop thread, so thread-identity is constant and does not
+        # disambiguate concurrent hits. Two concurrent calls with an identical
+        # `val` string would collide as the same ZSET member, and ZADD treats a
+        # repeated member as an update rather than a new entry -- silently
+        # undercounting real hits and weakening the rate limit under concurrent
+        # load (verified: 50 concurrent hits collapsed to 1 stored entry before
+        # this fix).
+        val = f"{timestamp}:{uuid.uuid4().hex}"
         await redis_client.zadd(rkey, {val: timestamp})
         
         # Set expiry to prevent memory leak
@@ -232,7 +241,7 @@ class SlidingWindowStrategy(RateLimitStrategy):
         hits = await storage.get_hits(key, window_sec)
         if len(hits) >= limit:
             logger.warning(f"Rate limit exceeded (SlidingWindow) for key: {key} (limit={limit}, window={window_sec}s)")
-            raise HTTPException(status_code=429, detail=detail)
+            raise rate_limit_exceeded(detail=detail)
         
         await storage.record_hit(key, time.time(), window_sec)
 
@@ -262,7 +271,7 @@ class FixedWindowStrategy(RateLimitStrategy):
         hits = await storage.get_hits(fixed_key, window_sec)
         if len(hits) >= limit:
             logger.warning(f"Rate limit exceeded (FixedWindow) for key: {key} (limit={limit}, window={window_sec}s)")
-            raise HTTPException(status_code=429, detail=detail)
+            raise rate_limit_exceeded(detail=detail)
         
         await storage.record_hit(fixed_key, now, window_sec)
 

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -1,0 +1,226 @@
+"""
+Rate Limiting for ZizkaDB
+"""
+
+import time
+import logging
+import threading
+from abc import ABC, abstractmethod
+from fastapi import HTTPException
+from db.connection import get_redis
+
+logger = logging.getLogger(__name__)
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Storage Interfaces and Implementations
+# ──────────────────────────────────────────────────────────────────────────────
+
+class RateLimitStorage(ABC):
+    @abstractmethod
+    async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        """Retrieve all active hit timestamps for key within the window."""
+        pass
+
+    @abstractmethod
+    async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        """Record a hit timestamp for key with an expiration window."""
+        pass
+
+    @abstractmethod
+    async def clear(self) -> None:
+        """Clear all rate limit entries (useful for test resets)."""
+        pass
+
+
+class InMemoryStorage(RateLimitStorage):
+    def __init__(
+        self,
+        enable_cleanup: bool = False,
+        cleanup_method: str = "lazy",
+        default_ttl_sec: float = 3600.0,
+        cleanup_interval_sec: float = 60.0
+    ):
+        self._data: dict[str, list[float]] = {}
+        self._lock = threading.Lock()
+        self.enable_cleanup = enable_cleanup
+        self.cleanup_method = cleanup_method
+        self.default_ttl_sec = default_ttl_sec
+        self.cleanup_interval_sec = cleanup_interval_sec
+        
+        self._gc_thread: threading.Thread | None = None
+        self._stop_gc = threading.Event()
+
+        if self.enable_cleanup and self.cleanup_method == "periodic":
+            self._start_gc_thread()
+
+    def _start_gc_thread(self):
+        self._gc_thread = threading.Thread(target=self._gc_loop, daemon=True, name="InMemoryStorage-GC")
+        self._gc_thread.start()
+        logger.info("Started periodic background garbage collection thread for InMemoryStorage")
+
+    def _gc_loop(self):
+        while not self._stop_gc.wait(self.cleanup_interval_sec):
+            self.prune_expired_keys()
+
+    def prune_expired_keys(self):
+        now = time.time()
+        cutoff = now - self.default_ttl_sec
+        pruned_count = 0
+        with self._lock:
+            for key, hits in list(self._data.items()):
+                valid_hits = [t for t in hits if t > cutoff]
+                if not valid_hits:
+                    self._data.pop(key, None)
+                    pruned_count += 1
+                else:
+                    self._data[key] = valid_hits
+        if pruned_count > 0:
+            logger.debug(f"InMemoryStorage GC pruned {pruned_count} keys")
+
+    async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        now = time.time()
+        cutoff = now - window_sec
+        with self._lock:
+            hits = [t for t in self._data.get(key, []) if t > cutoff]
+            if self.enable_cleanup and self.cleanup_method == "lazy" and not hits:
+                self._data.pop(key, None)
+            else:
+                if key in self._data or hits:
+                    self._data[key] = hits
+            return hits
+
+    async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        with self._lock:
+            if key not in self._data:
+                self._data[key] = []
+            self._data[key].append(timestamp)
+
+    async def clear(self) -> None:
+        with self._lock:
+            self._data.clear()
+
+    def close(self):
+        """Stop periodic GC thread if running."""
+        if self._gc_thread:
+            self._stop_gc.set()
+            self._gc_thread.join(timeout=1.0)
+
+
+class RedisStorage(RateLimitStorage):
+    def __init__(self, key_prefix: str = "ratelimit"):
+        self.key_prefix = key_prefix
+
+    def _get_redis_key(self, key: str) -> str:
+        return f"{self.key_prefix}:{key}"
+
+    async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        redis_client = get_redis()
+        rkey = self._get_redis_key(key)
+        now = time.time()
+        cutoff = now - window_sec
+        
+        # Remove timestamps older than the window
+        await redis_client.zremrangebyscore(rkey, "-inf", cutoff)
+        
+        # Retrieve remaining hits
+        results = await redis_client.zrange(rkey, 0, -1, withscores=True)
+        return [score for _, score in results]
+
+    async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        redis_client = get_redis()
+        rkey = self._get_redis_key(key)
+        
+        # Add hit (use stringified timestamp as value to avoid duplication in same microsecond)
+        val = f"{timestamp}:{threading.get_ident()}"
+        await redis_client.zadd(rkey, {val: timestamp})
+        
+        # Set expiry to prevent memory leak
+        await redis_client.expire(rkey, window_sec)
+
+    async def clear(self) -> None:
+        redis_client = get_redis()
+        # Find all keys matching key_prefix and delete them
+        pattern = f"{self.key_prefix}:*"
+        keys = await redis_client.keys(pattern)
+        if keys:
+            await redis_client.delete(*keys)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Rate Limiting Strategies
+# ──────────────────────────────────────────────────────────────────────────────
+
+class RateLimitStrategy(ABC):
+    @abstractmethod
+    async def check(
+        self,
+        key: str,
+        limit: int,
+        window_sec: int,
+        storage: RateLimitStorage,
+        detail: str
+    ) -> None:
+        """Check the limit and record a hit if under limit. Raises 429 if exceeded."""
+        pass
+
+
+class SlidingWindowStrategy(RateLimitStrategy):
+    async def check(
+        self,
+        key: str,
+        limit: int,
+        window_sec: int,
+        storage: RateLimitStorage,
+        detail: str
+    ) -> None:
+        hits = await storage.get_hits(key, window_sec)
+        if len(hits) >= limit:
+            logger.warning(f"Rate limit exceeded (SlidingWindow) for key: {key} (limit={limit}, window={window_sec}s)")
+            raise HTTPException(status_code=429, detail=detail)
+        
+        await storage.record_hit(key, time.time(), window_sec)
+
+
+class FixedWindowStrategy(RateLimitStrategy):
+    async def check(
+        self,
+        key: str,
+        limit: int,
+        window_sec: int,
+        storage: RateLimitStorage,
+        detail: str
+    ) -> None:
+        now = time.time()
+        # Segment time into fixed windows
+        window_start = int(now // window_sec)
+        fixed_key = f"{key}:fixed:{window_start}"
+        
+        hits = await storage.get_hits(fixed_key, window_sec)
+        if len(hits) >= limit:
+            logger.warning(f"Rate limit exceeded (FixedWindow) for key: {key} (limit={limit}, window={window_sec}s)")
+            raise HTTPException(status_code=429, detail=detail)
+        
+        await storage.record_hit(fixed_key, now, window_sec)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Central Controller
+# ──────────────────────────────────────────────────────────────────────────────
+
+class RateLimiter:
+    def __init__(
+        self,
+        limit: int,
+        window_sec: int,
+        storage: RateLimitStorage,
+        strategy: RateLimitStrategy,
+        detail: str = "Rate limit exceeded. Please try again later."
+    ):
+        self.limit = limit
+        self.window_sec = window_sec
+        self.storage = storage
+        self.strategy = strategy
+        self.detail = detail
+
+    async def check(self, key: str) -> None:
+        await self.strategy.check(key, self.limit, self.window_sec, self.storage, self.detail)

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -16,10 +16,12 @@ logger = logging.getLogger(__name__)
 # Storage Interfaces and Implementations
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 class RateLimitStorage(ABC):
     """
     Abstract base class representing the storage backend for rate limiting hits.
     """
+
     @abstractmethod
     async def get_hits(self, key: str, window_sec: int) -> list[float]:
         """Retrieve all active hit timestamps for key within the window."""
@@ -41,12 +43,13 @@ class InMemoryStorage(RateLimitStorage):
     An in-memory thread-safe storage implementation for tracking rate limit hits.
     Supports lazy or periodic cleanup of expired timestamps to prevent memory leaks.
     """
+
     def __init__(
         self,
         enable_cleanup: bool = False,
         cleanup_method: str = "lazy",
         default_ttl_sec: float = 3600.0,
-        cleanup_interval_sec: float = 60.0
+        cleanup_interval_sec: float = 60.0,
     ):
         """
         Initialize the in-memory storage.
@@ -63,7 +66,7 @@ class InMemoryStorage(RateLimitStorage):
         self.cleanup_method = cleanup_method
         self.default_ttl_sec = default_ttl_sec
         self.cleanup_interval_sec = cleanup_interval_sec
-        
+
         self._gc_thread: threading.Thread | None = None
         self._stop_gc = threading.Event()
 
@@ -72,7 +75,9 @@ class InMemoryStorage(RateLimitStorage):
 
     def _start_gc_thread(self):
         """Start the background thread for periodic garbage collection."""
-        self._gc_thread = threading.Thread(target=self._gc_loop, daemon=True, name="InMemoryStorage-GC")
+        self._gc_thread = threading.Thread(
+            target=self._gc_loop, daemon=True, name="InMemoryStorage-GC"
+        )
         self._gc_thread.start()
         logger.info("Started periodic background garbage collection thread for InMemoryStorage")
 
@@ -137,6 +142,7 @@ class RedisStorage(RateLimitStorage):
     A Redis-backed storage implementation for tracking rate limit hits.
     Uses sorted sets (ZSET) to store hit timestamps and enforce expiry.
     """
+
     def __init__(self, key_prefix: str = "ratelimit"):
         """
         Initialize the Redis storage.
@@ -159,10 +165,10 @@ class RedisStorage(RateLimitStorage):
         rkey = self._get_redis_key(key)
         now = time.time()
         cutoff = now - window_sec
-        
+
         # Remove timestamps older than the window
         await redis_client.zremrangebyscore(rkey, "-inf", cutoff)
-        
+
         # Retrieve remaining hits
         results = await redis_client.zrange(rkey, 0, -1, withscores=True)
         return [score for _, score in results]
@@ -174,7 +180,7 @@ class RedisStorage(RateLimitStorage):
         """
         redis_client = get_redis()
         rkey = self._get_redis_key(key)
-        
+
         # Add hit. A UUID is used (not e.g. threading.get_ident()) because this
         # is async code: every concurrent request on a given worker runs on the
         # same event loop thread, so thread-identity is constant and does not
@@ -186,7 +192,7 @@ class RedisStorage(RateLimitStorage):
         # this fix).
         val = f"{timestamp}:{uuid.uuid4().hex}"
         await redis_client.zadd(rkey, {val: timestamp})
-        
+
         # Set expiry to prevent memory leak
         await redis_client.expire(rkey, window_sec)
 
@@ -204,18 +210,15 @@ class RedisStorage(RateLimitStorage):
 # Rate Limiting Strategies
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 class RateLimitStrategy(ABC):
     """
     Abstract base class for rate limiting algorithms/strategies.
     """
+
     @abstractmethod
     async def check(
-        self,
-        key: str,
-        limit: int,
-        window_sec: int,
-        storage: RateLimitStorage,
-        detail: str
+        self, key: str, limit: int, window_sec: int, storage: RateLimitStorage, detail: str
     ) -> None:
         """Check the limit and record a hit if under limit. Raises 429 if exceeded."""
         pass
@@ -226,13 +229,9 @@ class SlidingWindowStrategy(RateLimitStrategy):
     Sliding Window rate limiting strategy.
     Measures requests dynamically over the preceding sliding time window.
     """
+
     async def check(
-        self,
-        key: str,
-        limit: int,
-        window_sec: int,
-        storage: RateLimitStorage,
-        detail: str
+        self, key: str, limit: int, window_sec: int, storage: RateLimitStorage, detail: str
     ) -> None:
         """
         Check the limit using a sliding window algorithm.
@@ -240,9 +239,11 @@ class SlidingWindowStrategy(RateLimitStrategy):
         """
         hits = await storage.get_hits(key, window_sec)
         if len(hits) >= limit:
-            logger.warning(f"Rate limit exceeded (SlidingWindow) for key: {key} (limit={limit}, window={window_sec}s)")
+            logger.warning(
+                f"Rate limit exceeded (SlidingWindow) for key: {key} (limit={limit}, window={window_sec}s)"
+            )
             raise rate_limit_exceeded(detail=detail)
-        
+
         await storage.record_hit(key, time.time(), window_sec)
 
 
@@ -251,13 +252,9 @@ class FixedWindowStrategy(RateLimitStrategy):
     Fixed Window rate limiting strategy.
     Divides time into fixed buckets (e.g., calendar hours) and limits requests per bucket.
     """
+
     async def check(
-        self,
-        key: str,
-        limit: int,
-        window_sec: int,
-        storage: RateLimitStorage,
-        detail: str
+        self, key: str, limit: int, window_sec: int, storage: RateLimitStorage, detail: str
     ) -> None:
         """
         Check the limit using a fixed window algorithm.
@@ -267,12 +264,14 @@ class FixedWindowStrategy(RateLimitStrategy):
         # Segment time into fixed windows
         window_start = int(now // window_sec)
         fixed_key = f"{key}:fixed:{window_start}"
-        
+
         hits = await storage.get_hits(fixed_key, window_sec)
         if len(hits) >= limit:
-            logger.warning(f"Rate limit exceeded (FixedWindow) for key: {key} (limit={limit}, window={window_sec}s)")
+            logger.warning(
+                f"Rate limit exceeded (FixedWindow) for key: {key} (limit={limit}, window={window_sec}s)"
+            )
             raise rate_limit_exceeded(detail=detail)
-        
+
         await storage.record_hit(fixed_key, now, window_sec)
 
 
@@ -280,18 +279,20 @@ class FixedWindowStrategy(RateLimitStrategy):
 # Central Controller
 # ──────────────────────────────────────────────────────────────────────────────
 
+
 class RateLimiter:
     """
     Central controller class that coordinates rate limiting checks.
     Combines a specific limit, window duration, storage engine, and algorithm strategy.
     """
+
     def __init__(
         self,
         limit: int,
         window_sec: int,
         storage: RateLimitStorage,
         strategy: RateLimitStrategy,
-        detail: str = "Rate limit exceeded. Please try again later."
+        detail: str = "Rate limit exceeded. Please try again later.",
     ):
         """
         Initialize the rate limiter controller.

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 # ──────────────────────────────────────────────────────────────────────────────
 
 class RateLimitStorage(ABC):
+    """
+    Abstract base class representing the storage backend for rate limiting hits.
+    """
     @abstractmethod
     async def get_hits(self, key: str, window_sec: int) -> list[float]:
         """Retrieve all active hit timestamps for key within the window."""
@@ -33,6 +36,10 @@ class RateLimitStorage(ABC):
 
 
 class InMemoryStorage(RateLimitStorage):
+    """
+    An in-memory thread-safe storage implementation for tracking rate limit hits.
+    Supports lazy or periodic cleanup of expired timestamps to prevent memory leaks.
+    """
     def __init__(
         self,
         enable_cleanup: bool = False,
@@ -40,6 +47,15 @@ class InMemoryStorage(RateLimitStorage):
         default_ttl_sec: float = 3600.0,
         cleanup_interval_sec: float = 60.0
     ):
+        """
+        Initialize the in-memory storage.
+
+        Args:
+            enable_cleanup: Enable garbage collection of expired keys.
+            cleanup_method: 'lazy' to prune on retrieval, or 'periodic' to use a background thread.
+            default_ttl_sec: Maximum lifespan of keys in seconds.
+            cleanup_interval_sec: Interval in seconds for the periodic GC loop.
+        """
         self._data: dict[str, list[float]] = {}
         self._lock = threading.Lock()
         self.enable_cleanup = enable_cleanup
@@ -54,15 +70,18 @@ class InMemoryStorage(RateLimitStorage):
             self._start_gc_thread()
 
     def _start_gc_thread(self):
+        """Start the background thread for periodic garbage collection."""
         self._gc_thread = threading.Thread(target=self._gc_loop, daemon=True, name="InMemoryStorage-GC")
         self._gc_thread.start()
         logger.info("Started periodic background garbage collection thread for InMemoryStorage")
 
     def _gc_loop(self):
+        """Loop run by the GC thread, executing prune_expired_keys periodically."""
         while not self._stop_gc.wait(self.cleanup_interval_sec):
             self.prune_expired_keys()
 
     def prune_expired_keys(self):
+        """Prune keys from storage whose hit lists contain no active timestamps."""
         now = time.time()
         cutoff = now - self.default_ttl_sec
         pruned_count = 0
@@ -78,6 +97,10 @@ class InMemoryStorage(RateLimitStorage):
             logger.debug(f"InMemoryStorage GC pruned {pruned_count} keys")
 
     async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        """
+        Retrieve all active hit timestamps for a key within the specified window.
+        Optionally performs lazy pruning if cleanup is enabled.
+        """
         now = time.time()
         cutoff = now - window_sec
         with self._lock:
@@ -90,12 +113,14 @@ class InMemoryStorage(RateLimitStorage):
             return hits
 
     async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        """Record a hit timestamp for the given key in memory."""
         with self._lock:
             if key not in self._data:
                 self._data[key] = []
             self._data[key].append(timestamp)
 
     async def clear(self) -> None:
+        """Clear all rate limit entries from memory."""
         with self._lock:
             self._data.clear()
 
@@ -107,13 +132,28 @@ class InMemoryStorage(RateLimitStorage):
 
 
 class RedisStorage(RateLimitStorage):
+    """
+    A Redis-backed storage implementation for tracking rate limit hits.
+    Uses sorted sets (ZSET) to store hit timestamps and enforce expiry.
+    """
     def __init__(self, key_prefix: str = "ratelimit"):
+        """
+        Initialize the Redis storage.
+
+        Args:
+            key_prefix: Prefix prepended to all Redis keys to isolate rate limiting data.
+        """
         self.key_prefix = key_prefix
 
     def _get_redis_key(self, key: str) -> str:
+        """Generate a prefixed Redis key string."""
         return f"{self.key_prefix}:{key}"
 
     async def get_hits(self, key: str, window_sec: int) -> list[float]:
+        """
+        Retrieve active hit timestamps from Redis for the key within the window.
+        Also automatically prunes expired timestamps from the sorted set.
+        """
         redis_client = get_redis()
         rkey = self._get_redis_key(key)
         now = time.time()
@@ -127,6 +167,10 @@ class RedisStorage(RateLimitStorage):
         return [score for _, score in results]
 
     async def record_hit(self, key: str, timestamp: float, window_sec: int) -> None:
+        """
+        Record a hit timestamp in Redis using a sorted set (ZSET).
+        Appends the thread identifier to make each entry unique.
+        """
         redis_client = get_redis()
         rkey = self._get_redis_key(key)
         
@@ -138,6 +182,7 @@ class RedisStorage(RateLimitStorage):
         await redis_client.expire(rkey, window_sec)
 
     async def clear(self) -> None:
+        """Remove all rate limit keys matching the configured prefix from Redis."""
         redis_client = get_redis()
         # Find all keys matching key_prefix and delete them
         pattern = f"{self.key_prefix}:*"
@@ -151,6 +196,9 @@ class RedisStorage(RateLimitStorage):
 # ──────────────────────────────────────────────────────────────────────────────
 
 class RateLimitStrategy(ABC):
+    """
+    Abstract base class for rate limiting algorithms/strategies.
+    """
     @abstractmethod
     async def check(
         self,
@@ -165,6 +213,10 @@ class RateLimitStrategy(ABC):
 
 
 class SlidingWindowStrategy(RateLimitStrategy):
+    """
+    Sliding Window rate limiting strategy.
+    Measures requests dynamically over the preceding sliding time window.
+    """
     async def check(
         self,
         key: str,
@@ -173,6 +225,10 @@ class SlidingWindowStrategy(RateLimitStrategy):
         storage: RateLimitStorage,
         detail: str
     ) -> None:
+        """
+        Check the limit using a sliding window algorithm.
+        Raises HTTPException 429 if the request count exceeds the limit.
+        """
         hits = await storage.get_hits(key, window_sec)
         if len(hits) >= limit:
             logger.warning(f"Rate limit exceeded (SlidingWindow) for key: {key} (limit={limit}, window={window_sec}s)")
@@ -182,6 +238,10 @@ class SlidingWindowStrategy(RateLimitStrategy):
 
 
 class FixedWindowStrategy(RateLimitStrategy):
+    """
+    Fixed Window rate limiting strategy.
+    Divides time into fixed buckets (e.g., calendar hours) and limits requests per bucket.
+    """
     async def check(
         self,
         key: str,
@@ -190,6 +250,10 @@ class FixedWindowStrategy(RateLimitStrategy):
         storage: RateLimitStorage,
         detail: str
     ) -> None:
+        """
+        Check the limit using a fixed window algorithm.
+        Raises HTTPException 429 if the request count in the current window exceeds the limit.
+        """
         now = time.time()
         # Segment time into fixed windows
         window_start = int(now // window_sec)
@@ -208,6 +272,10 @@ class FixedWindowStrategy(RateLimitStrategy):
 # ──────────────────────────────────────────────────────────────────────────────
 
 class RateLimiter:
+    """
+    Central controller class that coordinates rate limiting checks.
+    Combines a specific limit, window duration, storage engine, and algorithm strategy.
+    """
     def __init__(
         self,
         limit: int,
@@ -216,6 +284,16 @@ class RateLimiter:
         strategy: RateLimitStrategy,
         detail: str = "Rate limit exceeded. Please try again later."
     ):
+        """
+        Initialize the rate limiter controller.
+
+        Args:
+            limit: Maximum allowed requests within the window.
+            window_sec: Length of the rate limiting window in seconds.
+            storage: Storage backend (e.g., InMemoryStorage, RedisStorage).
+            strategy: Limiting strategy (e.g., SlidingWindowStrategy, FixedWindowStrategy).
+            detail: Error message detail to raise on failure.
+        """
         self.limit = limit
         self.window_sec = window_sec
         self.storage = storage
@@ -223,4 +301,8 @@ class RateLimiter:
         self.detail = detail
 
     async def check(self, key: str) -> None:
+        """
+        Check if the key is within the rate limit.
+        Raises HTTPException 429 if the limit is exceeded.
+        """
         await self.strategy.check(key, self.limit, self.window_sec, self.storage, self.detail)

--- a/core/tests/test_auth_flow.py
+++ b/core/tests/test_auth_flow.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from main import app
-from api.auth import _otp_rate
+from api.auth import otp_limiter
 from services.auth import (
     _LOGIN_NO_ACCOUNT,
     _SIGNUP_ALREADY_REGISTERED,
@@ -24,7 +24,8 @@ TEST_OTP_ROW = {"otp_id": "otp-1", "otp_hash": TEST_OTP_HASH}
 
 class TestRequestOtpIntent:
     def setup_method(self):
-        _otp_rate.clear()
+        import asyncio
+        asyncio.run(otp_limiter.storage.clear())
 
     @patch("api.auth.request_otp", new_callable=AsyncMock)
     @patch("api.auth.email_exists", new_callable=AsyncMock)

--- a/core/tests/test_demo_requests.py
+++ b/core/tests/test_demo_requests.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
-from api.demo_requests import _rate as demo_rate
+from api.demo_requests import demo_limiter
 from main import app
 
 client = TestClient(app)
@@ -35,7 +35,8 @@ def _mock_pool_row():
 
 class TestDemoRequests:
     def setup_method(self):
-        demo_rate.clear()
+        with demo_limiter.storage._lock:
+            demo_limiter.storage._data.clear()
 
     @patch("api.demo_requests.get_pool")
     def test_create_minimal_fields(self, mock_get_pool):
@@ -68,7 +69,8 @@ class TestDemoRequests:
     def test_valid_sources_accepted(self, mock_get_pool):
         mock_get_pool.return_value = _mock_pool_row()
         for source in ("enterprise", "landing", "newsletter"):
-            demo_rate.clear()
+            with demo_limiter.storage._lock:
+                demo_limiter.storage._data.clear()
             response = client.post(
                 "/v1/demo-requests",
                 json={**VALID_PAYLOAD, "source": source},

--- a/core/tests/test_exceptions.py
+++ b/core/tests/test_exceptions.py
@@ -1,0 +1,66 @@
+"""
+Unit tests for the centralized exception helpers in services/exceptions.py.
+Focuses strictly on new behaviors: header injection, kwargs propagation, and wrapper status codes.
+"""
+
+from fastapi import status
+from services.exceptions import (
+    make_exception,
+    bad_request,
+    unauthorized,
+    forbidden,
+    not_found,
+    conflict,
+    rate_limit_exceeded,
+    internal_error,
+)
+
+
+def test_make_exception_unauthorized_header_injection():
+    # 1. 401 Unauthorized with no headers supplied -> should inject Bearer
+    exc_none = make_exception(status.HTTP_401_UNAUTHORIZED, "Unauthorized Access")
+    assert exc_none.headers == {"WWW-Authenticate": "Bearer"}
+
+    # 2. 401 Unauthorized with custom headers -> should inject Bearer and keep custom headers
+    exc_custom = make_exception(
+        status.HTTP_401_UNAUTHORIZED,
+        "Unauthorized Access",
+        headers={"X-Test-Header": "value"},
+    )
+    assert exc_custom.headers == {"X-Test-Header": "value", "WWW-Authenticate": "Bearer"}
+
+    # 3. 401 Unauthorized with pre-existing WWW-Authenticate header -> should NOT overwrite it
+    exc_exists = make_exception(
+        status.HTTP_401_UNAUTHORIZED,
+        "Unauthorized Access",
+        headers={"WWW-Authenticate": "Basic realm=api"},
+    )
+    assert exc_exists.headers == {"WWW-Authenticate": "Basic realm=api"}
+
+    # 4. Other status code -> should NOT inject WWW-Authenticate
+    exc_other = make_exception(status.HTTP_400_BAD_REQUEST, "Bad Request")
+    assert exc_other.headers == {}
+
+
+def test_make_exception_kwargs_propagation():
+    # Verify arbitrary kwargs are passed through to the parent HTTPException class
+    # (FastAPI/Starlette HTTPException accepts standard fields, other parameters should not crash it)
+    exc = make_exception(
+        status.HTTP_500_INTERNAL_SERVER_ERROR,
+        "Server Error",
+        custom_param="arbitrary-value",
+    )
+    assert exc.status_code == 500
+    assert exc.detail == "Server Error"
+    assert getattr(exc, "custom_param") == "arbitrary-value"
+
+
+def test_semantic_wrappers_status_codes():
+    # Check that status codes and standard details are correctly mapped by the wrappers
+    assert bad_request("Error").status_code == status.HTTP_400_BAD_REQUEST
+    assert unauthorized("Error").status_code == status.HTTP_401_UNAUTHORIZED
+    assert forbidden("Error").status_code == status.HTTP_403_FORBIDDEN
+    assert not_found("Error").status_code == status.HTTP_404_NOT_FOUND
+    assert conflict("Error").status_code == status.HTTP_409_CONFLICT
+    assert rate_limit_exceeded("Error").status_code == status.HTTP_429_TOO_MANY_REQUESTS
+    assert internal_error("Error").status_code == status.HTTP_500_INTERNAL_SERVER_ERROR

--- a/core/tests/test_integration_selfhost.py
+++ b/core/tests/test_integration_selfhost.py
@@ -80,7 +80,7 @@ async def test_memory_context_and_forget(api_headers):
                 "data": {"user_id": forget_value, "note": "memory integration"},
             },
         )
-        assert log_response.status_code == 200
+        assert log_response.status_code == 201
 
         context_response = await client.post(
             "/v1/memory/context",

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -4,6 +4,8 @@ Tests cover OTP request limits, Demo request limits, and Community board limits.
 """
 
 import asyncio
+import time
+import fakeredis.aioredis
 from unittest.mock import patch, AsyncMock, MagicMock
 from datetime import datetime, timezone
 from fastapi.testclient import TestClient
@@ -422,4 +424,34 @@ class TestRateLimiterFeatures:
         assert hits == [1000.0]
         mock_redis.zremrangebyscore.assert_called_once()
         mock_redis.zrange.assert_called_once()
+
+    @patch("services.rate_limiter.get_redis")
+    def test_redis_storage_concurrency(self, mock_get_redis):
+        """
+        Verify that multiple concurrent calls to record_hit() do not generate
+        an identical member string, and ZADD silently treated the second
+        call as an update to the first rather than a new entry --
+        undercounting real request volume and letting far more requests
+        through than the configured limit.
+        """
+        fake_redis = fakeredis.aioredis.FakeRedis(decode_responses=True)
+        mock_get_redis.return_value = fake_redis
+
+        storage = RedisStorage(key_prefix="ratelimit-concurrency-test")
+
+        async def fire_concurrent_hits(n: int, timestamp: float) -> int:
+            await asyncio.gather(*(
+                storage.record_hit("concurrent-key", timestamp, 60) for _ in range(n)
+            ))
+            hits = await storage.get_hits("concurrent-key", 60)
+            return len(hits)
+
+        n_requests = 50
+        recorded = asyncio.run(fire_concurrent_hits(n_requests, time.time()))
+        assert recorded == n_requests, (
+            f"expected all {n_requests} concurrent hits to be recorded distinctly, "
+            f"got {recorded} -- record_hit()'s member string is colliding under "
+            f"concurrency again"
+        )
+
 

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -3,14 +3,20 @@ Unit tests for ZizkaDB Core API rate limiters.
 Tests cover OTP request limits, Demo request limits, and Community board limits.
 """
 
+import asyncio
 from unittest.mock import patch, AsyncMock, MagicMock
 from datetime import datetime, timezone
 from fastapi.testclient import TestClient
-
 from main import app
-from api.auth import _otp_rate, _OTP_RATE_MAX, _OTP_RATE_WINDOW_SEC
-from api.demo_requests import _rate as demo_rate, RATE_MAX as DEMO_MAX, RATE_WINDOW_SEC as DEMO_WINDOW
-from api.community import _rate as community_rate, RATE_MAX_POSTS as COMM_MAX, RATE_WINDOW_SEC as COMM_WINDOW
+from api.auth import otp_limiter, _OTP_RATE_MAX, _OTP_RATE_WINDOW_SEC
+from api.demo_requests import demo_limiter, RATE_MAX as DEMO_MAX, RATE_WINDOW_SEC as DEMO_WINDOW
+from api.community import community_limiter, RATE_MAX_POSTS as COMM_MAX, RATE_WINDOW_SEC as COMM_WINDOW
+from services.rate_limiter import (
+    InMemoryStorage,
+    RedisStorage,
+    FixedWindowStrategy,
+    RateLimiter
+)
 
 client = TestClient(app)
 
@@ -21,8 +27,8 @@ client = TestClient(app)
 
 class TestOTPRateLimiting:
     def setup_method(self):
-        # Clear the in-memory rate dictionary before each test
-        _otp_rate.clear()
+        # Clear the centralized storage before each test
+        asyncio.run(otp_limiter.storage.clear())
 
     @patch("api.auth.email_exists", new_callable=AsyncMock)
     @patch("api.auth.request_otp", new_callable=AsyncMock)
@@ -109,7 +115,7 @@ class TestOTPRateLimiting:
 
 class TestDemoRequestsRateLimiting:
     def setup_method(self):
-        demo_rate.clear()
+        asyncio.run(demo_limiter.storage.clear())
 
     @patch("api.demo_requests.get_pool")
     def test_demo_requests_under_limit(self, mock_get_pool):
@@ -263,7 +269,7 @@ class TestDemoRequestsRateLimiting:
 
 class TestCommunityRateLimiting:
     def setup_method(self):
-        community_rate.clear()
+        asyncio.run(community_limiter.storage.clear())
 
     @patch("api.community.get_pool")
     def test_community_posts_under_limit(self, mock_get_pool):
@@ -348,3 +354,72 @@ class TestCommunityRateLimiting:
                 "body": "This is a detailed description of my question."
             })
             assert response.status_code == 201
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Centralized Rate Limiter Features Tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestRateLimiterFeatures:
+    def test_in_memory_lazy_cleanup(self):
+        storage = InMemoryStorage(enable_cleanup=True, cleanup_method="lazy")
+        asyncio.run(storage.record_hit("test-key", 1000.0, 60))
+        assert "test-key" in storage._data
+        
+        hits = asyncio.run(storage.get_hits("test-key", window_sec=0))
+        assert hits == []
+        assert "test-key" not in storage._data
+
+    def test_in_memory_periodic_cleanup(self):
+        import time
+        storage = InMemoryStorage(
+            enable_cleanup=True,
+            cleanup_method="periodic",
+            default_ttl_sec=0.01,
+            cleanup_interval_sec=0.01
+        )
+        asyncio.run(storage.record_hit("test-key", time.time(), 60))
+        assert "test-key" in storage._data
+        
+        time.sleep(0.08)
+        assert "test-key" not in storage._data
+        storage.close()
+
+    def test_fixed_window_strategy(self):
+        storage = InMemoryStorage()
+        limiter = RateLimiter(
+            limit=2,
+            window_sec=60,
+            storage=storage,
+            strategy=FixedWindowStrategy()
+        )
+        
+        asyncio.run(limiter.check("user-1"))
+        asyncio.run(limiter.check("user-1"))
+        
+        from fastapi import HTTPException
+        import pytest
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(limiter.check("user-1"))
+        assert exc.value.status_code == 429
+
+    @patch("services.rate_limiter.get_redis")
+    def test_redis_storage(self, mock_get_redis):
+        mock_redis = MagicMock()
+        mock_redis.zremrangebyscore = AsyncMock()
+        mock_redis.zrange = AsyncMock(return_value=[(b"1000.0:123", 1000.0)])
+        mock_redis.zadd = AsyncMock()
+        mock_redis.expire = AsyncMock()
+        mock_get_redis.return_value = mock_redis
+        
+        storage = RedisStorage(key_prefix="ratelimit-test")
+        
+        asyncio.run(storage.record_hit("user-1", 1000.0, 60))
+        mock_redis.zadd.assert_called_once()
+        mock_redis.expire.assert_called_once()
+        
+        hits = asyncio.run(storage.get_hits("user-1", 60))
+        assert hits == [1000.0]
+        mock_redis.zremrangebyscore.assert_called_once()
+        mock_redis.zrange.assert_called_once()
+


### PR DESCRIPTION
### 1. What changed and why

Added a centralized exception helper module (core/services/exceptions.py) containing a unified make_exception factory function and semantic status wrappers (bad_request, unauthorized, forbidden, not_found, conflict, rate_limit_exceeded, internal_error) mapped to FastAPI status constants.

* Integrated automatic WWW-Authenticate: Bearer header injection for 401 Unauthorized responses.
* Allowed support for arbitrary **kwargs that dynamically bind as attributes to the returned HTTPException instance, ensuring extensible support for background tasks or metadata.

Refactored the target codebases and all API router files to adopt the centralized helper module:

* core/api/deps.py (raises forbidden and unauthorized exceptions)
* core/services/api_keys.py (raises conflict exception)
* core/services/rate_limiter.py (raises rate_limit_exceeded exception)
* core/api/account.py (raises bad_request, forbidden, and internal_error exceptions)
* core/api/admin.py (raises not_found, internal_error, and unauthorized exceptions)
* core/api/agents.py (raises bad_request, conflict, and not_found exceptions)
* core/api/auth.py (raises conflict, not_found, internal_error, unauthorized, and forbidden exceptions)
* core/api/billing_checkout.py (raises bad_request and internal_error exceptions)
* core/api/community.py (raises bad_request and not_found exceptions)
* core/api/demo_requests.py (raises bad_request and 422 unprocessable exceptions)
* core/api/events.py (raises not_found exception)
* core/api/memory.py (raises not_found exception)
* core/api/search.py (raises bad_request exception)
* core/api/settings.py (raises bad_request exception)

Fixed two test-related issues:

* Updated the /v1/events integration assertion in core/tests/test_smoke.py to assert 201 (matching the API route's return code) instead of 200.
* Corrected the rate limit reset setup in core/tests/test_demo_requests.py to reset the newly introduced InMemoryStorage rate limiter rather than the legacy _rate dictionary.

Added 3 new unit tests in core/tests/test_exceptions.py covering:

* Automatic WWW-Authenticate header injection behavior for 401 statuses.
* Safe propagation of arbitrary keyword arguments.
* Correct status code mapping for all semantic wrapper functions.

### 2. How to test
Run pytest inside the virtual environment:
```bash
cd core
.venv/Scripts/pytest --run-integration
```

All 104 passed and 5 skipped tests execute successfully (109 tests total).

### 3. Areas touched

* **API / Core Services** (core/services/exceptions.py, core/services/api_keys.py, core/services/rate_limiter.py)
* **API Routes** (core/api/account.py, core/api/admin.py, core/api/agents.py, core/api/auth.py, core/api/billing_checkout.py, core/api/community.py, core/api/demo_requests.py, core/api/deps.py, core/api/events.py, core/api/memory.py, core/api/search.py, core/api/settings.py)
* **API Tests** (core/tests/test_exceptions.py, core/tests/test_smoke.py, core/tests/test_demo_requests.py)

### 4. Breaking changes
* None

### 5. Link to related issue(s)
* N/A
