### PR TITLE
fix(core): memory agent-scope (G5) + stable embeddings cache key (G11)

### DIFF
--- a/core/api/memory.py
+++ b/core/api/memory.py
@@ -14,7 +14,7 @@ from typing import Any
 import json
 import logging
 
-from api.deps import get_tenant
+from api.deps import get_tenant, assert_agent_allowed
 from db.connection import get_pool, get_qdrant
 from services.embeddings import generate_embedding
 
@@ -60,6 +60,8 @@ async def get_context(
         ]
     """
     tenant_id = tenant["tenant_id"]
+    # Agent-scoped keys may only read their own agent's memory.
+    assert_agent_allowed(tenant, body.agent)
     pool = get_pool()
 
     # 1. Recent events — always include these for temporal grounding
@@ -226,6 +228,8 @@ async def session_diff(
         raise not_found("Session not found")
 
     agent_id = rows[0]["agent_id"]
+    # Agent-scoped keys may only inspect their own agent's sessions.
+    assert_agent_allowed(tenant, agent_id)
     events = []
     event_types: dict[str, int] = {}
     has_error = False
@@ -321,14 +325,19 @@ async def forget(
     tenant_id = tenant["tenant_id"]
     pool = get_pool()
 
+    # Agent-scoped keys may only forget their own agent's events (unscoped
+    # keys / dashboard JWTs delete across the whole tenant as before).
+    scoped_agent = tenant.get("agent_id")
+
     # Find matching event IDs
     rows = await pool.fetch(
         """
         SELECT event_id FROM events
         WHERE tenant_id = $1
           AND data->$2 = to_jsonb($3::text)
+          AND ($4::text IS NULL OR agent_id = $4)
         """,
-        tenant_id, body.filter_key, body.filter_value,
+        tenant_id, body.filter_key, body.filter_value, scoped_agent,
     )
 
     if not rows:

--- a/core/services/embeddings.py
+++ b/core/services/embeddings.py
@@ -1,3 +1,4 @@
+import hashlib
 import httpx
 import json
 import logging
@@ -34,7 +35,11 @@ async def generate_embedding_with_config(
         )
         return None
 
-    cache_key = f"emb:{config.provider}:{config.model}:{hash(text)}"
+    # sha256 (not the builtin hash()) so the key is stable across processes —
+    # hash() is salted per-process (PYTHONHASHSEED), so with multiple workers
+    # the same text produced different keys and the cache almost never hit.
+    text_hash = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+    cache_key = f"emb:{config.provider}:{config.model}:{text_hash}"
 
     try:
         redis = get_redis()


### PR DESCRIPTION
Closes #77.

Two independent backend hardening fixes (roadmap HIGH tier). Stacked on
`feat/impact-trace`; retarget to `main` as the stack merges.

## G5 — agent-scope on memory endpoints
`why`/`impact` already enforce `assert_agent_allowed` (#76). The memory endpoints
relied on tenant filtering only, so an agent-scoped API key could reach another
agent's memory in the same tenant. Now enforced on:
- `POST /v1/memory/context` (agent body param)
- `GET /v1/memory/diff/{session_id}` (session's agent)
- `DELETE /v1/memory/forget` (delete restricted to the scoped agent)

Unscoped keys / dashboard JWTs are unaffected.

## G11 — stable embeddings cache key
`hash(text)` is per-process salted (`PYTHONHASHSEED`) → with multiple workers the
same text produced different keys and the 24h cache almost never hit. Now
`sha256(text)[:16]`.

## Verified live
- memory/diff → 200 (valid) / 404 (unknown) ✅
- memory/context → 400 without embeddings (agent-scope passes first for unscoped) ✅
- forget no-match → `deleted_events: 0` ✅
- sha256 key deterministic across processes ✅

See `docs/DEBUGGING_SYSTEM_REVIEW.md` (G5, G11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)