### PR TITLE
Remove Status link from marketing footer

### DIFF
--- a/dashboard/components/marketing/footer-config.ts
+++ b/dashboard/components/marketing/footer-config.ts
@@ -33,7 +33,6 @@ export const ZIZKADB_FOOTER_COLUMNS: FooterColumn[] = [
       { label: 'Wiki', href: WIKI, external: true },
       { label: 'Community', href: '/community' },
       { label: 'MCP setup', href: '/docs#mcp' },
-      { label: 'Status', href: 'https://db.zizka.ai/health', external: true },
     ],
   },
   {


### PR DESCRIPTION
## Summary

Removes the **Status** link from the marketing footer Resources column.

It pointed at `/health`, which is not a public status page.

## Test plan

- [ ] Footer Resources column no longer shows Status
- [ ] Other footer links unchanged
- [ ] Deploy: `bash infra/deploy-dashboard.sh`