### PR TITLE
chore(audit): example documentation improvements — Phase 3

### DIFF
--- a/examples/crewai-agent/.env.example
+++ b/examples/crewai-agent/.env.example
@@ -1,4 +1,5 @@
 OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-4o-mini     # optional — overrides the default model used by the agent
 ZIZKADB_API_KEY=zizkadb_live_xxxx
 ZIZKADB_AGENT=crewai-researcher
 # ZIZKADB_HOST=http://localhost:8000

--- a/examples/crewai-agent/requirements.txt
+++ b/examples/crewai-agent/requirements.txt
@@ -1,4 +1,6 @@
 zizkadb-sdk>=0.2.1
+# Installed from source until zizkadb-crewai is published to PyPI.
+# Pin to a specific commit SHA instead of @main for reproducible installs.
 zizkadb-crewai @ git+https://github.com/Zizka-ai/ZizkaDB.git@main#subdirectory=integrations/crewai
 crewai>=0.80.0
 langchain-openai>=0.2.0

--- a/examples/langchain-agent/.env.example
+++ b/examples/langchain-agent/.env.example
@@ -1,4 +1,5 @@
 OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-4o-mini     # optional — overrides the default model used by the agent
 ZIZKADB_API_KEY=zizkadb_live_xxxx
 ZIZKADB_AGENT=langchain-agent
 # ZIZKADB_HOST=http://localhost:8000

--- a/examples/langchain-agent/requirements.txt
+++ b/examples/langchain-agent/requirements.txt
@@ -1,4 +1,6 @@
 zizkadb-sdk>=0.2.1
+# Installed from source until zizkadb-langchain is published to PyPI.
+# Pin to a specific commit SHA instead of @main for reproducible installs.
 zizkadb-langchain @ git+https://github.com/Zizka-ai/ZizkaDB.git@main#subdirectory=integrations/langchain
 langchain-openai>=0.2.0
 langchain-core>=0.3.0

--- a/examples/openai-agent/.env.example
+++ b/examples/openai-agent/.env.example
@@ -1,4 +1,5 @@
 OPENAI_API_KEY=sk-...
+# OPENAI_MODEL=gpt-4o-mini     # optional — overrides the default model used by the agent
 ZIZKADB_API_KEY=zizkadb_live_xxxx
 ZIZKADB_AGENT=gpt-4o-agent
 # ZIZKADB_HOST=http://localhost:8000


### PR DESCRIPTION
## Summary

Phase 3 of the full codebase onboarding audit. Documentation-only changes to the example agents — no runtime code changed, no CI impact. These fixes close the remaining gaps identified during the audit around contributor/self-hoster experience in the `examples/` directory.

---

## Changes

### 1. `OPENAI_MODEL` added to all three example `.env.example` files

`examples/langchain-agent/.env.example`, `examples/openai-agent/.env.example`, `examples/crewai-agent/.env.example` each now include:

```env
# OPENAI_MODEL=gpt-4o-mini     # optional — overrides the default model used by the agent
```

Contributors and self-hosters who want to change the model now find the knob where they look first (the `.env` file), rather than having to read through the agent source to find where the model string is hardcoded.

---

### 2. Pinning notes added to `@main` git-URL requirements

`examples/langchain-agent/requirements.txt` and `examples/crewai-agent/requirements.txt` use `git+https://...@main` to install the LangChain and CrewAI integrations (not yet published to PyPI). Added a two-line comment above each:

```
# Installed from source until zizkadb-langchain is published to PyPI.
# Pin to a specific commit SHA instead of @main for reproducible installs.
```

This flags the moving-target risk for users who want reproducible builds, without changing any install behaviour.

---

### 3. Scripts — no changes needed

`scripts/generate-readme-assets.py`, `scripts/seed-support-bot-events.py`, and `scripts/github-setup.sh` all already have clear docstrings and usage headers. No action was required.

---

## Testing

- `ruff check core/` → All checks passed (no Python changes)
- Documentation-only changes; no build or lint step affected

---

## Related

- Phase 1 (docs/env vars) — Issue #59 / PR #60
- Phase 2 (dead code + schema) — Issue #62 / PR #61
- This is the final phase of the audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)