### PR TITLE
fix: critical security — OTP PRNG, auth dep hardening, billing KeyError

### DIFF
--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -125,7 +125,7 @@ async def create_agent(
 @router.delete("/{agent_id}")
 async def delete_agent(
     agent_id: str,
-    tenant: dict = Depends(get_tenant),
+    tenant: dict = Depends(require_dashboard_session),
 ):
     """Delete an agent and all of its events. Cannot be undone."""
     agent_id = _validate_agent_id(agent_id)

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -194,7 +194,7 @@ async def api_keys_usage(session: dict = Depends(require_dashboard_session)):
 @router.delete("/api-keys/{key_id}")
 async def revoke_api_key(
     key_id: str,
-    tenant: dict = Depends(get_tenant),
+    tenant: dict = Depends(require_dashboard_session),
 ):
     """Revoke an API key. The key stops working immediately."""
     pool = get_pool()
@@ -258,7 +258,7 @@ async def test_event(tenant: dict = Depends(get_tenant)):
 
 
 @router.get("/api-keys")
-async def list_api_keys(tenant: dict = Depends(get_tenant)):
+async def list_api_keys(tenant: dict = Depends(require_dashboard_session)):
     pool = get_pool()
     rows = await pool.fetch(
         """

--- a/core/api/billing_checkout.py
+++ b/core/api/billing_checkout.py
@@ -7,7 +7,7 @@ import logging
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, field_validator
 
-from api.deps import get_tenant
+from api.deps import require_dashboard_session
 from services.billing import (
     VALID_PLANS,
     billing_status_payload,
@@ -32,13 +32,13 @@ class SelectPlanBody(BaseModel):
 
 
 @router.get("/status")
-async def billing_status(tenant: dict = Depends(get_tenant)):
+async def billing_status(tenant: dict = Depends(require_dashboard_session)):
     row = await fetch_user_billing(user_id=tenant["user_id"])
     return billing_status_payload(row)
 
 
 @router.post("/select-plan")
-async def choose_plan(body: SelectPlanBody, tenant: dict = Depends(get_tenant)):
+async def choose_plan(body: SelectPlanBody, tenant: dict = Depends(require_dashboard_session)):
     try:
         row = await select_plan(user_id=tenant["user_id"], plan=body.plan)
         return billing_status_payload(row)

--- a/core/services/auth.py
+++ b/core/services/auth.py
@@ -5,7 +5,6 @@ import os
 import logging
 import jwt
 import bcrypt
-import random
 import smtplib
 from typing import Literal
 from email.mime.text import MIMEText
@@ -103,7 +102,7 @@ async def email_exists(email: str) -> bool:
 
 async def request_otp(email: str) -> None:
     email = email.lower().strip()
-    otp = str(random.randint(100000, 999999))
+    otp = str(secrets.randbelow(900_000) + 100_000)
     otp_hash = bcrypt.hashpw(otp.encode(), bcrypt.gensalt()).decode()
     expires_at = datetime.now(timezone.utc) + timedelta(minutes=15)
 


### PR DESCRIPTION
## Summary

This PR fixes **5 critical/high severity security bugs** identified during a full codebase audit. All changes are Python-only and isolated to 4 files.

### Changes

| File | Line | Bug | Fix |
|---|---|---|---|
| `core/services/auth.py` | 106 | OTP uses `random.randint` (Mersenne Twister — predictable) | `secrets.randbelow(900_000) + 100_000` |
| `core/api/auth.py` | 194 | `DELETE /api-keys/{key_id}` accepted raw API keys — any key could revoke other keys | `require_dashboard_session` |
| `core/api/auth.py` | 260 | `GET /api-keys` accepted raw API keys — key could enumerate all tenant keys | `require_dashboard_session` |
| `core/api/agents.py` | 128 | `DELETE /{agent_id}` accepted raw API keys — agent key could delete itself or other agents | `require_dashboard_session` |
| `core/api/billing_checkout.py` | 35, 41 | `GET /billing/status` and `POST /billing/select-plan` crashed with `KeyError: 'user_id'` on API-key callers (HTTP 500) | `require_dashboard_session` |

### Why safe

- **OTP change:** Drop-in swap. Same 6-digit string format. `secrets` was already imported on line 3. No callers change.
- **Auth dep changes:** `require_dashboard_session` is already imported and used by `create_api_key`, `create_agent`, and other management routes in the same files. This makes deletion/listing consistent with creation — both require a dashboard JWT. No SDK workflow calls these routes.
- **Billing fix:** Billing is user-specific. API keys carry no `user_id`. Fixing the dep also fixes the 500.

### Testing

**Automated:** `ruff check` passes clean on all changed files. Python syntax verified.

**Manual checklist (run against a local or staging stack):**

- [ ] `POST /v1/auth/request-otp` → OTP arrives (6 digits, no change in format)
- [ ] Login via OTP → dashboard opens normally
- [ ] With a raw API key: `DELETE /v1/auth/api-keys/{key_id}` → **403** (was 200)
- [ ] With a raw API key: `GET /v1/auth/api-keys` → **403** (was 200)
- [ ] With a raw API key: `DELETE /v1/agents/{agent_id}` → **403** (was 200)
- [ ] With a raw API key: `GET /v1/billing/status` → **403** (was 500 KeyError)
- [ ] With a raw API key: `POST /v1/billing/select-plan` → **403** (was 500 KeyError)
- [ ] Dashboard JWT: all of the above still return **200/correct data**

🤖 Generated with [Claude Code](https://claude.com/claude-code)