### PR TITLE
fix: scope enforcement, delete_agent transaction, dashboard UI bugs

### DIFF
--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from api.deps import get_tenant, require_dashboard_session
+from api.deps import assert_agent_allowed, get_tenant, require_dashboard_session
 from db.connection import get_pool
 from services.api_keys import (
     assert_and_reserve_api_key_slot,
@@ -139,18 +139,20 @@ async def delete_agent(
     if not row:
         raise HTTPException(status_code=404, detail="Agent not found")
 
-    await pool.execute(
-        "UPDATE events SET parent_event_id = NULL WHERE tenant_id = $1 AND agent_id = $2",
-        tenant_id, agent_id,
-    )
-    await pool.execute(
-        "DELETE FROM events WHERE tenant_id = $1 AND agent_id = $2",
-        tenant_id, agent_id,
-    )
-    await pool.execute(
-        "DELETE FROM agents WHERE tenant_id = $1 AND agent_id = $2",
-        tenant_id, agent_id,
-    )
+    async with pool.acquire() as conn:
+        async with conn.transaction():
+            await conn.execute(
+                "UPDATE events SET parent_event_id = NULL WHERE tenant_id = $1 AND agent_id = $2",
+                tenant_id, agent_id,
+            )
+            await conn.execute(
+                "DELETE FROM events WHERE tenant_id = $1 AND agent_id = $2",
+                tenant_id, agent_id,
+            )
+            await conn.execute(
+                "DELETE FROM agents WHERE tenant_id = $1 AND agent_id = $2",
+                tenant_id, agent_id,
+            )
     return {
         "deleted": True,
         "agent": agent_id,
@@ -253,6 +255,7 @@ async def revoke_agent_api_key(
 
 @router.get("/{agent_id}/stats")
 async def agent_stats(agent_id: str, tenant: dict = Depends(get_tenant)):
+    assert_agent_allowed(tenant, agent_id)
     pool = get_pool()
 
     stats = await pool.fetchrow(
@@ -298,6 +301,7 @@ async def list_sessions(
     limit: int = Query(default=50, le=500),
     tenant: dict = Depends(get_tenant),
 ):
+    assert_agent_allowed(tenant, agent_id)
     pool = get_pool()
     rows = await pool.fetch(
         """
@@ -479,6 +483,7 @@ async def agent_baseline(
     `recent` = sessions ending inside that window, `baseline` = everything before.
     Otherwise falls back to the most recent N sessions vs everything prior.
     """
+    assert_agent_allowed(tenant, agent_id)
     pool = get_pool()
 
     sessions = await pool.fetch(
@@ -672,6 +677,7 @@ async def agent_behavior_change(
     Requires >= 50 events before the window to establish a meaningful baseline.
     """
     agent_id  = _validate_agent_id(agent_id)
+    assert_agent_allowed(tenant, agent_id)
     pool      = get_pool()
     tenant_id = tenant["tenant_id"]
 

--- a/core/api/events.py
+++ b/core/api/events.py
@@ -181,6 +181,7 @@ async def time_travel(
     timestamp: datetime,
     tenant: dict = Depends(get_tenant),
 ):
+    assert_agent_allowed(tenant, agent)
     pool = get_pool()
     tenant_id = tenant["tenant_id"]
 

--- a/dashboard/app/dashboard/agents/[id]/page.tsx
+++ b/dashboard/app/dashboard/agents/[id]/page.tsx
@@ -369,7 +369,6 @@ export default function AgentPage() {
 
   // ── sessions tab ──────────────────────────────────────────────────────────
   const loadSessions = async () => {
-    if (sessions.length > 0) return;
     setSessLoading(true);
     let token: string;
     try {

--- a/dashboard/app/dashboard/search/page.tsx
+++ b/dashboard/app/dashboard/search/page.tsx
@@ -29,7 +29,7 @@ export default function SearchPage() {
     try {
       const token = requireAuth();
       const res = await searchEvents(token, query);
-      setResults(res.results);
+      setResults(Array.isArray(res) ? res : (res?.results ?? []));
     } catch {
       setResults([]);
     } finally {

--- a/dashboard/app/dashboard/settings/page.tsx
+++ b/dashboard/app/dashboard/settings/page.tsx
@@ -60,6 +60,8 @@ export default function SettingsPage() {
     try {
       token = requireAuth();
     } catch {
+      setLoading(false);
+      setEmbLoading(false);
       return;
     }
     getApiKeys(token)

--- a/dashboard/hooks/useCopyToClipboard.ts
+++ b/dashboard/hooks/useCopyToClipboard.ts
@@ -15,11 +15,15 @@ export function useCopyToClipboard(resetMs = DEFAULT_RESET_MS) {
   }, []);
 
   const copy = useCallback(
-    (text: string) => {
-      navigator.clipboard.writeText(text);
-      setCopied(true);
-      if (timer.current) clearTimeout(timer.current);
-      timer.current = setTimeout(() => setCopied(false), resetMs);
+    async (text: string) => {
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        if (timer.current) clearTimeout(timer.current);
+        timer.current = setTimeout(() => setCopied(false), resetMs);
+      } catch {
+        // clipboard write failed (no focus, HTTP, permission denied) — do not show "Copied"
+      }
     },
     [resetMs],
   );


### PR DESCRIPTION
## Summary

Fixes **7 correctness bugs** identified in the codebase audit. See issue #49 for full root cause analysis.

### Changes

| File | Line | Bug | Fix |
|---|---|---|---|
| `core/api/agents.py` | 258 | `agent_stats` missing `assert_agent_allowed` | Added scope check |
| `core/api/agents.py` | 304 | `list_sessions` missing `assert_agent_allowed` | Added scope check |
| `core/api/agents.py` | 486 | `agent_baseline` missing `assert_agent_allowed` | Added scope check |
| `core/api/agents.py` | 680 | `agent_behavior_change` missing `assert_agent_allowed` | Added scope check |
| `core/api/events.py` | 184 | `time_travel` missing `assert_agent_allowed` | Added scope check |
| `core/api/agents.py` | 142–153 | `delete_agent` — 3 un-transacted SQL statements | Wrapped in `conn.transaction()` |
| `dashboard/agents/[id]/page.tsx` | 372 | Sessions tab never refreshes | Removed stale-cache guard |
| `dashboard/settings/page.tsx` | 62 | Permanent spinner on auth failure | `setLoading/setEmbLoading(false)` in catch |
| `dashboard/search/page.tsx` | 32 | Crash when backend returns bare array | Normalised with `Array.isArray` check |
| `dashboard/hooks/useCopyToClipboard.ts` | 19 | "Copied" shown on clipboard failure | `await` write, only set on success |

### Why safe

- **Scope checks:** `assert_agent_allowed` is a one-line guard already used by all sibling routes. NULL-scoped (tenant-wide) keys pass through unchanged — `scoped = tenant.get("agent_id")` returns `None`, and the guard does nothing.
- **Transaction:** Atomicity-only change. Success path is identical; failure path no longer leaves partial state.
- **Dashboard fixes:** Pure UI — no API contract changes.

### CI gates

- `ruff check` ✅
- `py_compile` syntax check ✅
- `npx tsc --noEmit` ✅

### Manual test checklist

- [ ] Scoped API key on `GET /agents/{other}/stats` → 403
- [ ] Tenant-wide key on same → 200
- [ ] Delete agent → DB is clean (no orphan rows)
- [ ] Sessions tab: switch away and back → data refreshes
- [ ] Settings page unauthenticated → no spinner
- [ ] Search → results render without crash
- [ ] Copy key → "Copied" only when clipboard succeeds

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)