### PR TITLE
refactor: extract shared utils, fix type annotation, DRY cleanups

### DIFF
--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -194,7 +194,7 @@ async def api_keys_usage(session: dict = Depends(require_dashboard_session)):
 @router.delete("/api-keys/{key_id}")
 async def revoke_api_key(
     key_id: str,
-    tenant: dict = Depends(get_tenant),
+    tenant: dict = Depends(require_dashboard_session),
 ):
     """Revoke an API key. The key stops working immediately."""
     pool = get_pool()
@@ -258,7 +258,7 @@ async def test_event(tenant: dict = Depends(get_tenant)):
 
 
 @router.get("/api-keys")
-async def list_api_keys(tenant: dict = Depends(get_tenant)):
+async def list_api_keys(tenant: dict = Depends(require_dashboard_session)):
     pool = get_pool()
     rows = await pool.fetch(
         """

--- a/core/api/community.py
+++ b/core/api/community.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, Field
 
+from api.utils import check_rate, client_ip
 from db.connection import get_pool
 
 router = APIRouter()
@@ -49,21 +50,6 @@ class CreateReplyBody(BaseModel):
     website: str | None = None
 
 
-def _client_ip(request: Request) -> str:
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
-
-
-def _check_rate(ip: str) -> None:
-    import time
-    now = time.time()
-    hits = [t for t in _rate.get(ip, []) if now - t < RATE_WINDOW_SEC]
-    if len(hits) >= RATE_MAX_POSTS:
-        raise HTTPException(status_code=429, detail="Too many posts. Try again later.")
-    hits.append(now)
-    _rate[ip] = hits
 
 
 def _public_base_url(request: Request) -> str:
@@ -173,7 +159,7 @@ async def create_post(body: CreatePostBody, request: Request):
     if body.category not in CATEGORIES:
         raise HTTPException(status_code=400, detail="Invalid category")
 
-    _check_rate(_client_ip(request))
+    check_rate(_rate, client_ip(request), RATE_WINDOW_SEC, RATE_MAX_POSTS, "Too many posts. Try again later.")
     pool = get_pool()
     urls = [u for u in body.image_urls if isinstance(u, str) and u.startswith("/v1/community/media/")][:6]
 
@@ -200,7 +186,7 @@ async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
     if body.website:
         raise HTTPException(status_code=400, detail="Invalid submission")
 
-    _check_rate(_client_ip(request))
+    check_rate(_rate, client_ip(request), RATE_WINDOW_SEC, RATE_MAX_POSTS, "Too many posts. Try again later.")
     pool = get_pool()
     try:
         pid = uuid.UUID(post_id)
@@ -237,7 +223,7 @@ async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
 
 @router.post("/upload")
 async def upload_image(request: Request, file: UploadFile = File(...)):
-    _check_rate(_client_ip(request) + ":upload")
+    check_rate(_rate, client_ip(request) + ":upload", RATE_WINDOW_SEC, RATE_MAX_POSTS, "Too many uploads. Try again later.")
 
     if not file.filename:
         raise HTTPException(status_code=400, detail="No file")

--- a/core/api/demo_requests.py
+++ b/core/api/demo_requests.py
@@ -5,11 +5,11 @@ Public demo request form — landing page "Book demo" submissions.
 from __future__ import annotations
 
 import logging
-import time
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 
+from api.utils import check_rate, client_ip
 from db.connection import get_pool
 
 router = APIRouter()
@@ -32,20 +32,6 @@ class CreateDemoRequestBody(BaseModel):
     botcheck: str | None = None  # honeypot — must be empty
 
 
-def _client_ip(request: Request) -> str:
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
-
-
-def _check_rate(ip: str) -> None:
-    now = time.time()
-    hits = [t for t in _rate.get(ip, []) if now - t < RATE_WINDOW_SEC]
-    if len(hits) >= RATE_MAX:
-        raise HTTPException(status_code=429, detail="Too many requests. Try again later.")
-    hits.append(now)
-    _rate[ip] = hits
 
 
 @router.post("", status_code=201)
@@ -53,8 +39,8 @@ async def create_demo_request(body: CreateDemoRequestBody, request: Request):
     if body.botcheck:
         raise HTTPException(status_code=400, detail="Invalid submission")
 
-    ip = _client_ip(request)
-    _check_rate(ip)
+    ip = client_ip(request)
+    check_rate(_rate, ip, RATE_WINDOW_SEC, RATE_MAX)
 
     source = (body.source.strip() or None) if body.source else None
     if source and source not in VALID_SOURCES:

--- a/core/api/marketing_subscriptions.py
+++ b/core/api/marketing_subscriptions.py
@@ -8,11 +8,11 @@ Public marketing subscription endpoint (popup lead capture).
 from __future__ import annotations
 
 import logging
-import time
 
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 
+from api.utils import check_rate, client_ip
 from db.connection import get_pool
 
 router = APIRouter()
@@ -29,20 +29,6 @@ class SubscribeBody(BaseModel):
     botcheck: str | None = None  # honeypot
 
 
-def _client_ip(request: Request) -> str:
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
-
-
-def _check_rate(ip: str) -> None:
-    now = time.time()
-    hits = [t for t in _rate.get(ip, []) if now - t < RATE_WINDOW_SEC]
-    if len(hits) >= RATE_MAX:
-        raise HTTPException(status_code=429, detail="Too many requests. Try again later.")
-    hits.append(now)
-    _rate[ip] = hits
 
 
 @router.post("", status_code=201)
@@ -50,8 +36,8 @@ async def subscribe(body: SubscribeBody, request: Request):
     if body.botcheck:
         raise HTTPException(status_code=400, detail="Invalid submission")
 
-    ip = _client_ip(request)
-    _check_rate(ip)
+    ip = client_ip(request)
+    check_rate(_rate, ip, RATE_WINDOW_SEC, RATE_MAX)
 
     pool = get_pool()
     email = str(body.email).strip().lower()

--- a/core/api/search.py
+++ b/core/api/search.py
@@ -1,5 +1,4 @@
 import json
-from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel

--- a/core/api/search.py
+++ b/core/api/search.py
@@ -1,8 +1,11 @@
-from fastapi import APIRouter, Depends, HTTPException
-from pydantic import BaseModel
+import json
 from typing import Any
 
-from api.deps import get_tenant, assert_agent_allowed
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from qdrant_client.models import FieldCondition, Filter, MatchValue
+
+from api.deps import assert_agent_allowed, get_tenant
 from db.connection import get_pool, get_qdrant
 from services.embeddings import generate_embedding
 
@@ -37,9 +40,7 @@ async def semantic_search(
 
     qdrant = get_qdrant()
 
-    query_filter = None
     if agent:
-        from qdrant_client.models import Filter, FieldCondition, MatchValue
         query_filter = Filter(
             must=[
                 FieldCondition(key="tenant_id", match=MatchValue(value=tenant_id)),
@@ -47,7 +48,6 @@ async def semantic_search(
             ]
         )
     else:
-        from qdrant_client.models import Filter, FieldCondition, MatchValue
         query_filter = Filter(
             must=[FieldCondition(key="tenant_id", match=MatchValue(value=tenant_id))]
         )
@@ -60,10 +60,7 @@ async def semantic_search(
         with_payload=True,
     )
 
-    # Fetch full events from Postgres
     pool = get_pool()
-    import json
-
     event_ids = [r.id for r in results]
     if not event_ids:
         return {"results": []}

--- a/core/api/utils.py
+++ b/core/api/utils.py
@@ -1,0 +1,29 @@
+"""Shared helpers reused across public API endpoints."""
+
+from __future__ import annotations
+
+import time
+
+from fastapi import HTTPException, Request
+
+
+def client_ip(request: Request) -> str:
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def check_rate(
+    store: dict[str, list[float]],
+    ip: str,
+    window_sec: int,
+    max_hits: int,
+    detail: str = "Too many requests. Try again later.",
+) -> None:
+    now = time.time()
+    hits = [t for t in store.get(ip, []) if now - t < window_sec]
+    if len(hits) >= max_hits:
+        raise HTTPException(status_code=429, detail=detail)
+    hits.append(now)
+    store[ip] = hits

--- a/core/requirements-dev.txt
+++ b/core/requirements-dev.txt
@@ -1,16 +1,5 @@
+-r requirements.txt
 pytest>=8.2.0
 pytest-asyncio>=0.23.0
 httpx>=0.27.0
 ruff>=0.8.0
-fastapi>=0.111.0
-python-multipart>=0.0.9
-uvicorn[standard]>=0.29.0
-asyncpg>=0.29.0
-pydantic[email]>=2.7.0
-redis>=5.0.4
-qdrant-client>=1.13.0,<1.14.0
-PyJWT>=2.8.0
-bcrypt>=4.1.3
-python-dotenv>=1.0.1
-cryptography>=42.0.0
-

--- a/core/services/auth.py
+++ b/core/services/auth.py
@@ -5,7 +5,6 @@ import os
 import logging
 import jwt
 import bcrypt
-import random
 import smtplib
 from typing import Literal
 from email.mime.text import MIMEText
@@ -48,7 +47,7 @@ REFRESH_TOKEN_EXPIRE_DAYS = 30
 # API KEY AUTH
 # ─────────────────────────────────────────
 
-def generate_api_key() -> tuple[str, str]:
+def generate_api_key() -> tuple[str, str, str]:
     """Returns (raw_key, key_hash, prefix). Store hash, show raw once."""
     raw = f"zizkadb_live_{secrets.token_urlsafe(32)}"
     key_hash = hashlib.sha256(raw.encode()).hexdigest()
@@ -103,7 +102,7 @@ async def email_exists(email: str) -> bool:
 
 async def request_otp(email: str) -> None:
     email = email.lower().strip()
-    otp = str(random.randint(100000, 999999))
+    otp = str(secrets.randbelow(900_000) + 100_000)
     otp_hash = bcrypt.hashpw(otp.encode(), bcrypt.gensalt()).decode()
     expires_at = datetime.now(timezone.utc) + timedelta(minutes=15)
 
@@ -359,10 +358,7 @@ def _send_otp_email_sync(email: str, otp: str) -> None:
     password = os.getenv("EMAIL_PASS")
 
     if not host or not user or not password:
-        print(f"\n{'='*50}")
-        print(f"OTP FOR {email}: {otp}")
-        print(f"(Set EMAIL_HOST / EMAIL_USER / EMAIL_PASS to send real emails)")
-        print(f"{'='*50}\n", flush=True)
+        log.warning("DEV OTP for %s: %s (set EMAIL_HOST / EMAIL_USER / EMAIL_PASS to send real emails)", email, otp)
         return
 
     port = int(os.getenv("EMAIL_PORT", 587))

--- a/dashboard/lib/community.ts
+++ b/dashboard/lib/community.ts
@@ -1,4 +1,4 @@
-const API = process.env.NEXT_PUBLIC_API_URL ?? ''
+import { API } from './api'
 
 export type CommunityCategory = 'question' | 'experience' | 'showcase'
 

--- a/dashboard/lib/demo.ts
+++ b/dashboard/lib/demo.ts
@@ -1,4 +1,4 @@
-const API = process.env.NEXT_PUBLIC_API_URL ?? ''
+import { API } from './api'
 
 export interface DemoRequestPayload {
   first_name: string

--- a/dashboard/lib/marketing.ts
+++ b/dashboard/lib/marketing.ts
@@ -1,4 +1,4 @@
-const API = process.env.NEXT_PUBLIC_API_URL ?? ''
+import { API } from './api'
 
 export interface MarketingSubscriptionPayload {
   email: string


### PR DESCRIPTION
## Summary

DRY refactor extracting shared rate-limiting utilities, fixing type annotations, and cleaning up the Python dependency file. Also back-ports two Tier 1 security fixes to this branch (which was cut from main before Tier 1 merged).

### Changes

**Shared rate-limit utilities (`core/api/utils.py` — new file)**
- Extracted `client_ip(request)` and `check_rate(store, ip, window_sec, max_hits)` from three separate files
- `client_ip` handles `request.client` being `None` (returns `"unknown"`)
- `check_rate` mutates the in-memory dict correctly by reference

**Updated callers**
- `core/api/community.py` — imports `check_rate`, `client_ip` from `api.utils`; deferred `import time` moved to module top
- `core/api/demo_requests.py` — same pattern
- `core/api/marketing_subscriptions.py` — same pattern

**`core/api/search.py`**
- Hoisted `qdrant_client.models` imports to module top (removed inline copies inside function body)
- Removed `from typing import Any` — unused after hoisting (was causing ruff F401 CI failure)

**`core/services/auth.py`**
- `generate_api_key()` return type corrected: `tuple[str, str]` → `tuple[str, str, str]`
- Dev OTP `print()` block replaced with `log.warning()` (structured logging)
- Re-applies Tier 1 OTP fix: `import random` removed, OTP uses `secrets.randbelow(900_000) + 100_000`

**`core/requirements-dev.txt`**
- Was duplicating all 12 production packages verbatim, causing inevitable version drift
- Now: `-r requirements.txt` as line 1, plus `pytest`, `pytest-asyncio`, `httpx`, `ruff`

**Dashboard lib unification**
- `dashboard/lib/community.ts`, `dashboard/lib/marketing.ts`, `dashboard/lib/demo.ts` — removed local `const API = process.env.NEXT_PUBLIC_API_URL ?? ''` copies; import `{ API }` from `./api`

**Back-ported Tier 1 security fix (auth dep hardening)**
- `core/api/auth.py` — `DELETE /api-keys/{key_id}` and `GET /api-keys` now use `require_dashboard_session` instead of `get_tenant`; without this, any valid API key could enumerate or revoke all tenant API keys

## Merge blockers resolved (commit 45019ca)

- ✅ `from typing import Any` removed from `core/api/search.py` — was ruff F401, would have broken CI
- ✅ `revoke_api_key` and `list_api_keys` in `auth.py` now use `require_dashboard_session`

## Test plan

- [ ] `ruff check core/` — must pass (no F401 or other issues)
- [ ] `pytest core/tests/ -m "not integration" -v` — must pass
- [ ] `pip install -r core/requirements.txt -r core/requirements-dev.txt` — no version conflicts
- [ ] Confirm rate limiting still works: 11th POST to `/v1/community/posts` from same IP within window returns `429`
- [ ] Confirm `GET /v1/auth/api-keys` with an API key returns `403` (not `200`)

## Related

Closes #55
Part of the 6-tier audit — merge after PRs #47, #50, #52, #54 in that order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)