### PR TITLE
fix: remove --reload and dev volume mount from production compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ DEV_API_KEY=zizkadb_dev_local
 # the users.plan column. Managed cloud must leave this unset (defaults to
 # "managed").
 DEPLOYMENT_MODE=self_hosted
-API_KEY_LIMITS_ENFORCED=true/false
+# API_KEY_LIMITS_ENFORCED=false   # set to true to enforce per-plan key caps (Pro: 3, Team: 10, Enterprise: 50)
 
 # Email — optional; enables OTP login on self-hosted dashboard (same as managed cloud)
 # Gmail: Settings → Security → App Passwords → generate one

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -1,0 +1,18 @@
+# Local development override — DO NOT use in production.
+#
+# Mounts the host core/ directory into the container (so edits take effect
+# without a rebuild) and enables uvicorn --reload so the server restarts on
+# file changes.
+#
+# Usage:
+#   docker compose -f infra/docker-compose.yml -f infra/docker-compose.dev.yml up -d
+#
+# The quickstart scripts (scripts/quickstart.sh, scripts/setup-local.sh) already
+# include this override automatically. Use the base compose alone for production.
+
+services:
+  api:
+    volumes:
+      - ../core:/app
+      - community_uploads:/data/community_uploads
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -86,9 +86,8 @@ services:
       redis:
         condition: service_healthy
     volumes:
-      - ../core:/app
       - community_uploads:/data/community_uploads
-    command: uvicorn main:app --host 0.0.0.0 --port 8000 --reload
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4
 
 volumes:
   postgres_data:

--- a/scripts/setup-local.sh
+++ b/scripts/setup-local.sh
@@ -74,6 +74,10 @@ else
 fi
 
 if [ ${#BUILD_FLAG[@]} -gt 0 ]; then
+  # Dev overlay: mounts host core/ into the container and enables --reload so
+  # local edits are reflected without a rebuild. Only used when building from
+  # source; pre-built OSS images are immutable and don't need the mount.
+  COMPOSE+=( -f infra/docker-compose.dev.yml )
   # Registry metadata checks during `compose build` occasionally hang/timeout
   # (DeadlineExceeded) even when the base image is already cached locally.
   # Pre-pulling once avoids that flake and speeds up every subsequent build.


### PR DESCRIPTION
## Summary

Fixes **3 infrastructure/config bugs** that affect the production deployment path. See issue #51 for full root cause analysis.

### Changes

| File | Change |
|---|---|
| `infra/docker-compose.yml` | Remove `../core:/app` volume mount; change `--reload` → `--workers 4` |
| `infra/docker-compose.dev.yml` | **New file** — local dev override (volume mount + reload) |
| `scripts/setup-local.sh` | Include dev overlay when building from source |
| `.env.example` | Fix `API_KEY_LIMITS_ENFORCED=true/false` → commented default |

### Why safe

- **`--reload` removal:** Restores normal multi-worker operation on the production host. The Dockerfile already installs all dependencies; removing the filesystem watcher is strictly safer.
- **Volume mount removal:** Production images bake source via `COPY` at build time. Removing the live mount ensures the tested artifact is what runs.
- **Dev overlay:** Local dev behavior is fully preserved via `docker-compose.dev.yml`. `setup-local.sh` includes it automatically for source builds.
- **`.env.example` fix:** Documentation-only for the repo; no running code reads this file directly.

### Impact on CI

`docker-compose.yml` is not used in `.github/workflows/ci.yml` or `publish-images.yml` — no CI impact.

### Manual test checklist

- [ ] `docker compose -f infra/docker-compose.yml up -d` → API healthy, no reload flag in logs
- [ ] `docker compose -f infra/docker-compose.yml -f infra/docker-compose.dev.yml up -d` → hot-reload works for local dev
- [ ] `bash scripts/setup-local.sh` → dev overlay included, edits to `core/` files reflected without rebuild

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)