### PR TITLE
Developer Leads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,14 @@ TRIAL_DAYS=30
 # PUBLIC_API_URL must be the externally reachable API base so open-tracking pixels load
 # in recipients' email clients (already documented above).
 
+# ── Developer Leads (GitHub public-email discovery) ────────────────────────────
+# Read-only GitHub token for /admin → Developer Leads.
+# Create at https://github.com/settings/tokens (classic: public_repo read is enough for public data;
+# fine-grained: public repository read + public profile read). Prefer a dedicated token.
+# GITHUB_LEADS_TOKEN=
+# Max new leads imported per UTC day (default: 100)
+# LEADS_DAILY_LIMIT=100
+
 # ── Dashboard standalone (npm run dev outside Docker) ─────────────────────────
 # URL the Next.js dev server proxies /v1/* requests to. Default: http://127.0.0.1:8000
 # API_REWRITE_TARGET=http://127.0.0.1:8000

--- a/core/api/developer_leads.py
+++ b/core/api/developer_leads.py
@@ -1,0 +1,312 @@
+"""
+Admin Developer Leads — GitHub public-email discovery.
+
+Manual "Find today's leads" only. Cap 100 new leads/day.
+Dedupes against existing leads and past outreach sends.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from api.admin import require_admin
+from db.connection import get_pool
+from services.github_leads import (
+    DAILY_LEAD_LIMIT,
+    DEFAULT_KEYWORDS,
+    find_public_leads,
+    github_token,
+    parse_keywords,
+)
+from services.leads_countries import countries_for_api
+
+log = logging.getLogger(__name__)
+
+admin_router = APIRouter()
+
+
+class FindLeadsRequest(BaseModel):
+    keywords: str = Field(DEFAULT_KEYWORDS, max_length=500)
+    country_code: str = Field("WW", max_length=8)
+
+
+class LeadStatusUpdate(BaseModel):
+    status: str = Field(..., pattern="^(new|approved|rejected|contacted)$")
+
+
+async def _imported_today(pool) -> int:
+    return int(
+        await pool.fetchval(
+            """
+            SELECT COUNT(*)::int FROM developer_leads
+            WHERE created_at >= date_trunc('day', NOW() AT TIME ZONE 'UTC')
+            """
+        )
+        or 0
+    )
+
+
+async def _exclude_sets(pool) -> tuple[set[str], set[str]]:
+    emails = await pool.fetch(
+        """
+        SELECT LOWER(email) AS email FROM developer_leads
+        UNION
+        SELECT LOWER(to_email) FROM email_outreach_sends
+        """
+    )
+    users = await pool.fetch(
+        "SELECT LOWER(github_username) AS u FROM developer_leads WHERE github_username IS NOT NULL"
+    )
+    return (
+        {r["email"] for r in emails if r["email"]},
+        {r["u"] for r in users if r["u"]},
+    )
+
+
+@admin_router.get("/leads/countries")
+async def leads_countries(_: dict = Depends(require_admin)):
+    return countries_for_api()
+
+
+@admin_router.get("/leads/stats")
+async def leads_stats(_: dict = Depends(require_admin)):
+    pool = get_pool()
+    imported_today = await _imported_today(pool)
+    row = await pool.fetchrow(
+        """
+        SELECT
+          COUNT(*)::int AS total,
+          COUNT(*) FILTER (WHERE status = 'new')::int AS status_new,
+          COUNT(*) FILTER (WHERE status = 'approved')::int AS approved,
+          COUNT(*) FILTER (WHERE status = 'rejected')::int AS rejected,
+          COUNT(*) FILTER (WHERE status = 'contacted')::int AS contacted
+        FROM developer_leads
+        """
+    )
+    return {
+        "imported_today": imported_today,
+        "daily_limit": DAILY_LEAD_LIMIT,
+        "remaining_today": max(0, DAILY_LEAD_LIMIT - imported_today),
+        "total": row["total"] or 0,
+        "status_new": row["status_new"] or 0,
+        "approved": row["approved"] or 0,
+        "rejected": row["rejected"] or 0,
+        "contacted": row["contacted"] or 0,
+        "token_configured": bool(github_token()),
+        "default_keywords": DEFAULT_KEYWORDS,
+    }
+
+
+@admin_router.get("/leads")
+async def list_leads(
+    status: str = "",
+    search: str = "",
+    limit: int = Query(100, ge=1, le=300),
+    _: dict = Depends(require_admin),
+):
+    pool = get_pool()
+    params: list = []
+    where = "WHERE TRUE"
+    if status.strip():
+        params.append(status.strip())
+        where += f" AND status = ${len(params)}"
+    if search.strip():
+        params.append(f"%{search.strip()}%")
+        n = len(params)
+        where += f"""
+            AND (
+                email ILIKE ${n}
+                OR github_username ILIKE ${n}
+                OR COALESCE(name, '') ILIKE ${n}
+                OR COALESCE(location, '') ILIKE ${n}
+                OR COALESCE(match_reason, '') ILIKE ${n}
+            )
+        """
+    params.append(limit)
+    rows = await pool.fetch(
+        f"""
+        SELECT lead_id, email, name, github_username, profile_url, bio, location,
+               country_code, matched_keyword, matched_repo, signal, match_reason,
+               status, created_at
+        FROM developer_leads
+        {where}
+        ORDER BY created_at DESC
+        LIMIT ${len(params)}
+        """,
+        *params,
+    )
+    return [
+        {
+            "lead_id": str(r["lead_id"]),
+            "email": r["email"],
+            "name": r["name"],
+            "github_username": r["github_username"],
+            "profile_url": r["profile_url"],
+            "bio": r["bio"],
+            "location": r["location"],
+            "country_code": r["country_code"],
+            "matched_keyword": r["matched_keyword"],
+            "matched_repo": r["matched_repo"],
+            "signal": r["signal"],
+            "match_reason": r["match_reason"],
+            "status": r["status"],
+            "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+        }
+        for r in rows
+    ]
+
+
+@admin_router.post("/leads/find")
+async def find_leads(body: FindLeadsRequest, _: dict = Depends(require_admin)):
+    pool = get_pool()
+    imported_today = await _imported_today(pool)
+    remaining = max(0, DAILY_LEAD_LIMIT - imported_today)
+    if remaining <= 0:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Daily lead import limit reached ({DAILY_LEAD_LIMIT}/day).",
+        )
+
+    keywords = parse_keywords(body.keywords)
+    country = (body.country_code or "WW").upper().strip()
+    exclude_emails, exclude_users = await _exclude_sets(pool)
+
+    run_id = uuid.uuid4()
+    await pool.execute(
+        """
+        INSERT INTO developer_lead_runs (
+            run_id, keywords, country_code, status, started_at
+        ) VALUES ($1, $2, $3, 'running', NOW())
+        """,
+        run_id,
+        ",".join(keywords),
+        country,
+    )
+
+    try:
+        candidates, meta = await find_public_leads(
+            keywords=keywords,
+            country_code=country,
+            exclude_emails=exclude_emails,
+            exclude_usernames=exclude_users,
+            limit=remaining,
+        )
+    except RuntimeError as exc:
+        await pool.execute(
+            """
+            UPDATE developer_lead_runs
+            SET status = 'failed', error = $2, finished_at = NOW()
+            WHERE run_id = $1
+            """,
+            run_id,
+            str(exc)[:500],
+        )
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        log.exception("leads find failed")
+        await pool.execute(
+            """
+            UPDATE developer_lead_runs
+            SET status = 'failed', error = $2, finished_at = NOW()
+            WHERE run_id = $1
+            """,
+            run_id,
+            str(exc)[:500],
+        )
+        raise HTTPException(status_code=500, detail=f"Lead search failed: {exc}") from exc
+
+    inserted = 0
+    for c in candidates:
+        try:
+            row = await pool.fetchrow(
+                """
+                INSERT INTO developer_leads (
+                    lead_id, email, name, github_username, profile_url, bio, location,
+                    country_code, matched_keyword, matched_repo, signal, match_reason,
+                    status, run_id
+                ) VALUES (
+                    $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,'new',$13
+                )
+                ON CONFLICT ((LOWER(email))) DO NOTHING
+                RETURNING lead_id
+                """,
+                uuid.uuid4(),
+                c.email,
+                c.name,
+                c.github_username,
+                c.profile_url,
+                c.bio,
+                c.location,
+                country,
+                c.matched_keyword,
+                c.matched_repo,
+                c.signal,
+                c.match_reason,
+                run_id,
+            )
+            if row:
+                inserted += 1
+        except Exception:
+            log.exception("failed inserting lead %s", c.email)
+
+    await pool.execute(
+        """
+        UPDATE developer_lead_runs
+        SET status = 'done',
+            found_count = $2,
+            inserted_count = $3,
+            meta = $4::jsonb,
+            finished_at = NOW()
+        WHERE run_id = $1
+        """,
+        run_id,
+        len(candidates),
+        inserted,
+        json.dumps(meta),
+    )
+
+    return {
+        "run_id": str(run_id),
+        "found": len(candidates),
+        "inserted": inserted,
+        "remaining_today": max(0, remaining - inserted),
+        "meta": meta,
+    }
+
+
+@admin_router.patch("/leads/{lead_id}")
+async def update_lead_status(
+    lead_id: str,
+    body: LeadStatusUpdate,
+    _: dict = Depends(require_admin),
+):
+    try:
+        lid = uuid.UUID(lead_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail="Not found") from exc
+
+    pool = get_pool()
+    row = await pool.fetchrow(
+        """
+        UPDATE developer_leads
+        SET status = $2, updated_at = NOW()
+        WHERE lead_id = $1
+        RETURNING lead_id, email, name, status
+        """,
+        lid,
+        body.status,
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Not found")
+    return {
+        "lead_id": str(row["lead_id"]),
+        "email": row["email"],
+        "name": row["name"],
+        "status": row["status"],
+    }

--- a/core/db/connection.py
+++ b/core/db/connection.py
@@ -221,6 +221,47 @@ async def init_db():
             ADD COLUMN IF NOT EXISTS discord_cta_url TEXT;
     """)
 
+    # Developer Leads (GitHub public-email discovery)
+    await _pg_pool.execute("""
+        CREATE TABLE IF NOT EXISTS developer_lead_runs (
+            run_id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            keywords        TEXT NOT NULL,
+            country_code    VARCHAR(8) NOT NULL DEFAULT 'WW',
+            status          VARCHAR(32) NOT NULL DEFAULT 'running',
+            found_count     INTEGER NOT NULL DEFAULT 0,
+            inserted_count  INTEGER NOT NULL DEFAULT 0,
+            meta            JSONB,
+            error           TEXT,
+            started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            finished_at     TIMESTAMPTZ
+        );
+
+        CREATE TABLE IF NOT EXISTS developer_leads (
+            lead_id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            email             VARCHAR(255) NOT NULL,
+            name              VARCHAR(255),
+            github_username   VARCHAR(120),
+            profile_url       TEXT,
+            bio               TEXT,
+            location          TEXT,
+            country_code      VARCHAR(8) NOT NULL DEFAULT 'WW',
+            matched_keyword   VARCHAR(80),
+            matched_repo      TEXT,
+            signal            VARCHAR(32),
+            match_reason      TEXT,
+            status            VARCHAR(32) NOT NULL DEFAULT 'new',
+            run_id            UUID REFERENCES developer_lead_runs(run_id),
+            created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_developer_leads_email
+            ON developer_leads (LOWER(email));
+        CREATE INDEX IF NOT EXISTS idx_developer_leads_created
+            ON developer_leads (created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_developer_leads_status
+            ON developer_leads (status, created_at DESC);
+    """)
+
     _redis = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379"))
     logger.info("Redis connected")
 

--- a/core/db/migrations/010_developer_leads.sql
+++ b/core/db/migrations/010_developer_leads.sql
@@ -1,0 +1,38 @@
+-- Developer Leads: GitHub public-email discovery for admin outreach
+CREATE TABLE IF NOT EXISTS developer_lead_runs (
+    run_id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    keywords        TEXT NOT NULL,
+    country_code    VARCHAR(8) NOT NULL DEFAULT 'WW',
+    status          VARCHAR(32) NOT NULL DEFAULT 'running',
+    found_count     INTEGER NOT NULL DEFAULT 0,
+    inserted_count  INTEGER NOT NULL DEFAULT 0,
+    meta            JSONB,
+    error           TEXT,
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at     TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS developer_leads (
+    lead_id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email             VARCHAR(255) NOT NULL,
+    name              VARCHAR(255),
+    github_username   VARCHAR(120),
+    profile_url       TEXT,
+    bio               TEXT,
+    location          TEXT,
+    country_code      VARCHAR(8) NOT NULL DEFAULT 'WW',
+    matched_keyword   VARCHAR(80),
+    matched_repo      TEXT,
+    signal            VARCHAR(32),
+    match_reason      TEXT,
+    status            VARCHAR(32) NOT NULL DEFAULT 'new',
+    run_id            UUID REFERENCES developer_lead_runs(run_id),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_developer_leads_email
+    ON developer_leads (LOWER(email));
+CREATE INDEX IF NOT EXISTS idx_developer_leads_created
+    ON developer_leads (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_developer_leads_status
+    ON developer_leads (status, created_at DESC);

--- a/core/db/schema.sql
+++ b/core/db/schema.sql
@@ -263,3 +263,44 @@ CREATE TABLE IF NOT EXISTS email_outreach_opens (
 );
 CREATE INDEX IF NOT EXISTS idx_email_outreach_opens_send
     ON email_outreach_opens (send_id, opened_at DESC);
+
+-- ─────────────────────────────────────────
+-- DEVELOPER LEADS (GitHub public-email discovery)
+-- ─────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS developer_lead_runs (
+    run_id          UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    keywords        TEXT NOT NULL,
+    country_code    VARCHAR(8) NOT NULL DEFAULT 'WW',
+    status          VARCHAR(32) NOT NULL DEFAULT 'running',
+    found_count     INTEGER NOT NULL DEFAULT 0,
+    inserted_count  INTEGER NOT NULL DEFAULT 0,
+    meta            JSONB,
+    error           TEXT,
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    finished_at     TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS developer_leads (
+    lead_id           UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email             VARCHAR(255) NOT NULL,
+    name              VARCHAR(255),
+    github_username   VARCHAR(120),
+    profile_url       TEXT,
+    bio               TEXT,
+    location          TEXT,
+    country_code      VARCHAR(8) NOT NULL DEFAULT 'WW',
+    matched_keyword   VARCHAR(80),
+    matched_repo      TEXT,
+    signal            VARCHAR(32),
+    match_reason      TEXT,
+    status            VARCHAR(32) NOT NULL DEFAULT 'new',
+    run_id            UUID REFERENCES developer_lead_runs(run_id),
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_developer_leads_email
+    ON developer_leads (LOWER(email));
+CREATE INDEX IF NOT EXISTS idx_developer_leads_created
+    ON developer_leads (created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_developer_leads_status
+    ON developer_leads (status, created_at DESC);

--- a/core/main.py
+++ b/core/main.py
@@ -17,6 +17,7 @@ from api.telemetry import router as telemetry_router
 from api.admin import router as admin_router
 from api.outreach import admin_router as outreach_admin_router
 from api.outreach import public_router as outreach_public_router
+from api.developer_leads import admin_router as leads_admin_router
 from api.stats import router as stats_router
 from api.billing_checkout import router as billing_checkout_router
 from api.community import router as community_router
@@ -111,6 +112,7 @@ app.include_router(memory_router,    prefix="/v1/memory",    tags=["memory"])
 app.include_router(telemetry_router, prefix="/v1/telemetry", tags=["telemetry"])
 app.include_router(admin_router,     prefix="/v1/admin",     include_in_schema=False)
 app.include_router(outreach_admin_router, prefix="/v1/admin", include_in_schema=False)
+app.include_router(leads_admin_router, prefix="/v1/admin", include_in_schema=False)
 app.include_router(outreach_public_router, prefix="/v1/outreach", tags=["outreach"])
 app.include_router(stats_router,     prefix="/v1/stats",     tags=["stats"])
 app.include_router(billing_checkout_router, prefix="/v1/billing", tags=["billing"])

--- a/core/services/github_leads.py
+++ b/core/services/github_leads.py
@@ -1,0 +1,267 @@
+"""
+GitHub Developer Leads finder.
+
+Finds public emails for developers who starred or contributed to repos
+matching interest keywords. Geography via profile location. Hard cap 100/day.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+import httpx
+
+from services.leads_countries import location_matches_country
+
+log = logging.getLogger(__name__)
+
+DEFAULT_KEYWORDS = "agent,agents,mcp,langchain,crewai,llm"
+DAILY_LEAD_LIMIT = int(os.getenv("LEADS_DAILY_LIMIT", "100"))
+GITHUB_API = "https://api.github.com"
+
+
+@dataclass
+class LeadCandidate:
+    github_username: str
+    email: str
+    name: Optional[str]
+    bio: Optional[str]
+    location: Optional[str]
+    profile_url: str
+    match_reason: str
+    matched_keyword: str
+    matched_repo: Optional[str]
+    signal: str  # star | contribution
+
+
+def github_token() -> Optional[str]:
+    return (os.getenv("GITHUB_LEADS_TOKEN") or os.getenv("GITHUB_TOKEN") or "").strip() or None
+
+
+def parse_keywords(raw: str) -> list[str]:
+    parts = re.split(r"[,;\s]+", (raw or "").strip().lower())
+    out: list[str] = []
+    seen: set[str] = set()
+    for p in parts:
+        p = p.strip()
+        if not p or p in seen:
+            continue
+        seen.add(p)
+        out.append(p)
+    return out or parse_keywords(DEFAULT_KEYWORDS)
+
+
+class GitHubLeadsClient:
+    def __init__(self, token: str):
+        self.token = token
+        self._client: Optional[httpx.AsyncClient] = None
+
+    async def __aenter__(self) -> "GitHubLeadsClient":
+        self._client = httpx.AsyncClient(
+            base_url=GITHUB_API,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "ZizkaDB-DeveloperLeads",
+            },
+            timeout=30.0,
+        )
+        return self
+
+    async def __aexit__(self, *args) -> None:
+        if self._client:
+            await self._client.aclose()
+
+    async def _get(self, path: str, params: Optional[dict] = None) -> httpx.Response:
+        assert self._client
+        # gentle pacing for search / core API
+        await asyncio.sleep(0.35)
+        resp = await self._client.get(path, params=params or {})
+        if resp.status_code == 403 and "rate limit" in resp.text.lower():
+            raise RuntimeError("GitHub API rate limit hit. Try again later.")
+        if resp.status_code == 401:
+            raise RuntimeError("GitHub token invalid. Check GITHUB_LEADS_TOKEN.")
+        resp.raise_for_status()
+        return resp
+
+    async def search_repos(self, keyword: str, per_page: int = 5) -> list[dict]:
+        # Prefer topic match, fall back to text search
+        queries = [
+            f"topic:{keyword} stars:>20",
+            f"{keyword} in:name,description,topics stars:>50",
+        ]
+        repos: list[dict] = []
+        seen: set[str] = set()
+        for q in queries:
+            try:
+                resp = await self._get(
+                    "/search/repositories",
+                    {"q": q, "sort": "stars", "order": "desc", "per_page": per_page},
+                )
+            except httpx.HTTPStatusError as exc:
+                if exc.response is not None and exc.response.status_code == 422:
+                    continue
+                raise
+            for item in resp.json().get("items") or []:
+                full = item.get("full_name")
+                if full and full not in seen:
+                    seen.add(full)
+                    repos.append(item)
+            if len(repos) >= per_page:
+                break
+        return repos[:per_page]
+
+    async def repo_contributors(self, full_name: str, per_page: int = 30) -> list[str]:
+        owner, repo = full_name.split("/", 1)
+        try:
+            resp = await self._get(
+                f"/repos/{owner}/{repo}/contributors",
+                {"per_page": per_page, "anon": "false"},
+            )
+        except httpx.HTTPStatusError:
+            return []
+        logins = []
+        for u in resp.json() or []:
+            login = u.get("login")
+            if login and u.get("type") == "User":
+                logins.append(login)
+        return logins
+
+    async def repo_stargazers(self, full_name: str, per_page: int = 30) -> list[str]:
+        owner, repo = full_name.split("/", 1)
+        assert self._client
+        await asyncio.sleep(0.35)
+        resp = await self._client.get(
+            f"/repos/{owner}/{repo}/stargazers",
+            params={"per_page": per_page},
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github.star+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "ZizkaDB-DeveloperLeads",
+            },
+        )
+        if resp.status_code >= 400:
+            return []
+        logins = []
+        for row in resp.json() or []:
+            user = row.get("user") if isinstance(row, dict) and "user" in row else row
+            if not isinstance(user, dict):
+                continue
+            login = user.get("login")
+            if login and user.get("type", "User") == "User":
+                logins.append(login)
+        return logins
+
+    async def get_user(self, login: str) -> Optional[dict]:
+        try:
+            resp = await self._get(f"/users/{login}")
+        except httpx.HTTPStatusError:
+            return None
+        return resp.json()
+
+
+async def find_public_leads(
+    *,
+    keywords: list[str],
+    country_code: str,
+    exclude_emails: set[str],
+    exclude_usernames: set[str],
+    limit: int,
+) -> tuple[list[LeadCandidate], dict]:
+    """
+    Discover up to `limit` new public-email leads.
+    Returns (candidates, meta).
+    """
+    token = github_token()
+    if not token:
+        raise RuntimeError(
+            "GITHUB_LEADS_TOKEN is not set. Add a read-only GitHub token on the API host."
+        )
+    if limit <= 0:
+        return [], {"repos_scanned": 0, "users_checked": 0, "skipped_no_email": 0}
+
+    found: list[LeadCandidate] = []
+    seen_emails = {e.lower() for e in exclude_emails}
+    seen_users = {u.lower() for u in exclude_usernames}
+    queued_users: dict[str, tuple[str, str, str]] = {}  # login -> (signal, keyword, repo)
+
+    repos_scanned = 0
+    users_checked = 0
+    skipped_no_email = 0
+
+    async with GitHubLeadsClient(token) as gh:
+        for kw in keywords:
+            if len(found) >= limit:
+                break
+            repos = await gh.search_repos(kw, per_page=4)
+            for repo in repos:
+                if len(found) >= limit:
+                    break
+                full = repo.get("full_name")
+                if not full:
+                    continue
+                repos_scanned += 1
+                contributors = await gh.repo_contributors(full, per_page=25)
+                for login in contributors:
+                    key = login.lower()
+                    if key not in seen_users and key not in queued_users:
+                        queued_users[key] = ("contribution", kw, full)
+                stargazers = await gh.repo_stargazers(full, per_page=25)
+                for login in stargazers:
+                    key = login.lower()
+                    if key not in seen_users and key not in queued_users:
+                        queued_users[key] = ("star", kw, full)
+
+        # Process queued users until we hit limit
+        for login_key, (signal, kw, repo) in list(queued_users.items()):
+            if len(found) >= limit:
+                break
+            if login_key in seen_users:
+                continue
+            user = await gh.get_user(login_key)
+            users_checked += 1
+            if not user:
+                continue
+            email = (user.get("email") or "").strip()
+            if not email or "@" not in email:
+                skipped_no_email += 1
+                continue
+            email_l = email.lower()
+            if email_l in seen_emails:
+                continue
+            if not location_matches_country(user.get("location"), country_code):
+                continue
+
+            login = user.get("login") or login_key
+            found.append(
+                LeadCandidate(
+                    github_username=login,
+                    email=email_l,
+                    name=(user.get("name") or "").strip() or None,
+                    bio=(user.get("bio") or "").strip() or None,
+                    location=(user.get("location") or "").strip() or None,
+                    profile_url=user.get("html_url") or f"https://github.com/{login}",
+                    match_reason=f"{signal} on {repo} (keyword: {kw})",
+                    matched_keyword=kw,
+                    matched_repo=repo,
+                    signal=signal,
+                )
+            )
+            seen_emails.add(email_l)
+            seen_users.add(login.lower())
+
+    meta = {
+        "repos_scanned": repos_scanned,
+        "users_checked": users_checked,
+        "skipped_no_email": skipped_no_email,
+        "queued_users": len(queued_users),
+        "found": len(found),
+    }
+    return found, meta

--- a/core/services/leads_countries.py
+++ b/core/services/leads_countries.py
@@ -1,0 +1,78 @@
+"""Country list for Developer Leads geography filter."""
+
+from __future__ import annotations
+
+# (iso2, display_name, match_aliases) — aliases match GitHub profile location (case-insensitive contains)
+COUNTRIES: list[tuple[str, str, tuple[str, ...]]] = [
+    ("WW", "Worldwide", ()),
+    ("US", "United States", ("united states", "usa", "u.s.", "america")),
+    ("GB", "United Kingdom", ("united kingdom", "uk", "england", "scotland", "wales", "britain")),
+    ("DE", "Germany", ("germany", "deutschland")),
+    ("FR", "France", ("france")),
+    ("ES", "Spain", ("spain", "españa", "espana")),
+    ("IT", "Italy", ("italy", "italia")),
+    ("NL", "Netherlands", ("netherlands", "holland")),
+    ("BE", "Belgium", ("belgium")),
+    ("PT", "Portugal", ("portugal")),
+    ("PL", "Poland", ("poland")),
+    ("SE", "Sweden", ("sweden")),
+    ("NO", "Norway", ("norway")),
+    ("DK", "Denmark", ("denmark")),
+    ("FI", "Finland", ("finland")),
+    ("IE", "Ireland", ("ireland")),
+    ("CH", "Switzerland", ("switzerland")),
+    ("AT", "Austria", ("austria")),
+    ("CA", "Canada", ("canada")),
+    ("MX", "Mexico", ("mexico")),
+    ("BR", "Brazil", ("brazil", "brasil")),
+    ("AR", "Argentina", ("argentina")),
+    ("IN", "India", ("india")),
+    ("PK", "Pakistan", ("pakistan")),
+    ("BD", "Bangladesh", ("bangladesh")),
+    ("CN", "China", ("china")),
+    ("JP", "Japan", ("japan")),
+    ("KR", "South Korea", ("south korea", "korea")),
+    ("SG", "Singapore", ("singapore")),
+    ("AU", "Australia", ("australia")),
+    ("NZ", "New Zealand", ("new zealand")),
+    ("IL", "Israel", ("israel")),
+    ("AE", "United Arab Emirates", ("uae", "dubai", "abu dhabi")),
+    ("SA", "Saudi Arabia", ("saudi")),
+    ("ZA", "South Africa", ("south africa")),
+    ("NG", "Nigeria", ("nigeria")),
+    ("KE", "Kenya", ("kenya")),
+    ("EG", "Egypt", ("egypt")),
+    ("TR", "Turkey", ("turkey", "türkiye", "turkiye")),
+    ("UA", "Ukraine", ("ukraine")),
+    ("RU", "Russia", ("russia")),
+    ("CZ", "Czechia", ("czech", "prague")),
+    ("RO", "Romania", ("romania")),
+    ("HU", "Hungary", ("hungary")),
+    ("GR", "Greece", ("greece")),
+    ("ID", "Indonesia", ("indonesia")),
+    ("TH", "Thailand", ("thailand")),
+    ("VN", "Vietnam", ("vietnam")),
+    ("PH", "Philippines", ("philippines")),
+    ("MY", "Malaysia", ("malaysia")),
+    ("TW", "Taiwan", ("taiwan")),
+    ("HK", "Hong Kong", ("hong kong")),
+]
+
+
+def countries_for_api() -> list[dict]:
+    return [{"code": code, "name": name} for code, name, _ in COUNTRIES]
+
+
+def location_matches_country(location: str | None, country_code: str) -> bool:
+    if not country_code or country_code.upper() == "WW":
+        return True
+    if not location or not location.strip():
+        return False
+    loc = location.strip().lower()
+    for code, _name, aliases in COUNTRIES:
+        if code == country_code.upper():
+            if any(a in loc for a in aliases):
+                return True
+            # also match display name tokens
+            return False
+    return False

--- a/core/tests/test_developer_leads_filters.py
+++ b/core/tests/test_developer_leads_filters.py
@@ -1,0 +1,18 @@
+from services.github_leads import parse_keywords
+from services.leads_countries import location_matches_country
+
+
+def test_parse_keywords_defaultish():
+    assert "mcp" in parse_keywords("agent, mcp, langchain")
+    assert parse_keywords("")  # falls back to defaults
+
+
+def test_location_worldwide():
+    assert location_matches_country(None, "WW")
+    assert location_matches_country("anywhere", "WW")
+
+
+def test_location_spain():
+    assert location_matches_country("Málaga, Spain", "ES")
+    assert location_matches_country("Berlin, Germany", "ES") is False
+    assert location_matches_country("somewhere in spain", "ES")

--- a/dashboard/app/admin/page.tsx
+++ b/dashboard/app/admin/page.tsx
@@ -19,9 +19,10 @@ import { format, formatDistanceToNow } from 'date-fns'
 import { setAdminToken, clearAdminToken, getAdminToken } from "@/lib/auth";
 import { FOUNDER_EMAIL, POLL_INTERVAL_MS, OTP_LENGTH } from "@/lib/constants";
 import { EmailOutreachSection } from "@/components/admin/EmailOutreachSection";
+import { DeveloperLeadsSection } from "@/components/admin/DeveloperLeadsSection";
 
 
-type Section = 'subscribers' | 'managed' | 'telemetry' | 'demo_requests' | 'marketing_subscriptions' | 'outreach'
+type Section = 'subscribers' | 'managed' | 'telemetry' | 'demo_requests' | 'marketing_subscriptions' | 'outreach' | 'leads'
 
 interface Overview {
   telemetry: { total_installs?: number; active_7d?: number; active_24h?: number; total_pings?: number }
@@ -509,6 +510,7 @@ function Dashboard({
             { key: 'demo_requests', label: 'Demo requests' },
             { key: 'marketing_subscriptions', label: 'Marketing Material Subscriptions' },
             { key: 'outreach', label: 'Email Outreach' },
+            { key: 'leads', label: 'Developer Leads' },
           ] as { key: Section; label: string }[]).map((t) => (
             <button key={t.key} onClick={() => setSection(t.key)}
                     style={{
@@ -544,6 +546,12 @@ function Dashboard({
         {section === 'demo_requests' && <DemoRequestsSection token={token} />}
         {section === 'marketing_subscriptions' && <MarketingSubscriptionsSection token={token} />}
         {section === 'outreach' && <EmailOutreachSection token={token} />}
+        {section === 'leads' && (
+          <DeveloperLeadsSection
+            token={token}
+            onOpenOutreach={() => setSection('outreach')}
+          />
+        )}
       </div>
     </div>
   );

--- a/dashboard/components/admin/DeveloperLeadsSection.tsx
+++ b/dashboard/components/admin/DeveloperLeadsSection.tsx
@@ -120,7 +120,7 @@ export function DeveloperLeadsSection({
     }
   };
 
-  const useInOutreach = (lead: DeveloperLead) => {
+  const openInOutreach = (lead: DeveloperLead) => {
     try {
       sessionStorage.setItem(
         "outreach_prefill",
@@ -312,7 +312,7 @@ export function DeveloperLeadsSection({
                     </td>
                     <td style={{ ...td, textAlign: "right" }}>
                       <div style={{ display: "inline-flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
-                        <button type="button" style={btnTiny()} onClick={() => useInOutreach(l)}>
+                        <button type="button" style={btnTiny()} onClick={() => openInOutreach(l)}>
                           Use in Outreach
                         </button>
                         {l.status !== "approved" && (

--- a/dashboard/components/admin/DeveloperLeadsSection.tsx
+++ b/dashboard/components/admin/DeveloperLeadsSection.tsx
@@ -1,0 +1,442 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import {
+  adminLeadsCountries,
+  adminLeadsFind,
+  adminLeadsList,
+  adminLeadsStats,
+  adminLeadsUpdateStatus,
+  type DeveloperLead,
+  type LeadsStats,
+} from "@/lib/api";
+
+const inputStyle: React.CSSProperties = {
+  width: "100%",
+  padding: "10px 12px",
+  background: "#0a0a0a",
+  border: "1px solid #2a2a2a",
+  borderRadius: 8,
+  color: "#fff",
+  fontSize: 13,
+  outline: "none",
+  boxSizing: "border-box",
+};
+
+const labelStyle: React.CSSProperties = {
+  display: "block",
+  fontSize: 11,
+  color: "#737373",
+  textTransform: "uppercase",
+  letterSpacing: 0.8,
+  marginBottom: 6,
+};
+
+function fmt(n?: number | null) {
+  if (n == null) return "—";
+  return n.toLocaleString();
+}
+
+export function DeveloperLeadsSection({
+  token,
+  onOpenOutreach,
+}: {
+  token: string;
+  onOpenOutreach?: (email: string, name?: string | null) => void;
+}) {
+  const [stats, setStats] = useState<LeadsStats | null>(null);
+  const [leads, setLeads] = useState<DeveloperLead[] | null>(null);
+  const [countries, setCountries] = useState<{ code: string; name: string }[]>([]);
+  const [keywords, setKeywords] = useState(
+    "agent,agents,mcp,langchain,crewai,llm",
+  );
+  const [countryCode, setCountryCode] = useState("WW");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [search, setSearch] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    adminLeadsStats(token)
+      .then((s) => {
+        setStats(s);
+        setKeywords((prev) => (prev ? prev : s.default_keywords));
+      })
+      .catch(() => setStats(null));
+    adminLeadsList(token, {
+      status: statusFilter || undefined,
+      search: search || undefined,
+      limit: 200,
+    })
+      .then(setLeads)
+      .catch(() => setLeads([]));
+  }, [token, statusFilter, search]);
+
+  useEffect(() => {
+    adminLeadsCountries(token)
+      .then(setCountries)
+      .catch(() => setCountries([{ code: "WW", name: "Worldwide" }]));
+  }, [token]);
+
+  useEffect(() => {
+    refresh();
+    const id = setInterval(refresh, 20_000);
+    return () => clearInterval(id);
+  }, [refresh]);
+
+  const onFind = async () => {
+    setErr(null);
+    setMsg(null);
+    if (!window.confirm(
+      `Find up to ${stats?.remaining_today ?? 100} public GitHub emails for today?\n\nKeywords: ${keywords}\nCountry: ${countryCode}`,
+    )) {
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await adminLeadsFind(token, {
+        keywords,
+        country_code: countryCode,
+      });
+      setMsg(
+        `Found ${res.found} candidates, imported ${res.inserted} new leads. Remaining today: ${res.remaining_today}.`,
+      );
+      refresh();
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Find failed");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const setStatus = async (leadId: string, status: string) => {
+    try {
+      await adminLeadsUpdateStatus(token, leadId, status);
+      refresh();
+    } catch (e: unknown) {
+      setErr(e instanceof Error ? e.message : "Update failed");
+    }
+  };
+
+  const useInOutreach = (lead: DeveloperLead) => {
+    try {
+      sessionStorage.setItem(
+        "outreach_prefill",
+        JSON.stringify({
+          email: lead.email,
+          name: lead.name || lead.github_username || "",
+        }),
+      );
+    } catch {
+      /* ignore */
+    }
+    void setStatus(lead.lead_id, "approved");
+    onOpenOutreach?.(lead.email, lead.name || lead.github_username);
+  };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <div style={{ display: "grid", gridTemplateColumns: "repeat(5, 1fr)", gap: 12 }}>
+        <MiniStat
+          label="Imported today"
+          value={`${fmt(stats?.imported_today)} / ${fmt(stats?.daily_limit)}`}
+          sub={`${fmt(stats?.remaining_today)} remaining`}
+          accent="#22c55e"
+        />
+        <MiniStat label="Total leads" value={fmt(stats?.total)} sub="all time" />
+        <MiniStat label="New" value={fmt(stats?.status_new)} sub="awaiting review" accent="#38bdf8" />
+        <MiniStat label="Approved" value={fmt(stats?.approved)} sub="ready to email" />
+        <MiniStat
+          label="GitHub token"
+          value={stats?.token_configured ? "Configured" : "Missing"}
+          sub="GITHUB_LEADS_TOKEN"
+          accent={stats?.token_configured ? "#22c55e" : "#f87171"}
+        />
+      </div>
+
+      {(err || msg) && (
+        <div
+          style={{
+            padding: "10px 14px",
+            borderRadius: 8,
+            fontSize: 13,
+            background: err ? "#1a0000" : "#052e16",
+            border: `1px solid ${err ? "#ef444440" : "#22c55e40"}`,
+            color: err ? "#f87171" : "#86efac",
+          }}
+        >
+          {err || msg}
+        </div>
+      )}
+
+      <div
+        style={{
+          background: "#111",
+          border: "1px solid #1f1f1f",
+          borderRadius: 14,
+          padding: "20px 22px",
+        }}
+      >
+        <div style={{ fontSize: 15, fontWeight: 600, color: "#fff", marginBottom: 4 }}>
+          Find today&apos;s leads
+        </div>
+        <div style={{ fontSize: 12, color: "#737373", marginBottom: 16 }}>
+          Manual only. Finds developers who starred or contributed to keyword repos and have a{" "}
+          <strong style={{ color: "#a3a3a3" }}>public</strong> GitHub email. Dedupes past leads +
+          outreach. Cap {stats?.daily_limit ?? 100}/day.
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "1.4fr 0.8fr auto", gap: 12, alignItems: "end" }}>
+          <label style={{ display: "block" }}>
+            <span style={labelStyle}>Keywords</span>
+            <input
+              value={keywords}
+              onChange={(e) => setKeywords(e.target.value)}
+              style={inputStyle}
+              placeholder="agent,agents,mcp,langchain,crewai,llm"
+            />
+          </label>
+          <label style={{ display: "block" }}>
+            <span style={labelStyle}>Country</span>
+            <select
+              value={countryCode}
+              onChange={(e) => setCountryCode(e.target.value)}
+              style={{ ...inputStyle, appearance: "auto" as const }}
+            >
+              {countries.map((c) => (
+                <option key={c.code} value={c.code}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <button type="button" onClick={onFind} disabled={busy} style={btnStyle(true)}>
+            {busy ? "Searching GitHub…" : "Find today's leads"}
+          </button>
+        </div>
+      </div>
+
+      <div
+        style={{
+          background: "#111",
+          border: "1px solid #1f1f1f",
+          borderRadius: 14,
+          padding: "20px 22px",
+        }}
+      >
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 14, alignItems: "center" }}>
+          <input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && refresh()}
+            placeholder="Search email, user, location…"
+            style={{ ...inputStyle, flex: "1 1 220px" }}
+          />
+          <select
+            value={statusFilter}
+            onChange={(e) => setStatusFilter(e.target.value)}
+            style={{ ...inputStyle, width: 160, appearance: "auto" as const }}
+          >
+            <option value="">All statuses</option>
+            <option value="new">New</option>
+            <option value="approved">Approved</option>
+            <option value="rejected">Rejected</option>
+            <option value="contacted">Contacted</option>
+          </select>
+          <button type="button" onClick={refresh} style={btnStyle(false)}>
+            Refresh
+          </button>
+        </div>
+
+        {!leads ? (
+          <div style={{ color: "#525252", fontSize: 13 }}>Loading…</div>
+        ) : leads.length === 0 ? (
+          <div style={{ color: "#525252", fontSize: 13 }}>
+            No leads yet. Run Find today&apos;s leads.
+          </div>
+        ) : (
+          <div style={{ overflowX: "auto" }}>
+            <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13, minWidth: 980 }}>
+              <thead>
+                <tr
+                  style={{
+                    borderBottom: "1px solid #1f1f1f",
+                    color: "#737373",
+                    fontSize: 11,
+                    textTransform: "uppercase",
+                  }}
+                >
+                  <th style={th}>Email</th>
+                  <th style={th}>GitHub</th>
+                  <th style={th}>Location</th>
+                  <th style={th}>Match</th>
+                  <th style={th}>Status</th>
+                  <th style={{ ...th, textAlign: "right" }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {leads.map((l) => (
+                  <tr key={l.lead_id} style={{ borderBottom: "1px solid #161616" }}>
+                    <td style={tdMono}>
+                      {l.email}
+                      {l.name ? (
+                        <div style={{ fontSize: 11, color: "#737373" }}>{l.name}</div>
+                      ) : null}
+                    </td>
+                    <td style={td}>
+                      <a
+                        href={l.profile_url || `https://github.com/${l.github_username}`}
+                        target="_blank"
+                        rel="noreferrer"
+                        style={{ color: "#86efac" }}
+                      >
+                        @{l.github_username}
+                      </a>
+                      <div style={{ fontSize: 11, color: "#525252" }}>
+                        {l.created_at
+                          ? formatDistanceToNow(new Date(l.created_at), { addSuffix: true })
+                          : ""}
+                      </div>
+                    </td>
+                    <td style={{ ...td, color: "#a3a3a3" }}>{l.location || "—"}</td>
+                    <td style={td}>
+                      <span style={{ color: "#d4d4d4" }}>{l.signal}</span>
+                      <div style={{ fontSize: 11, color: "#737373", maxWidth: 220 }}>
+                        {l.match_reason || l.matched_repo || l.matched_keyword}
+                      </div>
+                    </td>
+                    <td style={td}>
+                      <StatusTag status={l.status} />
+                    </td>
+                    <td style={{ ...td, textAlign: "right" }}>
+                      <div style={{ display: "inline-flex", gap: 6, flexWrap: "wrap", justifyContent: "flex-end" }}>
+                        <button type="button" style={btnTiny()} onClick={() => useInOutreach(l)}>
+                          Use in Outreach
+                        </button>
+                        {l.status !== "approved" && (
+                          <button type="button" style={btnTiny()} onClick={() => setStatus(l.lead_id, "approved")}>
+                            Approve
+                          </button>
+                        )}
+                        {l.status !== "rejected" && (
+                          <button type="button" style={btnTiny()} onClick={() => setStatus(l.lead_id, "rejected")}>
+                            Reject
+                          </button>
+                        )}
+                        {l.status !== "contacted" && (
+                          <button type="button" style={btnTiny()} onClick={() => setStatus(l.lead_id, "contacted")}>
+                            Mark contacted
+                          </button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusTag({ status }: { status: string }) {
+  const color =
+    status === "approved"
+      ? "#22c55e"
+      : status === "rejected"
+        ? "#f87171"
+        : status === "contacted"
+          ? "#38bdf8"
+          : "#a3a3a3";
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        padding: "2px 8px",
+        borderRadius: 4,
+        background: `${color}20`,
+        color,
+        fontWeight: 500,
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
+function MiniStat({
+  label,
+  value,
+  sub,
+  accent,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  accent?: string;
+}) {
+  return (
+    <div
+      style={{
+        background: "#111",
+        border: "1px solid #1f1f1f",
+        borderRadius: 12,
+        padding: "14px 16px",
+      }}
+    >
+      <div style={{ fontSize: 11, color: "#737373", textTransform: "uppercase", letterSpacing: 0.8 }}>
+        {label}
+      </div>
+      <div style={{ fontSize: 18, fontWeight: 600, color: accent || "#fff", marginTop: 6 }}>{value}</div>
+      <div style={{ fontSize: 11, color: "#525252", marginTop: 4 }}>{sub}</div>
+    </div>
+  );
+}
+
+function btnStyle(primary: boolean): React.CSSProperties {
+  return {
+    padding: "10px 16px",
+    borderRadius: 8,
+    border: primary ? "none" : "1px solid #2a2a2a",
+    background: primary ? "#22c55e" : "#0a0a0a",
+    color: primary ? "#0a0a0a" : "#d4d4d4",
+    fontSize: 13,
+    fontWeight: 600,
+    cursor: "pointer",
+    whiteSpace: "nowrap",
+  };
+}
+
+function btnTiny(): React.CSSProperties {
+  return {
+    padding: "4px 8px",
+    borderRadius: 6,
+    border: "1px solid #2a2a2a",
+    background: "#0a0a0a",
+    color: "#d4d4d4",
+    fontSize: 11,
+    cursor: "pointer",
+  };
+}
+
+const th: React.CSSProperties = {
+  padding: "10px 12px",
+  textAlign: "left",
+  fontWeight: 600,
+  letterSpacing: 0.8,
+};
+
+const td: React.CSSProperties = {
+  padding: "10px 12px",
+  color: "#d4d4d4",
+  verticalAlign: "top",
+};
+
+const tdMono: React.CSSProperties = {
+  ...td,
+  fontFamily: "JetBrains Mono, monospace",
+};

--- a/dashboard/components/admin/EmailOutreachSection.tsx
+++ b/dashboard/components/admin/EmailOutreachSection.tsx
@@ -76,6 +76,20 @@ export function EmailOutreachSection({ token }: { token: string }) {
   const [msg, setMsg] = useState<string | null>(null);
   const [err, setErr] = useState<string | null>(null);
 
+  useEffect(() => {
+    try {
+      const raw = sessionStorage.getItem("outreach_prefill");
+      if (!raw) return;
+      const data = JSON.parse(raw) as { email?: string; name?: string };
+      if (data.email) setToEmail(data.email);
+      if (data.name) setRecipientName(data.name);
+      sessionStorage.removeItem("outreach_prefill");
+      setMsg(`Prefilled from Developer Leads: ${data.email || ""}`);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+
   const refresh = useCallback(() => {
     adminOutreachStats(token)
       .then(setStats)

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -565,6 +565,85 @@ export async function adminOutreachSend(
   })
 }
 
+// ── Admin developer leads ─────────────────────────────────────────────────────
+
+export interface LeadsStats {
+  imported_today: number
+  daily_limit: number
+  remaining_today: number
+  total: number
+  status_new: number
+  approved: number
+  rejected: number
+  contacted: number
+  token_configured: boolean
+  default_keywords: string
+}
+
+export interface DeveloperLead {
+  lead_id: string
+  email: string
+  name: string | null
+  github_username: string | null
+  profile_url: string | null
+  bio: string | null
+  location: string | null
+  country_code: string
+  matched_keyword: string | null
+  matched_repo: string | null
+  signal: string | null
+  match_reason: string | null
+  status: string
+  created_at: string | null
+}
+
+export async function adminLeadsStats(token: string): Promise<LeadsStats> {
+  return apiFetch('/v1/admin/leads/stats', token)
+}
+
+export async function adminLeadsCountries(token: string): Promise<{ code: string; name: string }[]> {
+  return apiFetch('/v1/admin/leads/countries', token)
+}
+
+export async function adminLeadsList(
+  token: string,
+  params: { status?: string; search?: string; limit?: number } = {},
+): Promise<DeveloperLead[]> {
+  const qs = new URLSearchParams()
+  if (params.status?.trim()) qs.set('status', params.status.trim())
+  if (params.search?.trim()) qs.set('search', params.search.trim())
+  if (params.limit) qs.set('limit', String(params.limit))
+  const q = qs.toString()
+  return apiFetch(`/v1/admin/leads${q ? `?${q}` : ''}`, token)
+}
+
+export async function adminLeadsFind(
+  token: string,
+  body: { keywords: string; country_code: string },
+): Promise<{
+  run_id: string
+  found: number
+  inserted: number
+  remaining_today: number
+  meta: Record<string, number>
+}> {
+  return apiFetch('/v1/admin/leads/find', token, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+export async function adminLeadsUpdateStatus(
+  token: string,
+  leadId: string,
+  status: string,
+): Promise<{ lead_id: string; email: string; name: string | null; status: string }> {
+  return apiFetch(`/v1/admin/leads/${encodeURIComponent(leadId)}`, token, {
+    method: 'PATCH',
+    body: JSON.stringify({ status }),
+  })
+}
+
 export async function getApiKeys(token: string) {
   return apiFetch('/v1/auth/api-keys', token)
 }

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -81,6 +81,8 @@ services:
       DASHBOARD_URL: ${DASHBOARD_URL:-https://db.zizka.ai}
       TRIAL_DAYS: ${TRIAL_DAYS:-30}
       COMMUNITY_UPLOAD_DIR: /data/community_uploads
+      GITHUB_LEADS_TOKEN: ${GITHUB_LEADS_TOKEN:-}
+      LEADS_DAILY_LIMIT: ${LEADS_DAILY_LIMIT:-100}
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Adds **/admin → Developer Leads**:

- Manual **Find today's leads** button
- Keywords (default `agent,agents,mcp,langchain,crewai,llm`)
- **Country dropdown** (Worldwide default)
- Requires **public GitHub email** + star **or** contribution on keyword repos
- Cap **100 new leads / UTC day**
- Dedupes against existing leads **and** past outreach sends
- **Use in Outreach** prefills Email Outreach and switches tab

Uses `GITHUB_LEADS_TOKEN` (read-only). Additive DB tables only — no data deletion.

## Test plan

- [ ] Set `GITHUB_LEADS_TOKEN` in `infra/.env` on EC2
- [ ] Safe deploy API + dashboard (no `docker compose down -v`)
- [ ] `/admin` → Developer Leads → token shows Configured
- [ ] Find today's leads (Worldwide) imports ≤ remaining quota
- [ ] Second run skips already-seen emails
- [ ] Country filter reduces to matching locations
- [ ] Use in Outreach opens Email Outreach with To prefilled
- [ ] Existing users/events unchanged
