### PR TITLE
Add multi-column marketing footer (ZizkaDB)

### DIFF
--- a/dashboard/app/enterprise/page.tsx
+++ b/dashboard/app/enterprise/page.tsx
@@ -1,7 +1,6 @@
 'use client'
 
 import { BRAND } from '@/components/brand'
-import { BrandLogo } from '@/components/BrandLogo'
 import { CalendlyBookModal } from '@/components/marketing/CalendlyBookModal'
 import { EnterpriseConnectForm } from '@/components/marketing/enterprise/EnterpriseConnectForm'
 import {
@@ -14,6 +13,7 @@ import {
   sectionTitle,
 } from '@/components/marketing/marketing-theme'
 import { MarketingPageStyles } from '@/components/marketing/MarketingPageStyles'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
 import { SiteNav } from '@/components/SiteNav'
 import Link from 'next/link'
 import { useState } from 'react'
@@ -144,8 +144,6 @@ export default function EnterprisePage() {
           .ent-price-grid { grid-template-columns: 1fr !important; }
           .ent-hero-btns { flex-direction: column !important; align-items: stretch !important; }
           .ent-hero-btns a, .ent-hero-btns button { justify-content: center !important; }
-          .ent-footer { flex-direction: column !important; gap: 16px !important; align-items: flex-start !important; }
-          .ent-footer-links { flex-wrap: wrap !important; gap: 16px !important; }
           .ent-split { grid-template-columns: 1fr !important; }
         }
         .ent-table { width: 100%; border-collapse: collapse; }
@@ -609,29 +607,7 @@ export default function EnterprisePage() {
         </div>
       </section>
 
-      {/* Footer */}
-      <footer className="ent-footer" style={{
-        borderTop: `1px solid ${M.line}`, padding: '32px 24px',
-        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-        fontSize: 13, color: '#000', background: '#fff', flexWrap: 'wrap', gap: 16,
-      }}>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-          <BrandLogo variant="mark" showWordmark={false} href="/" />
-          <span style={{ fontWeight: 700, color: '#000' }}>ZizkaDB</span>
-          <span style={{ color: '#000' }}>·</span>
-          <span style={{ fontWeight: 500, color: '#000' }}>Open source operational database for AI agents</span>
-        </div>
-        <div className="ent-footer-links" style={{ display: 'flex', gap: 22, flexWrap: 'wrap' }}>
-          {[['Docs', '/docs'], ['Pricing', '/#pricing'], ['Trust', '/trust'], ['GitHub', GITHUB_URL], ['Sign in', '/login']].map(([label, href]) =>
-            href!.startsWith('http') ? (
-              <a key={label} href={href} target="_blank" rel="noreferrer" style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>{label}</a>
-            ) : (
-              <Link key={label} href={href!} style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>{label}</Link>
-            )
-          )}
-          <a href="#contact" style={{ color: '#000', fontWeight: 700, textDecoration: 'none' }}>Lets connect</a>
-        </div>
-      </footer>
+      <MarketingFooter />
     </div>
   )
 }

--- a/dashboard/components/marketing/MarketingFooter.tsx
+++ b/dashboard/components/marketing/MarketingFooter.tsx
@@ -1,61 +1,121 @@
 import Link from 'next/link'
 import { BrandLogo } from '@/components/BrandLogo'
+import { ZIZKADB_COMPANY, ZIZKADB_FOOTER_COLUMNS, type FooterLink } from './footer-config'
 
-const GITHUB_URL = 'https://github.com/Zizka-ai/ZizkaDB'
+const YEAR = new Date().getFullYear()
 
-const LINKS: [string, string][] = [
-  ['Docs', '/docs'],
-  ['Enterprise', '/enterprise'],
-  ['Pricing', '/#pricing'],
-  ['Trust', '/trust'],
-  ['GitHub', GITHUB_URL],
-  ['Sign in', '/login'],
-]
+function FooterAnchor({ link }: { link: FooterLink }) {
+  const style = {
+    color: 'rgba(255,255,255,0.72)',
+    textDecoration: 'none' as const,
+    fontSize: 14,
+    lineHeight: 1.5,
+    display: 'inline-block' as const,
+  }
+
+  if (link.external || link.href.startsWith('http') || link.href.startsWith('mailto:')) {
+    return (
+      <a href={link.href} target="_blank" rel="noopener noreferrer" style={style}>
+        {link.label}
+      </a>
+    )
+  }
+
+  return (
+    <Link href={link.href} style={style}>
+      {link.label}
+    </Link>
+  )
+}
 
 export function MarketingFooter() {
   return (
-    <footer
-      className="zdb-footer"
-      style={{
-        borderTop: '1px solid #e2e8f0',
-        padding: '32px 24px',
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'space-between',
-        fontSize: 13,
-        color: '#000',
-        background: '#fff',
-        flexWrap: 'wrap',
-        gap: 16,
-      }}
-    >
-      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-        <BrandLogo variant="mark" showWordmark={false} href="/" />
-        <span style={{ fontWeight: 700, color: '#000' }}>ZizkaDB</span>
-        <span style={{ color: '#000' }}>·</span>
-        <span style={{ fontWeight: 500, color: '#000' }}>Open source operational database for AI agents</span>
-      </div>
-      <div className="zdb-footer-links" style={{ display: 'flex', gap: 22, flexWrap: 'wrap' }}>
-        {LINKS.map(([label, href]) =>
-          href.startsWith('http') ? (
+    <footer className="zdb-footer" style={{ background: '#0f1117', color: 'rgba(255,255,255,0.72)' }}>
+      <div
+        className="zdb-footer-grid"
+        style={{
+          maxWidth: 1100,
+          margin: '0 auto',
+          padding: '56px 40px 40px',
+          display: 'grid',
+          gridTemplateColumns: '1.4fr repeat(3, 1fr)',
+          gap: 40,
+        }}
+      >
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+            <BrandLogo variant="mark" showWordmark={false} href="/" />
+            <span style={{ fontSize: 18, fontWeight: 700, color: '#fff', letterSpacing: -0.3 }}>ZizkaDB</span>
+          </div>
+          <p style={{ margin: '0 0 20px', fontSize: 14, lineHeight: 1.65, color: 'rgba(255,255,255,0.55)', maxWidth: 280 }}>
+            Know why your agent did what it did. Causal lineage, time travel, and drift for production agents.
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             <a
-              key={label}
-              href={href}
+              href="https://github.com/Zizka-ai/ZizkaDB"
               target="_blank"
-              rel="noreferrer"
-              style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}
+              rel="noopener noreferrer"
+              style={{ fontSize: 13, color: 'rgba(255,255,255,0.55)', textDecoration: 'none' }}
             >
-              {label}
+              GitHub →
             </a>
-          ) : (
-            <Link key={label} href={href} style={{ color: '#000', textDecoration: 'none', fontWeight: 500 }}>
-              {label}
-            </Link>
-          ),
-        )}
-        <Link href="/signup" style={{ color: '#000', fontWeight: 700, textDecoration: 'none' }}>
-          Start free
-        </Link>
+            <a
+              href={ZIZKADB_COMPANY.zizkaAiUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ fontSize: 13, color: 'rgba(255,255,255,0.55)', textDecoration: 'none' }}
+            >
+              zizka.ai →
+            </a>
+          </div>
+        </div>
+
+        {ZIZKADB_FOOTER_COLUMNS.map((col) => (
+          <div key={col.title}>
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                letterSpacing: 0.9,
+                textTransform: 'uppercase',
+                color: 'rgba(255,255,255,0.38)',
+                marginBottom: 16,
+              }}
+            >
+              {col.title}
+            </div>
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {col.links.map((link) => (
+                <li key={link.label}>
+                  <FooterAnchor link={link} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)' }}>
+        <div
+          className="zdb-footer-meta"
+          style={{
+            maxWidth: 1100,
+            margin: '0 auto',
+            padding: '20px 40px 28px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            flexWrap: 'wrap',
+            gap: 12,
+            fontSize: 12,
+            color: 'rgba(255,255,255,0.38)',
+          }}
+        >
+          <span>© {YEAR} {ZIZKADB_COMPANY.name}</span>
+          <span style={{ textAlign: 'right' }}>
+            {ZIZKADB_COMPANY.location} · {ZIZKADB_COMPANY.taxId}
+          </span>
+        </div>
       </div>
     </footer>
   )

--- a/dashboard/components/marketing/MarketingPageStyles.tsx
+++ b/dashboard/components/marketing/MarketingPageStyles.tsx
@@ -28,6 +28,9 @@ export function MarketingPageStyles() {
         outline: 2px solid #f97316;
         outline-offset: 2px;
       }
+      .zdb-footer-grid a:hover {
+        color: #fff !important;
+      }
       @media (max-width: 1024px) {
         .zdb-connect-grid { grid-template-columns: 1fr !important; }
         .zdb-feature-grid { grid-template-columns: repeat(2, 1fr) !important; }
@@ -50,8 +53,12 @@ export function MarketingPageStyles() {
         .zdb-resource-grid { grid-template-columns: 1fr 1fr !important; }
         .zdb-hero-btns { flex-direction: column !important; align-items: stretch !important; }
         .zdb-hero-btns a, .zdb-hero-btns button { justify-content: center !important; }
-        .zdb-footer { flex-direction: column !important; gap: 16px !important; align-items: flex-start !important; }
-        .zdb-footer-links { flex-wrap: wrap !important; gap: 16px !important; }
+        .zdb-footer-grid { grid-template-columns: 1fr !important; gap: 32px !important; padding: 40px 20px 32px !important; }
+        .zdb-footer-meta { flex-direction: column !important; padding: 16px 20px 24px !important; }
+        .zdb-footer-meta span { text-align: left !important; }
+      }
+      @media (max-width: 1024px) and (min-width: 769px) {
+        .zdb-footer-grid { grid-template-columns: 1fr 1fr !important; }
       }
     `}</style>
   )

--- a/dashboard/components/marketing/footer-config.ts
+++ b/dashboard/components/marketing/footer-config.ts
@@ -1,0 +1,57 @@
+export type FooterLink = {
+  label: string
+  href: string
+  external?: boolean
+}
+
+export type FooterColumn = {
+  title: string
+  links: FooterLink[]
+}
+
+const GITHUB = 'https://github.com/Zizka-ai/ZizkaDB'
+const WIKI = 'https://github.com/Zizka-ai/ZizkaDB/wiki'
+const ZIZKA_AI = 'https://zizka.ai'
+
+export const ZIZKADB_FOOTER_COLUMNS: FooterColumn[] = [
+  {
+    title: 'Product',
+    links: [
+      { label: 'Docs', href: '/docs' },
+      { label: 'Enterprise', href: '/enterprise' },
+      { label: 'Pricing', href: '/#pricing' },
+      { label: 'Compare', href: '/#compare' },
+      { label: 'Trust & security', href: '/trust' },
+      { label: 'API explorer', href: '/swagger' },
+    ],
+  },
+  {
+    title: 'Resources',
+    links: [
+      { label: 'Self-host (OSS)', href: `${GITHUB}/wiki/Self-Hosting`, external: true },
+      { label: 'GitHub', href: GITHUB, external: true },
+      { label: 'Wiki', href: WIKI, external: true },
+      { label: 'Community', href: '/community' },
+      { label: 'MCP setup', href: `${GITHUB}/wiki/MCP-and-Cursor`, external: true },
+      { label: 'Status', href: 'https://db.zizka.ai/health', external: true },
+    ],
+  },
+  {
+    title: 'Legal',
+    links: [
+      { label: 'Terms', href: `${ZIZKA_AI}/terms`, external: true },
+      { label: 'Privacy', href: `${ZIZKA_AI}/privacy`, external: true },
+      { label: 'Security', href: '/trust#security' },
+      { label: 'Contact', href: '/enterprise#contact' },
+      { label: 'Responsible disclosure', href: 'mailto:founder@zizka.ai?subject=Security%20disclosure', external: true },
+    ],
+  },
+]
+
+export const ZIZKADB_COMPANY = {
+  name: 'ZIZKA AI S.L.',
+  location: 'Málaga, Spain',
+  taxId: 'CIF B26956078',
+  email: 'founder@zizka.ai',
+  zizkaAiUrl: ZIZKA_AI,
+}


### PR DESCRIPTION
## Summary

Replaces the thin single-line footer with a Nodge-style multi-column layout on all marketing pages.

- **Brand column** — tagline + GitHub + zizka.ai links
- **Product** — Docs, Enterprise, Pricing, Compare, Trust, API explorer
- **Resources** — Self-host wiki, GitHub, Community, MCP, Status
- **Legal** — Terms, Privacy, Security, Contact, Responsible disclosure
- **Bottom bar** — © ZIZKA AI S.L. · Málaga · CIF

## Pages

Home, Docs, Trust, Enterprise, Community (via shared `MarketingFooter`)

## Test plan

- [ ] Check footer on `/`, `/docs`, `/trust`, `/enterprise`, `/community`
- [ ] Mobile: columns stack correctly
- [ ] All links resolve (internal + zizka.ai legal)

## Deploy

After merge: `bash infra/deploy-dashboard.sh` on EC2 (PM2 rebuild required — footer is in Next.js bundle)