### PR TITLE
Add Discord CTA to outreach emails

### DIFF
--- a/core/services/outreach_template.py
+++ b/core/services/outreach_template.py
@@ -56,14 +56,24 @@ def build_outreach_html(
         </div>
         """
 
-    cta_block = ""
+    discord_url = "https://discord.gg/EBjAABKkh"
+    star_btn = ""
     if cta_label and cta_url:
-        cta_block = f"""
-        <div style="margin:28px 0 8px;text-align:center;">
+        star_btn = f"""
           <a href="{_escape(cta_url)}"
              style="display:inline-block;background:#22c55e;color:#0a0a0a;text-decoration:none;
                     font-weight:700;font-size:14px;padding:12px 22px;border-radius:8px;">
             {_escape(cta_label)}
+          </a>
+          <div style="height:12px;line-height:12px;font-size:12px;">&nbsp;</div>
+        """
+    cta_block = f"""
+        <div style="margin:28px 0 8px;text-align:center;">
+          {star_btn}
+          <a href="{_escape(discord_url)}"
+             style="display:inline-block;background:#5865F2;color:#ffffff;text-decoration:none;
+                    font-weight:700;font-size:14px;padding:12px 22px;border-radius:8px;">
+            Join our Discord community
           </a>
         </div>
         """
@@ -137,7 +147,10 @@ def build_outreach_text(
     if cta_label and cta_url:
         lines.append(f"{cta_label}: {cta_url}")
         lines.append("")
+    lines.append("Join our Discord community: https://discord.gg/EBjAABKkh")
+    lines.append("")
     lines.append(f"GitHub: {github_url}")
+
     lines.append("")
     lines.append(sign_off.strip())
     return "\n".join(lines)

--- a/core/tests/test_outreach_template.py
+++ b/core/tests/test_outreach_template.py
@@ -20,7 +20,10 @@ def test_build_outreach_html_includes_pixel_and_image():
     assert "dashboard-preview.png" in html
     assert "Dashboard preview" in html
     assert "Star on GitHub" in html
+    assert "Join our Discord community" in html
+    assert "https://discord.gg/EBjAABKkh" in html
     assert "api.example/v1/outreach/o/abc.gif" in html
+
 
 
 def test_build_outreach_escapes_html():
@@ -54,3 +57,4 @@ def test_build_outreach_text():
     assert "Line one" in text
     assert "[Screenshot:" in text
     assert "Star: https://github.com" in text
+    assert "Join our Discord community: https://discord.gg/EBjAABKkh" in text


### PR DESCRIPTION
## Summary

Adds a **Join our Discord community** button directly under **Star on GitHub** in outreach emails, linking to https://discord.gg/EBjAABKkh

No other changes.

## Test plan

- [ ] `/admin` → Email Outreach → Preview shows Discord button under Star
- [ ] Send test email → Discord button opens https://discord.gg/EBjAABKkh
