### PR TITLE
Fix Swagger UI: hide visible /openapi.json link

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -53,21 +53,38 @@ app = FastAPI(
 @app.get("/swagger", include_in_schema=False)
 async def swagger_ui():
     """
-    Swagger UI with a small CSS tweak to hide the visible /openapi.json link.
-    The OpenAPI schema remains available at /openapi.json.
+    Swagger UI without the visible /openapi.json link under the title.
+    The schema remains available at /openapi.json for tools that need it.
     """
     html = get_swagger_ui_html(
         openapi_url=app.openapi_url,
         title=f"{app.title} - Swagger UI",
     )
-    # Inject CSS to hide the OpenAPI URL control/link in the top bar.
     body = html.body.decode("utf-8")
+
     css = """
     <style>
       .swagger-ui .topbar .download-url-wrapper { display: none !important; }
-      .swagger-ui .topbar a[href$="openapi.json"] { display: none !important; }
+      .swagger-ui .info hgroup.main a { display: none !important; }
+      .swagger-ui .info .link { display: none !important; }
+      .swagger-ui .info a[href*="openapi.json"] { display: none !important; }
     </style>
     """
+
+    hide_url_plugin = """
+    const HideInfoUrlPlugin = () => ({
+      wrapComponents: {
+        InfoUrl: () => () => null,
+      },
+    });
+    """
+
+    body = body.replace(
+        "const ui = SwaggerUIBundle({",
+        hide_url_plugin + "\n    const ui = SwaggerUIBundle({\n        plugins: [HideInfoUrlPlugin],",
+        1,
+    )
+
     return HTMLResponse(body.replace("</head>", f"{css}</head>"))
 
 


### PR DESCRIPTION
## Summary

Removes the visible `/openapi.json` link under the title on `/swagger`.

Swagger UI 5 renders the spec URL in the **info block**, not the topbar. The previous CSS-only fix targeted the wrong selectors.

## Changes

- Inject Swagger UI `HideInfoUrlPlugin` to disable `InfoUrl` rendering
- Add CSS fallbacks for `.info hgroup.main a` and related selectors
- `/openapi.json` remains available for tools — only the UI link is hidden

## Test plan

- [ ] Open `/swagger` after API restart
- [ ] Confirm no `/openapi.json` link under **ZizkaDB** title
- [ ] Confirm API docs still load and endpoints are expandable
- [ ] `curl -s /openapi.json | head` still returns schema