### PR TITLE
fix(security): critical security fixes (Phase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,14 @@ DASHBOARD_URL=http://localhost:3001
 
 # Dashboard (when running npm run dev)
 NEXT_PUBLIC_API_URL=http://localhost:8000
+# MUST be false for any public/production deployment — when true, the dashboard
+# login page bypasses OTP entirely via an "Open my dashboard" shortcut.
+# infra/deploy-production.sh refuses to deploy if this is still "true".
 NEXT_PUBLIC_DEV_MODE=true
+
+# Cross-origin allowlist for the API (comma-separated, no trailing slashes).
+# Must be set to your real dashboard origin(s) before deploying publicly.
+CORS_ORIGINS=http://localhost:3001,http://localhost:3000
 
 # Trial length for new signups (days)
 TRIAL_DAYS=30

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## What does this PR do?
+
+<!-- One paragraph or bullet list explaining the change -->
+
+## How to test
+
+<!-- Steps for the reviewer to verify -->
+
+## Checklist
+
+- [ ] Tests pass (`pytest core/tests/ -m "not integration" -v`)
+- [ ] Lint passes (`ruff check core/ sdk/python/ mcp/ integrations/`)
+- [ ] Dashboard builds (`cd dashboard && npm run lint && npm run build`)
+- [ ] No new `allow_origins=["*"]` + `allow_credentials=True` combinations
+- [ ] Schema changes are idempotent (`IF NOT EXISTS` / `IF EXISTS`)
+- [ ] Auth dependency is correct (`get_tenant` vs `require_dashboard_session`)
+- [ ] Per-agent analytics routes call `assert_agent_allowed()`
+- [ ] Plan limits only live in `PLAN_ENTITLEMENTS` (`core/services/entitlements.py`)
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` if user-facing or security-relevant

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to ZizkaDB are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+Versioning follows [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Security
+- Fix OTP plaintext logging in production when SMTP is unconfigured — now raises instead of logging the code
+- Fix CORS wildcard + credentials combination (`allow_origins=["*"]` with `allow_credentials=True` is invalid and was silently rejected by all browsers); origins now read from `CORS_ORIGINS`
+- Fix user enumeration in `POST /v1/auth/request-otp` — existing vs. non-existing emails no longer produce distinguishable responses (was 409 vs 404)
+- Add `restart: unless-stopped` to every Docker Compose service
+- Bind Postgres, Qdrant, and Redis ports to `127.0.0.1` instead of `0.0.0.0`
+- Fix `infra/deploy-production.sh` to poll `/health/deep` (real dependency check) instead of `/health` (always 200)
+- Add `NEXT_PUBLIC_DEV_MODE=true` production deploy guard to `infra/deploy-production.sh`
+- Add non-root `USER` to `core/Dockerfile` and a `core/.dockerignore`
+- Fix `client_ip()` to only trust `X-Forwarded-For` from a configured trusted proxy, preventing IP-spoofing bypass of rate limits
+- Add startup guard refusing to boot if `DEV_API_KEY` is set while `ENV=production`; remove the `DEV_API_KEY` compose default that could silently re-enable the dev auth bypass
+- Remove redundant `docker compose restart api` step in the deploy script
+
+## [0.1.0] - 2024-01-01
+
+### Added
+- Initial public release

--- a/core/.dockerignore
+++ b/core/.dockerignore
@@ -1,0 +1,12 @@
+.git
+__pycache__
+*.pyc
+*.pyo
+.pytest_cache
+tests/
+.env
+.env.*
+*.egg-info
+.ruff_cache
+CLAUDE.md
+README.md

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -11,6 +11,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN addgroup --system app && adduser --system --ingroup app app \
+    && mkdir -p /data/community_uploads \
+    && chown -R app:app /app /data/community_uploads
+USER app
+
 EXPOSE 8000
 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/core/api/auth.py
+++ b/core/api/auth.py
@@ -66,24 +66,17 @@ async def request_otp_route(body: RequestOTPBody):
     email = body.email.lower().strip()
     _check_otp_rate_limit(email)
 
-    if body.intent == "signup" and await email_exists(email):
-        raise HTTPException(
-            status_code=409,
-            detail="This email is already registered. Please sign in instead.",
-        )
+    # Do not disclose whether the email is registered — both branches below
+    # return the same generic message regardless of account existence, to
+    # avoid user enumeration via this endpoint.
+    exists = await email_exists(email)
+    if (body.intent == "signup" and not exists) or (body.intent == "login" and exists):
+        try:
+            await request_otp(email)
+        except Exception as e:
+            log.error(f"request_otp failed for {email}: {e}")
 
-    if body.intent == "login" and not await email_exists(email):
-        raise HTTPException(
-            status_code=404,
-            detail="No account found for this email. Create an account to get started.",
-        )
-
-    try:
-        await request_otp(email)
-        return {"message": "Code sent"}
-    except Exception as e:
-        log.error(f"request_otp failed for {email}: {e}")
-        raise HTTPException(status_code=500, detail="Failed to send code. Check server logs.")
+    return {"message": "If an account matches, a login code has been sent."}
 
 
 @router.post("/verify-otp")

--- a/core/api/deps.py
+++ b/core/api/deps.py
@@ -1,8 +1,10 @@
+import logging
 import os
 from fastapi import HTTPException, Security, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from services.auth import verify_api_key, decode_access_token
 
+logger = logging.getLogger(__name__)
 bearer = HTTPBearer()
 
 # Dev key: set DEV_API_KEY in .env for self-hosted local development.
@@ -57,14 +59,18 @@ def assert_agent_allowed(tenant: dict, agent_id: str) -> None:
 def _dev_key_accepted(token: str) -> bool:
     if _IS_PRODUCTION:
         return False
+    accepted = False
     if _DEV_API_KEY:
         if token == _DEV_API_KEY:
-            return True
+            accepted = True
         # Transition: old infra/.env used agdb_dev_local; SDK/MCP use zizkadb_dev_local.
-        if _DEV_API_KEY in _KNOWN_DEV_KEYS and token in _KNOWN_DEV_KEYS:
-            return True
-        return False
-    return token in _KNOWN_DEV_KEYS
+        elif _DEV_API_KEY in _KNOWN_DEV_KEYS and token in _KNOWN_DEV_KEYS:
+            accepted = True
+    else:
+        accepted = token in _KNOWN_DEV_KEYS
+    if accepted:
+        logger.warning("Dev API key accepted for request — must never happen in production (ENV=production).")
+    return accepted
 
 
 def dashboard_session_dependency(forbid_detail: str):

--- a/core/api/utils.py
+++ b/core/api/utils.py
@@ -2,16 +2,30 @@
 
 from __future__ import annotations
 
+import os
 import time
 
 from fastapi import HTTPException, Request
 
+# X-Forwarded-For is only trusted when the direct TCP connection comes from a
+# known reverse proxy — otherwise any client can forge the header to spoof
+# their IP and dodge rate limiting. In Docker Compose, nginx/the dashboard
+# connect over the bridge network, not 127.0.0.1, so operators fronting the
+# API with a proxy on another host/IP must set TRUSTED_PROXY_IPS.
+_TRUSTED_PROXIES = {
+    "127.0.0.1",
+    "::1",
+    *(ip.strip() for ip in os.getenv("TRUSTED_PROXY_IPS", "").split(",") if ip.strip()),
+}
+
 
 def client_ip(request: Request) -> str:
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+    direct_ip = request.client.host if request.client else None
+    if direct_ip in _TRUSTED_PROXIES:
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded:
+            return forwarded.split(",")[0].strip()
+    return direct_ip or "unknown"
 
 
 def check_rate(

--- a/core/main.py
+++ b/core/main.py
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    if os.getenv("ENV") == "production" and os.getenv("DEV_API_KEY"):
+        raise RuntimeError(
+            "DEV_API_KEY must not be set when ENV=production. "
+            "Remove DEV_API_KEY from your .env before deploying publicly."
+        )
     await init_db()
     # Seed dev tenant for local self-host (ENV=development) or when DEV_API_KEY is set.
     if os.getenv("ENV", "development") == "development" or os.getenv("DEV_API_KEY"):
@@ -93,12 +98,18 @@ async def api_explorer_redirect():
     """Legacy URL; nginx may mis-route this unless ^~ /api-explorer is configured."""
     return RedirectResponse(url="/swagger")
 
+_cors_origins = [
+    origin.strip()
+    for origin in os.getenv("CORS_ORIGINS", "http://localhost:3001,http://localhost:3000").split(",")
+    if origin.strip()
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
+    allow_headers=["Authorization", "Content-Type", "X-Api-Key"],
 )
 
 app.include_router(auth_router,      prefix="/v1/auth",      tags=["auth"])

--- a/core/services/auth.py
+++ b/core/services/auth.py
@@ -358,8 +358,11 @@ def _send_otp_email_sync(email: str, otp: str) -> None:
     password = os.getenv("EMAIL_PASS")
 
     if not host or not user or not password:
-        log.warning("DEV OTP for %s: %s (set EMAIL_HOST / EMAIL_USER / EMAIL_PASS to send real emails)", email, otp)
-        return
+        if os.getenv("ENV", "development") == "development":
+            log.warning("DEV OTP for %s: %s (set EMAIL_HOST / EMAIL_USER / EMAIL_PASS to send real emails)", email, otp)
+            return
+        log.error("SMTP not configured — OTP could not be sent to %s. Set EMAIL_HOST / EMAIL_USER / EMAIL_PASS.", email)
+        raise RuntimeError("Email service not configured")
 
     port = int(os.getenv("EMAIL_PORT", 587))
     from_addr = os.getenv("EMAIL_FROM", f'"ZizkaDB" <{user}>')

--- a/core/tests/test_auth_flow.py
+++ b/core/tests/test_auth_flow.py
@@ -28,14 +28,14 @@ class TestRequestOtpIntent:
 
     @patch("api.auth.request_otp", new_callable=AsyncMock)
     @patch("api.auth.email_exists", new_callable=AsyncMock)
-    def test_login_rejects_unknown_email(self, mock_exists, mock_request):
+    def test_login_unknown_email_returns_generic_response(self, mock_exists, mock_request):
+        """Unknown email must not be distinguishable from a known one (user enumeration)."""
         mock_exists.return_value = False
         res = client.post(
             "/v1/auth/request-otp",
             json={"email": "gone@example.com", "intent": "login"},
         )
-        assert res.status_code == 404
-        assert "No account found" in res.json()["detail"]
+        assert res.status_code == 200
         mock_request.assert_not_called()
 
     @patch("api.auth.request_otp", new_callable=AsyncMock)
@@ -51,14 +51,14 @@ class TestRequestOtpIntent:
 
     @patch("api.auth.request_otp", new_callable=AsyncMock)
     @patch("api.auth.email_exists", new_callable=AsyncMock)
-    def test_signup_rejects_existing_email(self, mock_exists, mock_request):
+    def test_signup_existing_email_returns_generic_response(self, mock_exists, mock_request):
+        """Existing email on signup must not be distinguishable from a new one (user enumeration)."""
         mock_exists.return_value = True
         res = client.post(
             "/v1/auth/request-otp",
             json={"email": "user@example.com", "intent": "signup"},
         )
-        assert res.status_code == 409
-        assert "already registered" in res.json()["detail"]
+        assert res.status_code == 200
         mock_request.assert_not_called()
 
     @patch("api.auth.request_otp", new_callable=AsyncMock)

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -12,7 +12,10 @@ from api.auth import _otp_rate, _OTP_RATE_MAX, _OTP_RATE_WINDOW_SEC
 from api.demo_requests import _rate as demo_rate, RATE_MAX as DEMO_MAX, RATE_WINDOW_SEC as DEMO_WINDOW
 from api.community import _rate as community_rate, RATE_MAX_POSTS as COMM_MAX, RATE_WINDOW_SEC as COMM_WINDOW
 
-client = TestClient(app)
+# client_ip() only trusts X-Forwarded-For from a trusted proxy address (see
+# api/utils.py). Simulate the TestClient connecting from 127.0.0.1 so tests
+# that partition by x-forwarded-for continue to exercise that code path.
+client = TestClient(app, client=("127.0.0.1", 123))
 
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -35,8 +38,7 @@ class TestOTPRateLimiting:
             for _ in range(_OTP_RATE_MAX):
                 response = client.post("/v1/auth/request-otp", json={"email": "user@example.com"})
                 assert response.status_code == 200
-                assert response.json() == {"message": "Code sent"}
-            
+
             assert mock_request_otp.call_count == _OTP_RATE_MAX
 
     @patch("api.auth.email_exists", new_callable=AsyncMock)

--- a/infra/deploy-production.sh
+++ b/infra/deploy-production.sh
@@ -30,6 +30,12 @@ if ! zizka_is_production; then
   [ "$ok" = "y" ] || [ "$ok" = "Y" ] || exit 1
 fi
 
+if [ "${NEXT_PUBLIC_DEV_MODE:-}" = "true" ]; then
+  echo "ERROR: NEXT_PUBLIC_DEV_MODE=true in infra/.env." >&2
+  echo "This bypasses dashboard login entirely — must be 'false' for any public deployment." >&2
+  exit 1
+fi
+
 zizka_require_deploy_confirm
 
 echo "════════════════════════════════════════════════════════"
@@ -48,11 +54,10 @@ git pull origin main
 
 echo "→ Step 3/5: Rebuild & restart API stack (no -v)"
 "${COMPOSE[@]}" up -d --build
-"${COMPOSE[@]}" restart api
 
 echo "→ Step 4/5: Wait for API health"
 for i in $(seq 1 30); do
-  if curl -sf http://127.0.0.1:8000/health >/dev/null 2>&1; then
+  if curl -sf http://127.0.0.1:8000/health/deep >/dev/null 2>&1; then
     break
   fi
   sleep 2
@@ -61,7 +66,7 @@ for i in $(seq 1 30); do
     exit 1
   fi
 done
-curl -sf http://127.0.0.1:8000/health && echo ""
+curl -sf http://127.0.0.1:8000/health/deep && echo ""
 
 echo "→ Step 5/5: Dashboard (PM2)"
 bash "$ROOT/infra/deploy-dashboard.sh"
@@ -75,7 +80,7 @@ echo "  Deploy complete"
 echo "════════════════════════════════════════════════════════"
 echo "  Users before: $USERS_BEFORE"
 echo "  Users after:  $USERS_AFTER"
-echo "  Health:       $(curl -sf http://127.0.0.1:8000/health || echo FAIL)"
+echo "  Health:       $(curl -sf http://127.0.0.1:8000/health/deep || echo FAIL)"
 echo ""
 
 if [ "$USERS_BEFORE" != "?" ] && [ "$USERS_AFTER" != "?" ] && [ "$USERS_BEFORE" -gt 0 ] 2>/dev/null && [ "$USERS_AFTER" = "0" ]; then

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     container_name: zizkadb_postgres
+    restart: unless-stopped
     # WARNING: docker compose down -v deletes ALL user accounts and events.
     # Production: use bash infra/deploy-production.sh — never -v.
     # Local reset only: bash scripts/reset-local-db.sh
@@ -12,7 +13,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-zizkadb}
       POSTGRES_DB: ${POSTGRES_DB:-zizkadb}
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ../core/db/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql
@@ -25,19 +26,26 @@ services:
   qdrant:
     image: qdrant/qdrant:v1.13.5
     container_name: zizkadb_qdrant
+    restart: unless-stopped
     ports:
-      - "6333:6333"
-      - "6334:6334"
+      - "127.0.0.1:6333:6333"
+      - "127.0.0.1:6334:6334"
     volumes:
       - qdrant_data:/qdrant/storage
     environment:
       QDRANT__SERVICE__GRPC_PORT: 6334
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c 'exec 3<>/dev/tcp/localhost/6333' || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: redis:7-alpine
     container_name: zizkadb_redis
+    restart: unless-stopped
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     volumes:
       - redis_data:/data
     command: redis-server --appendonly yes
@@ -52,6 +60,7 @@ services:
       context: ../core
       dockerfile: Dockerfile
     container_name: zizkadb_api
+    restart: unless-stopped
     ports:
       - "8000:8000"
     environment:
@@ -62,8 +71,13 @@ services:
       JWT_SECRET: ${JWT_SECRET:-dev-secret-change-in-production}
       JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET:-dev-refresh-secret-change-in-production}
       ENV: ${ENV:-development}
-      # Local dev only — leave unset on managed cloud (ENV=production)
-      DEV_API_KEY: ${DEV_API_KEY:-zizkadb_dev_local}
+      # Local dev only — must be left unset (not even empty-string) in your
+      # infra/.env on managed cloud / any public deployment (ENV=production).
+      # No fallback default here on purpose: a compose `:-default` triggers on
+      # both "unset" and "empty string", so defaulting this would silently
+      # re-enable the dev bypass for anyone who set DEV_API_KEY= in their .env.
+      DEV_API_KEY: ${DEV_API_KEY}
+      CORS_ORIGINS: ${CORS_ORIGINS:-http://localhost:3001,http://localhost:3000}
       # IMPORTANT FOR SELF-HOSTERS: set DEPLOYMENT_MODE=self_hosted in your
       # infra/.env (see .env.example). Without it, plan-based API key limits
       # are evaluated as if you are a managed-cloud tenant (default: "managed").
@@ -85,6 +99,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      qdrant:
         condition: service_healthy
     volumes:
       - community_uploads:/data/community_uploads


### PR DESCRIPTION
## What does this PR do?

Phase 1 of the security audit remediation plan — fixes the CRITICAL and highest-impact HIGH findings that would cause embarrassing failures on day-1 of public launch.

- **OTP plaintext logging**: no longer logs the OTP code when SMTP is unconfigured in production; raises instead
- **CORS wildcard + credentials**: `allow_origins=["*"]` + `allow_credentials=True` is an invalid combination browsers silently reject. Origins now come from `CORS_ORIGINS` env var
- **User enumeration**: `POST /v1/auth/request-otp` returned 409 for existing emails and 404 for unknown ones. Both cases now return an identical 200 response
- **No restart policies**: added `restart: unless-stopped` to every Docker Compose service
- **Services bound to 0.0.0.0**: Postgres, Qdrant, Redis ports now bind to `127.0.0.1` only
- **Shallow health check in deploy script**: `infra/deploy-production.sh` now polls `/health/deep` (real dependency check) instead of `/health` (always 200)
- **`NEXT_PUBLIC_DEV_MODE` footgun**: deploy script now refuses to deploy if this is still `true` (bypasses dashboard OTP login)
- **Dockerfile ran as root**: added non-root `USER` + `core/.dockerignore`
- **`client_ip()` spoofing**: `X-Forwarded-For` is now only trusted from a configured trusted proxy address, closing a rate-limit bypass
- **Dev API key footgun**: refuses to boot if `DEV_API_KEY` is set while `ENV=production`; removed the compose default that could silently re-enable the bypass
- Added `CHANGELOG.md` and `.github/PULL_REQUEST_TEMPLATE.md`

## How to test

```bash
# Lint
/Users/apple/Library/Python/3.14/bin/ruff check core/ sdk/python/ mcp/ integrations/

# Core unit tests (includes updated OTP-enumeration and rate-limit tests)
pytest core/tests/ -m "not integration" -v

# SDK + MCP + TS SDK
pytest sdk/python/tests/ -v
pytest mcp/tests/ -v
cd sdk/typescript && npm test

# Dashboard
cd dashboard && npm run lint && npm run build
```

Manual checks:
- `curl -s -o /dev/null -w "%{http_code}" -X POST http://localhost:8000/v1/auth/request-otp -H "Content-Type: application/json" -d '{"email":"nobody@example.com"}'` → 200
- Set `ENV=production` + `DEV_API_KEY=zizkadb_dev_local` → app refuses to start

## Checklist

- [x] Tests pass (`pytest core/tests/ -m "not integration" -v` — 136 passed)
- [x] Lint passes (`ruff check core/ sdk/python/ mcp/ integrations/`)
- [x] Dashboard lints clean (`npm run lint`)
- [x] No new `allow_origins=["*"]` + `allow_credentials=True` combinations
- [x] Schema changes are idempotent — N/A, no schema changes in this PR
- [x] Auth dependency is correct — no auth-dependency routing changed
- [x] `CHANGELOG.md` updated under `[Unreleased]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)