### PR TITLE
docs: fix documentation inaccuracies and missing env var documentation (codebase audit phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ OPENAI_API_KEY=sk-...
 # EMBEDDING_ENCRYPTION_KEY=
 
 # Auth
+# WARNING: Change BOTH secrets before any production or internet-facing deployment.
+# Anyone with these values can forge valid JWTs and log in as any user.
+# Generate with: python -c "import secrets; print(secrets.token_hex(32))"
 JWT_SECRET=change-this-to-a-random-32-char-string
 JWT_REFRESH_SECRET=change-this-to-another-random-32-char-string
 
@@ -43,7 +46,10 @@ EMAIL_FROM='ZizkaDB <founder@zizka.ai>'
 
 # App
 ENV=development
-API_URL=http://localhost:8000
+# PUBLIC_API_URL is read by the API server (core/api/community.py) to build
+# absolute image URLs for community post media. Must be the externally
+# reachable base URL of the API (no trailing slash).
+PUBLIC_API_URL=http://localhost:8000
 DASHBOARD_URL=http://localhost:3001
 
 # Dashboard (when running npm run dev)
@@ -58,3 +64,33 @@ TRIAL_DAYS=30
 
 # Optional: override the Calendly booking URL shown on the landing page
 # NEXT_PUBLIC_CALENDLY_URL=https://calendly.com/your-team/meeting
+
+# ── Admin panel ────────────────────────────────────────────────────────────────
+# Email address that is allowed to access the operator admin panel at /v1/admin/*.
+# Non-matching emails receive a 404 (not 403) so the panel's existence is not
+# advertised. Change this before deploying if you are not the Zizka founder.
+# ADMIN_EMAIL=founder@zizka.ai
+
+# ── Community uploads ──────────────────────────────────────────────────────────
+# Directory where community post images are stored on the API host.
+# When using Docker Compose this is mapped to the community_uploads named volume.
+# For native installs create this directory and ensure the API process can write to it.
+# COMMUNITY_UPLOAD_DIR=/data/community_uploads
+
+# ── API key plan overrides ─────────────────────────────────────────────────────
+# Override the default per-plan API key caps at runtime (requires API_KEY_LIMITS_ENFORCED=true).
+# API_KEY_LIMIT_PRO=3
+# API_KEY_LIMIT_TEAM=10
+# API_KEY_LIMIT_ENTERPRISE=50
+
+# ── Managed cloud only ─────────────────────────────────────────────────────────
+# Number of days added to a user's trial on retention offer (default: 30).
+# RETENTION_TRIAL_DAYS=30
+
+# ── Email tuning ───────────────────────────────────────────────────────────────
+# SMTP connection timeout in seconds (default: 15). Increase on slow mail servers.
+# EMAIL_SMTP_TIMEOUT=15
+
+# ── Dashboard standalone (npm run dev outside Docker) ─────────────────────────
+# URL the Next.js dev server proxies /v1/* requests to. Default: http://127.0.0.1:8000
+# API_REWRITE_TARGET=http://127.0.0.1:8000

--- a/CONNECT.md
+++ b/CONNECT.md
@@ -93,15 +93,18 @@ pip install zizkadb-sdk zizkadb-langchain
 ```
 
 ```python
+import asyncio
 from langchain_openai import ChatOpenAI
 from zizkadb import ZizkaDB
 from zizkadb_langchain import ZizkaDBCallbackHandler
 
-db = ZizkaDB(host="http://localhost:8000")
-handler = ZizkaDBCallbackHandler(db, agent="my-bot")
+async def main():
+    async with ZizkaDB(host="http://localhost:8000") as db:
+        handler = ZizkaDBCallbackHandler(db=db, agent="my-bot")
+        llm = ChatOpenAI(model="gpt-4o-mini")
+        await llm.ainvoke("Hello", config={"callbacks": [handler]})
 
-llm = ChatOpenAI(model="gpt-4o-mini", callbacks=[handler])
-llm.invoke("Hello")
+asyncio.run(main())
 ```
 
 Or scaffold: `zizkadb init my-agent --template langchain`

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ bash scripts/quickstart.sh
 |---|---|
 | **Python** | `pip install zizkadb-sdk` |
 | **TypeScript / JavaScript** | `npm install zizkadb-sdk` |
-| **LangChain** | `pip install zizkadb-sdk zizkadb-langchain` |
-| **CrewAI** | `pip install zizkadb-sdk zizkadb-crewai` |
+| **LangChain** | `pip install zizkadb-sdk "zizkadb-langchain @ git+https://github.com/Zizka-ai/ZizkaDB.git@main#subdirectory=integrations/langchain"` |
+| **CrewAI** | `pip install zizkadb-sdk "zizkadb-crewai @ git+https://github.com/Zizka-ai/ZizkaDB.git@main#subdirectory=integrations/crewai"` |
 | **AI Editor (Cursor, Claude)** | `uvx zizkadb-mcp` |
 | **REST (any language)** | No install needed — use any HTTP client |
 

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -38,7 +38,7 @@
 
 ## 1. Dashboard Architecture
 
-**Framework:** Next.js 14.2.35 App Router (bumped from 14.2.3 2026-07-08 to clear a critical middleware auth-bypass advisory; `npm audit` still reports 4 high/1 moderate advisories on 14.2.35 that only a Next.js 16.x major bump would clear — not taken, tracked as a follow-up, not a regression), React 18, TypeScript. Styling is a mix of **Tailwind** (dashboard app, `className`) and **inline styles** (marketing/landing + signup). Charts via `recharts`, icons via `lucide-react`, JWT decode via `jose`.
+**Framework:** Next.js 14.2.35 App Router (bumped from 14.2.3 2026-07-08 to clear a critical middleware auth-bypass advisory; `npm audit` still reports 4 high/1 moderate advisories on 14.2.35 that only a Next.js 16.x major bump would clear — not taken, tracked as a follow-up, not a regression), React 18, TypeScript. Styling is a mix of **Tailwind** (dashboard app, `className`) and **inline styles** (marketing/landing + signup). Icons via `lucide-react`, JWT decode via `jose`. No chart library is installed — all data visualisation is custom inline HTML/CSS.
 
 **No global state library.** No Redux/Zustand/React Query/SWR/Context. State is:
 - **Local** via `useState`/`useEffect` per page.
@@ -615,7 +615,7 @@ The logic that drives every dashboard gate and funnel branch. Routers are thin; 
 ### 18.4 Events & memory
 
 - **`write_event`** (`core/services/event_write.py:16-109`): upsert agent + bump `event_count`; insert event with SHA-256 checksum of sorted JSON; best-effort embedding + Qdrant upsert to `agent_events`; increment `usage_daily.events_written`; returns `{event_id, timestamp, sequence_no, checksum}`.
-- **Events API** (`core/api/events.py`): `POST /` and `GET /` enforce agent scope (`assert_agent_allowed`); `GET /{id}/why` walks the parent chain (`depth≤50`); `GET /at` reconstructs state at a timestamp via `STATE_SET`/`STATE_DELETE` reduction — note **`/at` does NOT enforce agent scope**.
+- **Events API** (`core/api/events.py`): `POST /`, `GET /`, and `GET /at` all enforce agent scope (`assert_agent_allowed`); `GET /{id}/why` walks the parent chain (`depth≤50`); `GET /at` reconstructs state at a timestamp via `STATE_SET`/`STATE_DELETE` reduction — **scoped API keys (bound to a specific `agent_id`) cannot time-travel into another agent's state and will receive 403**.
 - **Memory** (`core/api/memory.py`): `POST /context` (recent + semantic search merged into a char-budgeted prompt block), `GET /diff/{session_id}` (session summary + new event types vs prior), `DELETE /forget` (deletes events by exact JSONB match + purges Qdrant).
 
 ### 18.5 Agents & baseline (`core/api/agents.py`)

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -64,11 +64,12 @@ services:
       ENV: ${ENV:-development}
       # Local dev only — leave unset on managed cloud (ENV=production)
       DEV_API_KEY: ${DEV_API_KEY:-zizkadb_dev_local}
-      # Marks this stack as self-hosted for plan-based entitlement checks
-      # (e.g. API key limits). This compose file is also used to deploy
-      # managed cloud (infra/deploy-production.sh), so the default here MUST
-      # stay "managed" — self-host installs opt in explicitly via their own
-      # infra/.env (see .env.example / wiki/Self-Hosting.md).
+      # IMPORTANT FOR SELF-HOSTERS: set DEPLOYMENT_MODE=self_hosted in your
+      # infra/.env (see .env.example). Without it, plan-based API key limits
+      # are evaluated as if you are a managed-cloud tenant (default: "managed").
+      # This file is also used by infra/deploy-production.sh for the managed
+      # cloud, so the in-compose default must stay "managed" — self-hosters
+      # must override via their .env file (see wiki/Self-Hosting.md).
       DEPLOYMENT_MODE: ${DEPLOYMENT_MODE:-managed}
       # Email — optional; enables OTP login on self-hosted dashboard
       EMAIL_HOST: ${EMAIL_HOST}


### PR DESCRIPTION
## Summary

Phase 1 of a systematic full-repository audit. Fixes five documentation inaccuracies and six missing env var entries. **No code behaviour is changed** — all changes are documentation, configuration comments, and `.env.example` additions.

Closes #59

## Changes

### `dashboard/DASHBOARD_KNOWLEDGE_BASE.md`
- **Removed stale `recharts` reference** (line 41): `recharts` is not installed and has zero imports. Was causing confusion about the dashboard's charting capabilities.
- **Corrected `/at` endpoint agent scope claim** (line 618): The KB falsely stated `GET /at` does NOT enforce agent scope. `core/api/events.py:173` calls `assert_agent_allowed()` — scoped keys receive 403 if they attempt to time-travel into another agent's state. This was a security-relevant factual error.

### `CONNECT.md`
- Fixed LangChain quick-connect example to use `async with ZizkaDB(...) as db:` instead of the sync constructor `db = ZizkaDB(...)`. The sync form leaves the httpx session unclosed.

### `README.md`
- Updated LangChain and CrewAI install commands: these packages are installed via git URL, not PyPI. The previous `pip install zizkadb-langchain` command would fail with a package-not-found error.

### `.env.example`
- **Renamed `API_URL` → `PUBLIC_API_URL`**: `core/api/community.py` reads `os.getenv("PUBLIC_API_URL")`. The old `API_URL` name was never read by the Python process, so community image URLs were silently broken for self-hosters following the template.
- **Improved JWT_SECRET warning**: moved the "change this" instruction into a proper `# WARNING:` comment with a generation command. Previously the warning was embedded in the value itself and could be copy-pasted literally.
- **Added 7 previously undocumented env vars** with explanations: `ADMIN_EMAIL`, `COMMUNITY_UPLOAD_DIR`, `API_KEY_LIMIT_<PLAN>`, `RETENTION_TRIAL_DAYS`, `EMAIL_SMTP_TIMEOUT`, `API_REWRITE_TARGET`.

### `infra/docker-compose.yml`
- Expanded `DEPLOYMENT_MODE` comment to more prominently warn self-hosters they must set `DEPLOYMENT_MODE=self_hosted` in their `.env`, or plan-based API key limits default to managed-cloud behaviour.

## Test plan
- [x] `ruff check core/ sdk/python/ mcp/ integrations/` — all checks passed
- [x] `npm run lint` in `dashboard/` — only pre-existing `<img>` warnings (unrelated)
- [x] Verified `PUBLIC_API_URL` is the name used in `core/api/community.py:56`
- [x] Verified `assert_agent_allowed` is called in `core/api/events.py:173` (time_travel handler)
- [x] Confirmed `recharts` has zero occurrences in `package.json`, `node_modules` installs, or any `.tsx`/`.ts` import

🤖 Generated with [Claude Code](https://claude.com/claude-code)