### PR TITLE
Fix footer Self-host (OSS) link to GitHub repo

### DIFF
--- a/dashboard/components/marketing/footer-config.ts
+++ b/dashboard/components/marketing/footer-config.ts
@@ -28,7 +28,7 @@ export const ZIZKADB_FOOTER_COLUMNS: FooterColumn[] = [
   {
     title: 'Resources',
     links: [
-      { label: 'Self-host (OSS)', href: `${GITHUB}/wiki/Self-Hosting`, external: true },
+      { label: 'Self-host (OSS)', href: GITHUB, external: true },
       { label: 'GitHub', href: GITHUB, external: true },
       { label: 'Wiki', href: WIKI, external: true },
       { label: 'Community', href: '/community' },


### PR DESCRIPTION
## Summary

Footer **Self-host (OSS)** now links to the repository:

https://github.com/Zizka-ai/ZizkaDB

Previously pointed to `wiki/Self-Hosting`, which does not exist for visitors.

## Test plan

- [ ] Footer → Self-host (OSS) opens GitHub repo
- [ ] Deploy: `bash infra/deploy-dashboard.sh`