### PR TITLE
docs: fix example imports, add MCP tests to CI, externalize Calendly URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,6 @@ TRIAL_DAYS=30
 
 # Set on managed cloud EC2:
 # ENV=production
+
+# Optional: override the Calendly booking URL shown on the landing page
+# NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/your-team/meeting

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Python SDK tests
         run: pytest sdk/python/tests/ -v
 
+      - name: MCP tests
+        run: pytest mcp/tests/ -v
+
   typescript-sdk:
     name: typescript-sdk
     runs-on: ubuntu-latest

--- a/dashboard/components/marketing/CalendlyBookModal.tsx
+++ b/dashboard/components/marketing/CalendlyBookModal.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react'
 import { M, violetBtn } from './marketing-theme'
 
-const CALENDLY_URL = 'https://calendly.com/founder-zizka/15-minutes'
+const CALENDLY_URL = process.env.NEXT_PUBLIC_CALENDLY_URL ?? 'https://calendly.com/founder-zizka/15-minutes'
 
 type Props = {
   open: boolean

--- a/examples/crewai-agent/agent.py
+++ b/examples/crewai-agent/agent.py
@@ -7,7 +7,7 @@ from crewai import Agent, Crew, Task
 from langchain_openai import ChatOpenAI
 
 from zizkadb import ZizkaDB
-from zizkadb.integrations.crewai import ZizkaDBCrewLogger
+from zizkadb_crewai import ZizkaDBCrewLogger
 
 AGENT = os.getenv("ZIZKADB_AGENT", "crewai-researcher")
 API_KEY = os.getenv("ZIZKADB_API_KEY")

--- a/examples/langchain-agent/agent.py
+++ b/examples/langchain-agent/agent.py
@@ -7,7 +7,7 @@ from langchain_core.messages import HumanMessage
 from langchain_openai import ChatOpenAI
 
 from zizkadb import ZizkaDB
-from zizkadb.integrations.langchain import ZizkaDBCallbackHandler
+from zizkadb_langchain import ZizkaDBCallbackHandler
 
 AGENT = os.getenv("ZIZKADB_AGENT", "langchain-agent")
 API_KEY = os.getenv("ZIZKADB_API_KEY")


### PR DESCRIPTION
## Summary

Three documentation and CI gaps fixed. No runtime behavior changes in production.

## Changes

### 6a — Fix example import paths
- \`examples/langchain-agent/agent.py\`: \`from zizkadb.integrations.langchain import ZizkaDBCallbackHandler\` → \`from zizkadb_langchain import ZizkaDBCallbackHandler\`
- \`examples/crewai-agent/agent.py\`: \`from zizkadb.integrations.crewai import ZizkaDBCrewLogger\` → \`from zizkadb_crewai import ZizkaDBCrewLogger\`
- Each example installs the standalone package in its \`requirements.txt\`; the examples now import from that package's public interface rather than the internal SDK path

### 6c — Add MCP tests to CI
- \`.github/workflows/ci.yml\`: added \`pytest mcp/tests/ -v\` step after the Python SDK tests
- The \`mcp\` package is already installed via \`pip install -e mcp\` in the same job — no new setup needed

### 6e — Externalize Calendly URL
- \`CalendlyBookModal.tsx\`: \`const CALENDLY_URL = 'https://...']\` → \`process.env.NEXT_PUBLIC_CALENDLY_URL ?? 'https://...'\`
- \`.env.example\`: documented \`NEXT_PUBLIC_CALENDLY_URL\` (commented out by default so production is unchanged)

## Test Plan

- [x] \`ruff check\` on example agent files — all checks passed
- [x] \`npx tsc --noEmit\` inside \`dashboard/\` — no TypeScript errors
- [x] CI change is additive — no existing steps removed or reordered

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)