### PR TITLE
Editable Discord CTA in Email Outreach

### DIFF
--- a/core/api/outreach.py
+++ b/core/api/outreach.py
@@ -30,6 +30,8 @@ public_router = APIRouter()
 
 DAILY_SEND_LIMIT = int(os.getenv("OUTREACH_DAILY_LIMIT", "100"))
 GITHUB_DEFAULT = "https://github.com/Zizka-ai/ZizkaDB"
+DISCORD_DEFAULT = "https://discord.gg/EBjAABKkh"
+DISCORD_LABEL_DEFAULT = "Join our Discord community"
 
 # 1×1 transparent GIF
 _PIXEL_GIF = (
@@ -51,6 +53,8 @@ class OutreachSendRequest(BaseModel):
     image_caption: Optional[str] = Field(None, max_length=300)
     cta_label: Optional[str] = Field("Star on GitHub", max_length=80)
     cta_url: Optional[str] = Field(GITHUB_DEFAULT, max_length=500)
+    discord_cta_label: Optional[str] = Field(DISCORD_LABEL_DEFAULT, max_length=80)
+    discord_cta_url: Optional[str] = Field(DISCORD_DEFAULT, max_length=500)
     github_url: str = Field(GITHUB_DEFAULT, max_length=500)
     sign_off: str = Field(
         "Best,\nFellow Developer,\nMir",
@@ -65,6 +69,8 @@ class OutreachPreviewRequest(BaseModel):
     image_caption: Optional[str] = Field(None, max_length=300)
     cta_label: Optional[str] = Field("Star on GitHub", max_length=80)
     cta_url: Optional[str] = Field(GITHUB_DEFAULT, max_length=500)
+    discord_cta_label: Optional[str] = Field(DISCORD_LABEL_DEFAULT, max_length=80)
+    discord_cta_url: Optional[str] = Field(DISCORD_DEFAULT, max_length=500)
     github_url: str = Field(GITHUB_DEFAULT, max_length=500)
     sign_off: str = Field(
         "Best,\nFellow Developer,\nMir",
@@ -158,6 +164,8 @@ async def outreach_preview(body: OutreachPreviewRequest, _: dict = Depends(requi
         image_caption=body.image_caption,
         cta_label=body.cta_label,
         cta_url=body.cta_url,
+        discord_cta_label=body.discord_cta_label,
+        discord_cta_url=body.discord_cta_url,
         github_url=body.github_url,
         pixel_url=pixel_url,
         sign_off=body.sign_off,
@@ -168,6 +176,8 @@ async def outreach_preview(body: OutreachPreviewRequest, _: dict = Depends(requi
         image_url=body.image_url,
         cta_label=body.cta_label,
         cta_url=body.cta_url,
+        discord_cta_label=body.discord_cta_label,
+        discord_cta_url=body.discord_cta_url,
         github_url=body.github_url,
         sign_off=body.sign_off,
     )
@@ -193,6 +203,8 @@ async def outreach_send(body: OutreachSendRequest, _: dict = Depends(require_adm
         image_caption=body.image_caption,
         cta_label=body.cta_label,
         cta_url=body.cta_url,
+        discord_cta_label=body.discord_cta_label,
+        discord_cta_url=body.discord_cta_url,
         github_url=body.github_url,
         pixel_url=pixel_url,
         sign_off=body.sign_off,
@@ -203,6 +215,8 @@ async def outreach_send(body: OutreachSendRequest, _: dict = Depends(require_adm
         image_url=body.image_url,
         cta_label=body.cta_label,
         cta_url=body.cta_url,
+        discord_cta_label=body.discord_cta_label,
+        discord_cta_url=body.discord_cta_url,
         github_url=body.github_url,
         sign_off=body.sign_off,
     )
@@ -211,8 +225,9 @@ async def outreach_send(body: OutreachSendRequest, _: dict = Depends(require_adm
         """
         INSERT INTO email_outreach_sends (
             send_id, to_email, subject, recipient_name, body_text, html_body,
-            image_url, image_caption, cta_label, cta_url, github_url, sign_off, status
-        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'queued')
+            image_url, image_caption, cta_label, cta_url,
+            discord_cta_label, discord_cta_url, github_url, sign_off, status
+        ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,'queued')
         """,
         send_id,
         body.to_email.lower().strip(),
@@ -224,6 +239,8 @@ async def outreach_send(body: OutreachSendRequest, _: dict = Depends(require_adm
         (body.image_caption or "").strip() or None,
         (body.cta_label or "").strip() or None,
         (body.cta_url or "").strip() or None,
+        (body.discord_cta_label or "").strip() or None,
+        (body.discord_cta_url or "").strip() or None,
         body.github_url.strip(),
         body.sign_off.strip(),
     )

--- a/core/db/connection.py
+++ b/core/db/connection.py
@@ -186,6 +186,8 @@ async def init_db():
             image_caption   TEXT,
             cta_label       VARCHAR(80),
             cta_url         TEXT,
+            discord_cta_label VARCHAR(80),
+            discord_cta_url TEXT,
             github_url      TEXT,
             sign_off        TEXT,
             status          VARCHAR(32) NOT NULL DEFAULT 'queued',
@@ -210,6 +212,13 @@ async def init_db():
         );
         CREATE INDEX IF NOT EXISTS idx_email_outreach_opens_send
             ON email_outreach_opens (send_id, opened_at DESC);
+    """)
+
+    await _pg_pool.execute("""
+        ALTER TABLE email_outreach_sends
+            ADD COLUMN IF NOT EXISTS discord_cta_label VARCHAR(80);
+        ALTER TABLE email_outreach_sends
+            ADD COLUMN IF NOT EXISTS discord_cta_url TEXT;
     """)
 
     _redis = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379"))

--- a/core/db/migrations/009_outreach_discord_cta.sql
+++ b/core/db/migrations/009_outreach_discord_cta.sql
@@ -1,0 +1,5 @@
+-- Editable Discord CTA fields for outreach emails (additive only)
+ALTER TABLE email_outreach_sends
+    ADD COLUMN IF NOT EXISTS discord_cta_label VARCHAR(80);
+ALTER TABLE email_outreach_sends
+    ADD COLUMN IF NOT EXISTS discord_cta_url TEXT;

--- a/core/db/schema.sql
+++ b/core/db/schema.sql
@@ -237,6 +237,8 @@ CREATE TABLE IF NOT EXISTS email_outreach_sends (
     image_caption   TEXT,
     cta_label       VARCHAR(80),
     cta_url         TEXT,
+    discord_cta_label VARCHAR(80),
+    discord_cta_url TEXT,
     github_url      TEXT,
     sign_off        TEXT,
     status          VARCHAR(32) NOT NULL DEFAULT 'queued',

--- a/core/services/outreach_template.py
+++ b/core/services/outreach_template.py
@@ -32,6 +32,8 @@ def build_outreach_html(
     image_caption: Optional[str],
     cta_label: Optional[str],
     cta_url: Optional[str],
+    discord_cta_label: Optional[str] = None,
+    discord_cta_url: Optional[str] = None,
     github_url: str,
     pixel_url: str,
     sign_off: str,
@@ -56,25 +58,30 @@ def build_outreach_html(
         </div>
         """
 
-    discord_url = "https://discord.gg/EBjAABKkh"
-    star_btn = ""
+    buttons = []
     if cta_label and cta_url:
-        star_btn = f"""
-          <a href="{_escape(cta_url)}"
+        buttons.append(
+            f"""<a href="{_escape(cta_url)}"
              style="display:inline-block;background:#22c55e;color:#0a0a0a;text-decoration:none;
                     font-weight:700;font-size:14px;padding:12px 22px;border-radius:8px;">
             {_escape(cta_label)}
-          </a>
-          <div style="height:12px;line-height:12px;font-size:12px;">&nbsp;</div>
-        """
-    cta_block = f"""
-        <div style="margin:28px 0 8px;text-align:center;">
-          {star_btn}
-          <a href="{_escape(discord_url)}"
+          </a>"""
+        )
+    if discord_cta_label and discord_cta_url:
+        buttons.append(
+            f"""<a href="{_escape(discord_cta_url)}"
              style="display:inline-block;background:#5865F2;color:#ffffff;text-decoration:none;
                     font-weight:700;font-size:14px;padding:12px 22px;border-radius:8px;">
-            Join our Discord community
-          </a>
+            {_escape(discord_cta_label)}
+          </a>"""
+        )
+
+    cta_block = ""
+    if buttons:
+        spacer = '<div style="height:12px;line-height:12px;font-size:12px;">&nbsp;</div>'
+        cta_block = f"""
+        <div style="margin:28px 0 8px;text-align:center;">
+          {spacer.join(buttons)}
         </div>
         """
 
@@ -136,6 +143,8 @@ def build_outreach_text(
     image_url: Optional[str],
     cta_label: Optional[str],
     cta_url: Optional[str],
+    discord_cta_label: Optional[str] = None,
+    discord_cta_url: Optional[str] = None,
     github_url: str,
     sign_off: str,
 ) -> str:
@@ -147,10 +156,10 @@ def build_outreach_text(
     if cta_label and cta_url:
         lines.append(f"{cta_label}: {cta_url}")
         lines.append("")
-    lines.append("Join our Discord community: https://discord.gg/EBjAABKkh")
-    lines.append("")
+    if discord_cta_label and discord_cta_url:
+        lines.append(f"{discord_cta_label}: {discord_cta_url}")
+        lines.append("")
     lines.append(f"GitHub: {github_url}")
-
     lines.append("")
     lines.append(sign_off.strip())
     return "\n".join(lines)

--- a/core/tests/test_outreach_template.py
+++ b/core/tests/test_outreach_template.py
@@ -11,6 +11,8 @@ def test_build_outreach_html_includes_pixel_and_image():
         image_caption="Dashboard preview",
         cta_label="Star on GitHub",
         cta_url="https://github.com/Zizka-ai/ZizkaDB",
+        discord_cta_label="Join our Discord community",
+        discord_cta_url="https://discord.gg/EBjAABKkh",
         github_url="https://github.com/Zizka-ai/ZizkaDB",
         pixel_url="https://api.example/v1/outreach/o/abc.gif",
         sign_off="Best,\nMir",
@@ -25,7 +27,6 @@ def test_build_outreach_html_includes_pixel_and_image():
     assert "api.example/v1/outreach/o/abc.gif" in html
 
 
-
 def test_build_outreach_escapes_html():
     html = build_outreach_html(
         recipient_name="<script>alert(1)</script>",
@@ -34,6 +35,8 @@ def test_build_outreach_escapes_html():
         image_caption=None,
         cta_label=None,
         cta_url=None,
+        discord_cta_label=None,
+        discord_cta_url=None,
         github_url="https://github.com/Zizka-ai/ZizkaDB",
         pixel_url="https://x/p.gif",
         sign_off="Mir",
@@ -41,6 +44,7 @@ def test_build_outreach_escapes_html():
     assert "<script>" not in html
     assert "&lt;script&gt;" in html
     assert "&lt;b&gt;here&lt;/b&gt;" in html
+    assert "Join our Discord" not in html
 
 
 def test_build_outreach_text():
@@ -50,6 +54,8 @@ def test_build_outreach_text():
         image_url="https://img.example/a.png",
         cta_label="Star",
         cta_url="https://github.com/Zizka-ai/ZizkaDB",
+        discord_cta_label="Join our Discord community",
+        discord_cta_url="https://discord.gg/EBjAABKkh",
         github_url="https://github.com/Zizka-ai/ZizkaDB",
         sign_off="Mir",
     )

--- a/dashboard/components/admin/EmailOutreachSection.tsx
+++ b/dashboard/components/admin/EmailOutreachSection.tsx
@@ -67,6 +67,8 @@ export function EmailOutreachSection({ token }: { token: string }) {
   );
   const [ctaLabel, setCtaLabel] = useState("Star on GitHub");
   const [ctaUrl, setCtaUrl] = useState("https://github.com/Zizka-ai/ZizkaDB");
+  const [discordCtaLabel, setDiscordCtaLabel] = useState("Join our Discord community");
+  const [discordCtaUrl, setDiscordCtaUrl] = useState("https://discord.gg/EBjAABKkh");
   const [githubUrl, setGithubUrl] = useState("https://github.com/Zizka-ai/ZizkaDB");
   const [signOff, setSignOff] = useState("Best,\nFellow Developer,\nMir");
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
@@ -98,6 +100,8 @@ export function EmailOutreachSection({ token }: { token: string }) {
     image_caption: imageCaption.trim() || undefined,
     cta_label: ctaLabel.trim() || undefined,
     cta_url: ctaUrl.trim() || undefined,
+    discord_cta_label: discordCtaLabel.trim() || undefined,
+    discord_cta_url: discordCtaUrl.trim() || undefined,
     github_url: githubUrl.trim() || "https://github.com/Zizka-ai/ZizkaDB",
     sign_off: signOff,
   });
@@ -114,6 +118,8 @@ export function EmailOutreachSection({ token }: { token: string }) {
         image_caption: imageCaption.trim() || undefined,
         cta_label: ctaLabel.trim() || undefined,
         cta_url: ctaUrl.trim() || undefined,
+        discord_cta_label: discordCtaLabel.trim() || undefined,
+        discord_cta_url: discordCtaUrl.trim() || undefined,
         github_url: githubUrl.trim() || "https://github.com/Zizka-ai/ZizkaDB",
         sign_off: signOff,
       });
@@ -285,6 +291,23 @@ export function EmailOutreachSection({ token }: { token: string }) {
             </Field>
             <Field label="CTA URL">
               <input value={ctaUrl} onChange={(e) => setCtaUrl(e.target.value)} style={inputStyle} />
+            </Field>
+          </div>
+
+          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12, marginTop: 12 }}>
+            <Field label="Discord CTA label">
+              <input
+                value={discordCtaLabel}
+                onChange={(e) => setDiscordCtaLabel(e.target.value)}
+                style={inputStyle}
+              />
+            </Field>
+            <Field label="Discord CTA URL">
+              <input
+                value={discordCtaUrl}
+                onChange={(e) => setDiscordCtaUrl(e.target.value)}
+                style={inputStyle}
+              />
             </Field>
           </div>
 

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -524,6 +524,8 @@ export interface OutreachComposePayload {
   image_caption?: string
   cta_label?: string
   cta_url?: string
+  discord_cta_label?: string
+  discord_cta_url?: string
   github_url?: string
   sign_off?: string
 }


### PR DESCRIPTION
## Summary

Discord button in outreach emails is now editable in `/admin` → **Email Outreach**, same as Star CTA:

- **Discord CTA label**
- **Discord CTA URL** (default `https://discord.gg/EBjAABKkh`)

Adds nullable columns only (`ADD COLUMN IF NOT EXISTS`) — no data deletion.

## Test plan

- [ ] Deploy API + dashboard (safe, no `-v`)
- [ ] Admin form shows Discord CTA label/URL fields
- [ ] Change label/URL → Preview updates
- [ ] Clear both fields → Discord button hidden
- [ ] Existing outreach send history unchanged
