### PR TITLE
feat(errors): Error Explorer — cross-agent failure triage (F3)

### DIFF
--- a/core/api/events.py
+++ b/core/api/events.py
@@ -259,6 +259,87 @@ async def impact(
 
 
 # ─────────────────────────────────────────
+# ERROR EXPLORER — GET /v1/events/errors
+# Group failures across agents into a triage queue
+# ─────────────────────────────────────────
+
+_WINDOW_INTERVALS = {"24h": "24 hours", "7d": "7 days", "30d": "30 days"}
+
+
+@router.get("/errors")
+async def list_errors(
+    agent: str | None = Query(default=None),
+    window: str = Query(default="7d", pattern="^(24h|7d|30d|all)$"),
+    limit: int = Query(default=20, le=100),
+    tenant: dict = Depends(get_tenant),
+):
+    """Group error/fail events into signatures for triage.
+
+    An event counts as an error when its type contains "error"/"fail" (same
+    heuristic as memory diff) or its data has an `error` key. Groups by
+    (event_type, data->>'error') with counts, affected agents/sessions, first/
+    last seen, and a few sample event ids to trace.
+    """
+    pool = get_pool()
+    tenant_id = tenant["tenant_id"]
+
+    # Agent scope: honor an explicit ?agent= and always the scoped key's agent.
+    effective_agent = agent or tenant.get("agent_id")
+    if effective_agent:
+        assert_agent_allowed(tenant, effective_agent)
+
+    interval = _WINDOW_INTERVALS.get(window)  # None for "all"
+
+    rows = await pool.fetch(
+        """
+        SELECT
+            event_type,
+            COALESCE(data->>'error', '') AS error_key,
+            COUNT(*)                       AS count,
+            COUNT(DISTINCT agent_id)       AS agents_affected,
+            COUNT(DISTINCT session_id)     AS sessions_affected,
+            MIN(timestamp)                 AS first_seen,
+            MAX(timestamp)                 AS last_seen,
+            (array_agg(event_id ORDER BY timestamp DESC))[1:3]  AS sample_ids,
+            (array_agg(DISTINCT agent_id))[1:5]                 AS agents
+        FROM events
+        WHERE tenant_id = $1
+          AND (event_type ILIKE '%error%' OR event_type ILIKE '%fail%' OR data ? 'error')
+          AND ($2::text IS NULL OR agent_id = $2)
+          AND ($3::text IS NULL OR timestamp >= NOW() - $3::interval)
+        GROUP BY event_type, COALESCE(data->>'error', '')
+        ORDER BY count DESC, last_seen DESC
+        LIMIT $4
+        """,
+        tenant_id, effective_agent, interval, limit,
+    )
+
+    groups = []
+    for r in rows:
+        error_key = r["error_key"] or None
+        groups.append({
+            "signature": r["event_type"] + (f": {error_key}" if error_key else ""),
+            "event_type": r["event_type"],
+            "error": error_key,
+            "count": r["count"],
+            "agents_affected": r["agents_affected"],
+            "sessions_affected": r["sessions_affected"],
+            "first_seen": r["first_seen"].isoformat() if r["first_seen"] else None,
+            "last_seen": r["last_seen"].isoformat() if r["last_seen"] else None,
+            "sample_event_ids": [str(e) for e in (r["sample_ids"] or [])],
+            "agents": [a for a in (r["agents"] or []) if a],
+        })
+
+    return {
+        "window": window,
+        "agent": effective_agent,
+        "group_count": len(groups),
+        "total_errors": sum(g["count"] for g in groups),
+        "groups": groups,
+    }
+
+
+# ─────────────────────────────────────────
 # TIME TRAVEL — GET /v1/events/at
 # Reconstruct agent state at a given time
 # ─────────────────────────────────────────

--- a/dashboard/app/dashboard/debugging/errors/page.tsx
+++ b/dashboard/app/dashboard/debugging/errors/page.tsx
@@ -1,0 +1,272 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { getErrors, type ErrorReport, type ErrorGroup } from "@/lib/api";
+import { requireAuth } from "@/lib/auth";
+import { format } from "date-fns";
+import {
+  AlertTriangle,
+  Loader2,
+  AlertCircle,
+  GitBranch,
+  GitFork,
+  Copy,
+  Check,
+} from "lucide-react";
+
+const WINDOWS: { key: string; label: string }[] = [
+  { key: "24h", label: "24h" },
+  { key: "7d", label: "7 days" },
+  { key: "30d", label: "30 days" },
+  { key: "all", label: "All time" },
+];
+
+function fmt(ts: string | null): string {
+  if (!ts) return "—";
+  const d = new Date(ts);
+  return Number.isNaN(d.getTime()) ? ts : format(d, "MMM d, HH:mm");
+}
+
+export default function ErrorExplorerPage() {
+  const [window, setWindow] = useState("7d");
+  const [report, setReport] = useState<ErrorReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [copied, setCopied] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setLoading(true);
+      setError("");
+      try {
+        const token = requireAuth();
+        const r = await getErrors(token, { window });
+        if (!cancelled) setReport(r);
+      } catch (err) {
+        if (!cancelled) {
+          const m = (err instanceof Error ? err.message : "").toLowerCase();
+          setError(
+            m.includes("failed to fetch") || m.includes("networkerror")
+              ? "Couldn't reach the server. Check that the ZizkaDB API is running, then retry."
+              : err instanceof Error
+                ? err.message
+                : "Failed to load errors.",
+          );
+          setReport(null);
+        }
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [window]);
+
+  async function copyId(id: string) {
+    try {
+      await navigator.clipboard.writeText(id);
+      setCopied(id);
+      setTimeout(() => setCopied((c) => (c === id ? null : c)), 1500);
+    } catch {
+      /* noop */
+    }
+  }
+
+  return (
+    <div className="p-6 sm:p-8 max-w-4xl mx-auto">
+      {/* Header */}
+      <div className="mb-6">
+        <div className="flex items-center gap-2 mb-1.5">
+          <AlertTriangle size={17} style={{ color: "#f87171" }} />
+          <h1 className="text-white font-semibold text-xl">Error Explorer</h1>
+        </div>
+        <p className="text-sm leading-relaxed" style={{ color: "#a3a3a3" }}>
+          Every failure across your agents, grouped for triage. Pick a group, then
+          trace any instance to its root cause or downstream impact.
+        </p>
+      </div>
+
+      {/* Window filter */}
+      <div className="flex items-center gap-2 mb-6">
+        {WINDOWS.map((w) => (
+          <button
+            key={w.key}
+            onClick={() => setWindow(w.key)}
+            className="text-xs px-3 py-1.5 rounded-lg transition"
+            style={{
+              background: window === w.key ? "#1a1a1a" : "transparent",
+              border: `1px solid ${window === w.key ? "#3a3a3a" : "#1f1f1f"}`,
+              color: window === w.key ? "#fff" : "#a3a3a3",
+            }}
+          >
+            {w.label}
+          </button>
+        ))}
+        {report && !loading && (
+          <span className="text-xs ml-auto" style={{ color: "#737373" }}>
+            {report.total_errors} error{report.total_errors !== 1 ? "s" : ""} ·{" "}
+            {report.group_count} group{report.group_count !== 1 ? "s" : ""}
+          </span>
+        )}
+      </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-sm py-8" style={{ color: "#a3a3a3" }}>
+          <Loader2 size={14} className="animate-spin" />
+          Scanning for errors…
+        </div>
+      )}
+
+      {error && !loading && (
+        <div
+          className="flex items-start gap-2.5 rounded-xl px-4 py-3 mb-6 text-sm"
+          style={{ background: "#1f1414", border: "1px solid #3a1f1f", color: "#f87171" }}
+        >
+          <AlertCircle size={15} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {!loading && !error && report && report.groups.length === 0 && (
+        <div
+          className="text-center py-16 px-6 rounded-xl text-sm"
+          style={{ background: "#0d0d0d", border: "1px dashed #1f2a1f", color: "#a3a3a3" }}
+        >
+          <span style={{ color: "#22c55e" }}>No errors</span> in this window — your
+          agents are running clean.
+        </div>
+      )}
+
+      {!loading && !error && report && report.groups.length > 0 && (
+        <div className="space-y-3">
+          {report.groups.map((g) => (
+            <ErrorGroupCard key={g.signature} group={g} copied={copied} onCopy={copyId} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ErrorGroupCard({
+  group,
+  copied,
+  onCopy,
+}: {
+  group: ErrorGroup;
+  copied: string | null;
+  onCopy: (id: string) => void;
+}) {
+  return (
+    <div
+      className="rounded-xl p-4"
+      style={{ background: "#111", border: "1px solid #3a1f1f" }}
+    >
+      <div className="flex items-start gap-3 flex-wrap">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className="text-sm font-mono font-medium truncate"
+              style={{ color: "#f87171" }}
+            >
+              {group.event_type}
+            </span>
+            {group.error && (
+              <span
+                className="text-xs font-mono px-1.5 py-0.5 rounded"
+                style={{ background: "#2a1414", color: "#fca5a5" }}
+              >
+                {group.error}
+              </span>
+            )}
+          </div>
+          <div className="flex flex-wrap gap-x-4 gap-y-1 mt-2 text-xs" style={{ color: "#a3a3a3" }}>
+            <span>
+              <span style={{ color: "#666" }}>count</span> {group.count}
+            </span>
+            <span>
+              <span style={{ color: "#666" }}>agents</span> {group.agents_affected}
+            </span>
+            <span>
+              <span style={{ color: "#666" }}>sessions</span> {group.sessions_affected}
+            </span>
+            <span>
+              <span style={{ color: "#666" }}>last</span> {fmt(group.last_seen)}
+            </span>
+            <span>
+              <span style={{ color: "#666" }}>first</span> {fmt(group.first_seen)}
+            </span>
+          </div>
+          {group.agents.length > 0 && (
+            <div className="flex flex-wrap gap-1.5 mt-2">
+              {group.agents.map((a) => (
+                <span
+                  key={a}
+                  className="text-xs font-mono px-1.5 py-0.5 rounded"
+                  style={{ background: "#1a1a1a", color: "#a3a3a3" }}
+                >
+                  {a}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+        <span
+          className="text-lg font-bold font-mono shrink-0"
+          style={{ color: "#f87171" }}
+        >
+          {group.count}
+        </span>
+      </div>
+
+      {/* Sample instances → trace */}
+      {group.sample_event_ids.length > 0 && (
+        <div className="mt-3 pt-3" style={{ borderTop: "1px solid #1f1f1f" }}>
+          <div className="text-xs mb-2" style={{ color: "#666" }}>
+            Trace an instance:
+          </div>
+          <div className="space-y-1.5">
+            {group.sample_event_ids.map((id) => (
+              <div key={id} className="flex items-center gap-2 flex-wrap">
+                <span className="text-xs font-mono truncate" style={{ color: "#a3a3a3" }}>
+                  {id}
+                </span>
+                <button
+                  onClick={() => onCopy(id)}
+                  className="shrink-0"
+                  style={{ color: "#666" }}
+                  title="Copy event ID"
+                >
+                  {copied === id ? (
+                    <Check size={11} style={{ color: "#22c55e" }} />
+                  ) : (
+                    <Copy size={11} />
+                  )}
+                </button>
+                <div className="flex gap-1.5 ml-auto shrink-0">
+                  <Link
+                    href={`/dashboard/debugging/why?event_id=${encodeURIComponent(id)}`}
+                    className="flex items-center gap-1 text-xs px-2 py-1 rounded-lg transition"
+                    style={{ background: "#14241a", border: "1px solid #1f3a24", color: "#22c55e" }}
+                  >
+                    <GitBranch size={11} /> Root cause
+                  </Link>
+                  <Link
+                    href={`/dashboard/debugging/impact?event_id=${encodeURIComponent(id)}`}
+                    className="flex items-center gap-1 text-xs px-2 py-1 rounded-lg transition"
+                    style={{ background: "#1a1a1a", border: "1px solid #2a2a2a", color: "#a3a3a3" }}
+                  >
+                    <GitFork size={11} /> Impact
+                  </Link>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/components/DashboardShell.tsx
+++ b/dashboard/components/DashboardShell.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { clearToken } from "@/lib/auth";
 import { BrandLogo } from "@/components/BrandLogo";
-import { Search, Settings, LogOut, Cpu, GitBranch, GitFork, Bug } from "lucide-react";
+import { Search, Settings, LogOut, Cpu, GitBranch, GitFork, AlertTriangle, Bug } from "lucide-react";
 import { ConnectionStatus } from "@/components/ConnectionStatus";
 import { TenantPlanBanner } from "@/components/TenantPlanBanner";
 
@@ -21,6 +21,7 @@ const nav: NavEntry[] = [
     children: [
       { href: "/dashboard/debugging/why", label: "Causal Trace", icon: GitBranch },
       { href: "/dashboard/debugging/impact", label: "Impact Trace", icon: GitFork },
+      { href: "/dashboard/debugging/errors", label: "Error Explorer", icon: AlertTriangle },
     ],
   },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -214,6 +214,38 @@ export async function getImpactChain(
   return apiFetch(`/v1/events/${eventId}/impact${qs}`, token)
 }
 
+export interface ErrorGroup {
+  signature: string
+  event_type: string
+  error: string | null
+  count: number
+  agents_affected: number
+  sessions_affected: number
+  first_seen: string | null
+  last_seen: string | null
+  sample_event_ids: string[]
+  agents: string[]
+}
+
+export interface ErrorReport {
+  window: string
+  agent: string | null
+  group_count: number
+  total_errors: number
+  groups: ErrorGroup[]
+}
+
+export async function getErrors(
+  token: string,
+  opts: { window?: string; agent?: string } = {},
+): Promise<ErrorReport> {
+  const params = new URLSearchParams()
+  if (opts.window) params.set('window', opts.window)
+  if (opts.agent) params.set('agent', opts.agent)
+  const qs = params.toString() ? `?${params.toString()}` : ''
+  return apiFetch(`/v1/events/errors${qs}`, token)
+}
+
 // The backend's search response shape isn't fully pinned down (some call
 // sites defensively handle both `{ results: [...] }` and a bare array) — kept
 // loosely typed here rather than forcing a shape that would fight that


### PR DESCRIPTION
Closes #79.

## What
**Error Explorer** — one place to see every failure across your agents, grouped
into signatures for triage, with one-click **Root cause** (Causal Trace) and
**Impact** (Impact Trace) on any instance.

> Stacked on `feat/debug-hardening`; retarget to `main` as the stack merges.

## Changes
**Backend** (`core/api/events.py`)
- `GET /v1/events/errors?agent=&window=&limit=` — groups error events
  (`event_type ILIKE '%error%'/'%fail%'` OR `data ? 'error'`) by
  `(event_type, data->>'error')` signature within a window (`24h|7d|30d|all`), with
  count, agents/sessions affected, first/last seen, and sample event ids.
  Tenant-isolated + agent-scope aware; uses `idx_events_type`.

**Frontend**
- `lib/api.ts`: `getErrors()` + `ErrorReport`/`ErrorGroup` types.
- New `/dashboard/debugging/errors` page — window filter, ranked error group cards
  (signature, counts, affected agents), sample instances linking to Root cause /
  Impact; loading / error / clean "no errors" states.
- `DashboardShell`: **Error Explorer** entry in the Debugging nav group (now 3 tools).

## Verified live (seeded data)
| Case | Result |
|---|---|
| all-time | 4 groups / 12 errors, signatures + counts + samples ✅ |
| 24h window | 0 groups ✅ |
| agent filter (why-demo-bot) | 3 groups ✅ |
| bad window | 422 ✅ |
| sample id → Causal Trace | 200 ✅ |
| dashboard build / page | clean / 200 ✅ |

See `docs/DEBUGGING_SYSTEM_REVIEW.md` (F3, HIGH tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)