### PR TITLE
Fix remote quickstart when GHCR images unavailable

### DIFF
--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -56,3 +56,15 @@ jobs:
           tags: |
             ${{ env.DASHBOARD_IMAGE }}:latest
             ${{ env.DASHBOARD_IMAGE }}:${{ steps.meta.outputs.tag }}
+
+      - name: Make GHCR packages public (required for curl quickstart)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          for pkg in zizkadb-api zizkadb-dashboard; do
+            echo "→ Setting visibility=public for ${pkg}"
+            gh api --method PATCH "/orgs/zizka-ai/packages/container/${pkg}" \
+              -f visibility=public \
+              || echo "WARN: could not set ${pkg} public — enable manually in GitHub Packages settings"
+          done

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quick
 
 No signup. No API key on localhost.
 
+> **Note:** Pre-built images pull from `ghcr.io/zizka-ai/` (public). If GHCR is unavailable, the script auto-clones shallow and builds locally — first run may take a few minutes.
+
 <details>
 <summary><strong>Alternative paths</strong> (contributors, air-gapped, or no curl)</summary>
 

--- a/scripts/quickstart-remote.sh
+++ b/scripts/quickstart-remote.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-# ZizkaDB OSS quickstart — NO git clone.
+# ZizkaDB OSS quickstart — NO git clone (when GHCR images are public).
 # Downloads ~4 small files to ~/.zizkadb, pulls pre-built Docker images, runs db.why() demo.
+# If GHCR pull fails, automatically shallow-clones and builds locally.
 #
 #   curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
 #
@@ -11,6 +12,7 @@ REPO="${ZIZKADB_REPO:-Zizka-ai/ZizkaDB}"
 BASE="https://raw.githubusercontent.com/${REPO}/${REF}"
 INSTALL_DIR="${ZIZKADB_HOME:-${HOME}/.zizkadb}"
 INFRA="${INSTALL_DIR}/infra"
+CLONE_DIR="${INSTALL_DIR}/repo"
 
 echo "════════════════════════════════════════════════════════"
 echo "  ZizkaDB — remote quickstart (no repo clone)"
@@ -29,50 +31,19 @@ if ! docker info >/dev/null 2>&1; then
   exit 1
 fi
 
-mkdir -p "${INFRA}"
+run_demo() {
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "WARN: python3 not found — stack is up but demo skipped."
+    echo "  pip install zizkadb-sdk && zizkadb demo"
+    return 0
+  fi
 
-echo "→ Downloading compose + schema (not the full repo)..."
-curl -fsSL "${BASE}/infra/docker-compose.quickstart.yml" -o "${INFRA}/docker-compose.quickstart.yml"
-curl -fsSL "${BASE}/core/db/schema.sql" -o "${INFRA}/schema.sql"
-curl -fsSL "${BASE}/infra/.env.quickstart" -o "${INFRA}/.env"
+  echo "→ Installing SDK from PyPI..."
+  python3 -m pip install -q zizkadb-sdk
 
-echo "→ Pulling pre-built images from ghcr.io/zizka-ai/..."
-cd "${INFRA}"
-if ! docker compose -f docker-compose.quickstart.yml pull 2>/dev/null; then
   echo ""
-  echo "WARN: Could not pull pre-built images from GHCR." >&2
-  echo "  Fallback — clone the repo and build locally:" >&2
-  echo "    git clone https://github.com/${REPO}.git && cd ZizkaDB && bash scripts/quickstart.sh" >&2
-  exit 1
-fi
-
-echo "→ Starting stack..."
-docker compose -f docker-compose.quickstart.yml up -d
-
-echo "→ Waiting for API..."
-for i in $(seq 1 30); do
-  if curl -sf http://localhost:8000/health >/dev/null 2>&1; then
-    break
-  fi
-  sleep 2
-  if [ "$i" -eq 30 ]; then
-    echo "ERROR: API did not become healthy. Check: docker compose -f ${INFRA}/docker-compose.quickstart.yml logs api" >&2
-    exit 1
-  fi
-done
-
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "WARN: python3 not found — stack is up but demo skipped."
-  echo "  pip install zizkadb-sdk && zizkadb demo"
-  exit 0
-fi
-
-echo "→ Installing SDK from PyPI..."
-python3 -m pip install -q zizkadb-sdk
-
-echo ""
-echo "→ Running causal lineage demo..."
-zizkadb demo || python3 -c "
+  echo "→ Running causal lineage demo..."
+  zizkadb demo || python3 -c "
 import asyncio
 from zizkadb import ZizkaDB
 async def main():
@@ -84,14 +55,64 @@ async def main():
 asyncio.run(main())
 "
 
-echo ""
-echo "════════════════════════════════════════════════════════"
-echo "  Done"
-echo "════════════════════════════════════════════════════════"
-echo ""
-echo "  Dashboard:  http://localhost:3001/login  →  Open my dashboard →"
-echo "  API:        http://localhost:8000/health"
-echo "  Connect:    https://github.com/${REPO}/blob/${REF}/CONNECT.md"
-echo ""
+  echo ""
+  echo "════════════════════════════════════════════════════════"
+  echo "  Done"
+  echo "════════════════════════════════════════════════════════"
+  echo ""
+  echo "  Dashboard:  http://localhost:3001/login  →  Open my dashboard →"
+  echo "  API:        http://localhost:8000/health"
+  echo "  Connect:    https://github.com/${REPO}/blob/${REF}/CONNECT.md"
+  echo ""
+}
+
+fallback_shallow_clone() {
+  echo ""
+  echo "→ GHCR pre-built images unavailable — falling back to shallow clone + local build..."
+  echo "  (First run may take a few minutes while Docker builds api + dashboard.)"
+  echo ""
+
+  if ! command -v git >/dev/null 2>&1; then
+    echo "ERROR: git is required for the build fallback." >&2
+    echo "  Install git, or run:" >&2
+    echo "    git clone https://github.com/${REPO}.git && cd ZizkaDB && bash scripts/quickstart.sh" >&2
+    exit 1
+  fi
+
+  rm -rf "${CLONE_DIR}"
+  git clone --depth 1 --branch "${REF}" "https://github.com/${REPO}.git" "${CLONE_DIR}"
+  exec bash "${CLONE_DIR}/scripts/quickstart.sh"
+}
+
+mkdir -p "${INFRA}"
+
+echo "→ Downloading compose + schema (not the full repo)..."
+curl -fsSL "${BASE}/infra/docker-compose.quickstart.yml" -o "${INFRA}/docker-compose.quickstart.yml"
+curl -fsSL "${BASE}/core/db/schema.sql" -o "${INFRA}/schema.sql"
+curl -fsSL "${BASE}/infra/.env.quickstart" -o "${INFRA}/.env"
+
+echo "→ Pulling pre-built images from ghcr.io/zizka-ai/..."
+cd "${INFRA}"
+if ! docker compose -f docker-compose.quickstart.yml pull; then
+  fallback_shallow_clone
+fi
+
+echo "→ Starting stack..."
+docker compose -f docker-compose.quickstart.yml up -d
+
+echo "→ Waiting for API..."
+for i in $(seq 1 60); do
+  if curl -sf http://localhost:8000/health >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+  if [ "$i" -eq 60 ]; then
+    echo "ERROR: API did not become healthy. Check: docker compose -f ${INFRA}/docker-compose.quickstart.yml logs api" >&2
+    exit 1
+  fi
+done
+
+run_demo
+
 echo "  Stop:  cd ${INFRA} && docker compose -f docker-compose.quickstart.yml down"
 echo ""


### PR DESCRIPTION
## Problem

`curl …/quickstart-remote.sh | bash` fails because **GHCR images were never published** (Publish OSS images workflow has 0 runs). Pull returns 401/404 for anonymous users.

## Fix

1. **Auto-fallback** — on pull failure, shallow-clone + `bash scripts/quickstart.sh` (local Docker build)
2. **Show real docker pull errors** (removed `2>/dev/null`)
3. **Publish workflow** — after push, attempt to set `zizkadb-api` and `zizkadb-dashboard` visibility to **public**

## After merge

Run **Actions → Publish OSS images → Run workflow** once (or push tag `v0.2.5`) so GHCR images exist for the fast path.

If visibility API fails, manually set both packages to Public in GitHub Packages settings.

## Test plan

- [ ] `curl -fsSL …/quickstart-remote.sh | bash` with no GHCR images → auto-clones and completes demo
- [ ] After publish workflow + public visibility → curl path pulls images in ~60s