### PR TITLE
feat(debugging): Unified Debugging Hub + Time Travel & Session Insights (F1)

### DIFF
--- a/core/tests/test_debugging_endpoints.py
+++ b/core/tests/test_debugging_endpoints.py
@@ -1,0 +1,204 @@
+"""
+Unit tests for the debugging/query endpoints (mocked pool, no running stack):
+Causal Trace (why), Impact Trace (impact), Time Travel (at), and the agent-scope
+hardening on the memory endpoints. Closes the G9 test gap for these handlers.
+"""
+
+import datetime
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from main import app
+from api.deps import get_tenant
+
+TENANT_ID = "11111111-1111-1111-1111-111111111111"
+TENANT = {"tenant_id": TENANT_ID, "user_id": "user-1"}
+# A key scoped to "agent-a" (may only touch agent-a's data).
+SCOPED_A = {"tenant_id": TENANT_ID, "user_id": "user-1", "agent_id": "agent-a"}
+
+EID_A = "22222222-2222-2222-2222-222222222222"
+EID_B = "33333333-3333-3333-3333-333333333333"
+
+
+def _row(event_id, *, agent="agent-a", event_type="tool_call", parent=None, depth=0, data=None):
+    return {
+        "event_id": event_id,
+        "agent_id": agent,
+        "timestamp": datetime.datetime(2026, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc),
+        "event_type": event_type,
+        "data": data if data is not None else {},
+        "parent_event_id": parent,
+        "session_id": "sess-1",
+        "sequence_no": 1,
+        "depth": depth,
+    }
+
+
+@pytest.fixture
+def client():
+    c = TestClient(app)
+    yield c
+    app.dependency_overrides.clear()
+
+
+def _auth(tenant):
+    app.dependency_overrides[get_tenant] = lambda: tenant
+
+
+def _mock_pool(monkeypatch, fetch_result, module="api.events"):
+    pool = AsyncMock()
+    pool.fetch.return_value = fetch_result
+    monkeypatch.setattr(f"{module}.get_pool", lambda: pool)
+    return pool
+
+
+# ── Causal Trace (why) ────────────────────────────────────────────────────────
+
+class TestWhy:
+    def test_returns_chain(self, client, monkeypatch):
+        _auth(TENANT)
+        rows = [_row(EID_B, event_type="user_message", parent=None),
+                _row(EID_A, event_type="tool_error", parent=EID_B)]
+        _mock_pool(monkeypatch, rows)
+        r = client.get(f"/v1/events/{EID_A}/why")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["chain_length"] == 2
+        assert set(body["chain"][0].keys()) == {
+            "event_id", "agent", "timestamp", "event", "data", "parent_id",
+            "session_id", "sequence_no",
+        }
+
+    def test_bad_uuid_404(self, client, monkeypatch):
+        _auth(TENANT)
+        _mock_pool(monkeypatch, [])
+        assert client.get("/v1/events/not-a-uuid/why").status_code == 404
+
+    def test_unknown_event_404(self, client, monkeypatch):
+        _auth(TENANT)
+        _mock_pool(monkeypatch, [])
+        assert client.get(f"/v1/events/{EID_A}/why").status_code == 404
+
+    def test_parent_id_match(self, client, monkeypatch):
+        _auth(TENANT)
+        rows = [_row(EID_B, parent=None), _row(EID_A, parent=EID_B)]
+        _mock_pool(monkeypatch, rows)
+        r = client.get(f"/v1/events/{EID_A}/why?parent_id={EID_B}")
+        assert r.status_code == 200
+
+    def test_parent_id_mismatch_400(self, client, monkeypatch):
+        _auth(TENANT)
+        rows = [_row(EID_B, parent=None), _row(EID_A, parent=EID_B)]
+        _mock_pool(monkeypatch, rows)
+        wrong = "44444444-4444-4444-4444-444444444444"
+        r = client.get(f"/v1/events/{EID_A}/why?parent_id={wrong}")
+        assert r.status_code == 400
+        assert "does not match" in r.json()["detail"]
+
+    def test_parent_id_invalid_uuid_400(self, client, monkeypatch):
+        _auth(TENANT)
+        _mock_pool(monkeypatch, [_row(EID_A, parent=None)])
+        r = client.get(f"/v1/events/{EID_A}/why?parent_id=not-a-uuid")
+        assert r.status_code == 400
+
+    def test_agent_scope_denied_403(self, client, monkeypatch):
+        _auth(SCOPED_A)  # key bound to agent-a
+        _mock_pool(monkeypatch, [_row(EID_A, agent="agent-b", parent=None)])
+        assert client.get(f"/v1/events/{EID_A}/why").status_code == 403
+
+    def test_agent_scope_allowed(self, client, monkeypatch):
+        _auth(SCOPED_A)
+        _mock_pool(monkeypatch, [_row(EID_A, agent="agent-a", parent=None)])
+        assert client.get(f"/v1/events/{EID_A}/why").status_code == 200
+
+
+# ── Impact Trace (impact) ─────────────────────────────────────────────────────
+
+class TestImpact:
+    def test_returns_tree_with_depth(self, client, monkeypatch):
+        _auth(TENANT)
+        rows = [_row(EID_A, depth=0, parent=None), _row(EID_B, depth=1, parent=EID_A)]
+        _mock_pool(monkeypatch, rows)
+        r = client.get(f"/v1/events/{EID_A}/impact")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["node_count"] == 2
+        assert body["nodes"][0]["depth"] == 0
+        assert body["nodes"][1]["depth"] == 1
+
+    def test_single_leaf(self, client, monkeypatch):
+        _auth(TENANT)
+        _mock_pool(monkeypatch, [_row(EID_A, depth=0, parent=None)])
+        body = client.get(f"/v1/events/{EID_A}/impact").json()
+        assert body["node_count"] == 1
+
+    def test_bad_uuid_404(self, client, monkeypatch):
+        _auth(TENANT)
+        _mock_pool(monkeypatch, [])
+        assert client.get("/v1/events/not-a-uuid/impact").status_code == 404
+
+    def test_unknown_event_404(self, client, monkeypatch):
+        _auth(TENANT)
+        _mock_pool(monkeypatch, [])
+        assert client.get(f"/v1/events/{EID_A}/impact").status_code == 404
+
+    def test_agent_scope_denied_403(self, client, monkeypatch):
+        _auth(SCOPED_A)
+        _mock_pool(monkeypatch, [_row(EID_A, agent="agent-b", depth=0, parent=None)])
+        assert client.get(f"/v1/events/{EID_A}/impact").status_code == 403
+
+
+# ── Time Travel (at) ──────────────────────────────────────────────────────────
+
+class TestTimeTravel:
+    TS = "2026-01-01T13:00:00Z"
+
+    def test_state_set_reconstruction(self, client, monkeypatch):
+        _auth(TENANT)
+        rows = [
+            _row(EID_A, event_type="STATE_SET", data={"balance": 100}),
+            _row(EID_B, event_type="STATE_SET", data={"status": "active"}),
+        ]
+        _mock_pool(monkeypatch, rows)
+        r = client.get(f"/v1/events/at?agent=agent-a&timestamp={self.TS}")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["event_count"] == 2
+        assert body["state"]["balance"] == 100
+        assert body["state"]["status"] == "active"
+
+    def test_last_event_fallback(self, client, monkeypatch):
+        _auth(TENANT)
+        _mock_pool(monkeypatch, [_row(EID_A, event_type="tool_call", data={"x": 1})])
+        body = client.get(f"/v1/events/at?agent=agent-a&timestamp={self.TS}").json()
+        assert "_last_event" in body["state"]
+
+    def test_missing_timestamp_422(self, client):
+        _auth(TENANT)
+        assert client.get("/v1/events/at?agent=agent-a").status_code == 422
+
+    def test_missing_agent_422(self, client):
+        _auth(TENANT)
+        assert client.get(f"/v1/events/at?timestamp={self.TS}").status_code == 422
+
+    def test_agent_scope_denied_403(self, client):
+        _auth(SCOPED_A)  # bound to agent-a, requesting agent-b
+        assert client.get(f"/v1/events/at?agent=agent-b&timestamp={self.TS}").status_code == 403
+
+
+# ── Memory endpoints — agent-scope hardening (G5) ─────────────────────────────
+
+class TestMemoryAgentScope:
+    def test_context_scope_denied_403(self, client):
+        # assert_agent_allowed fires before any DB call, so no pool mock needed.
+        _auth(SCOPED_A)
+        r = client.post("/v1/memory/context", json={"agent": "agent-b", "task": "x"})
+        assert r.status_code == 403
+
+    def test_diff_scope_denied_403(self, client, monkeypatch):
+        _auth(SCOPED_A)
+        # session belongs to agent-b; scoped key for agent-a must be denied.
+        _mock_pool(monkeypatch, [_row(EID_A, agent="agent-b")], module="api.memory")
+        assert client.get("/v1/memory/diff/sess-b").status_code == 403

--- a/dashboard/app/dashboard/debugging/page.tsx
+++ b/dashboard/app/dashboard/debugging/page.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Link from "next/link";
+import {
+  GitBranch,
+  GitFork,
+  AlertTriangle,
+  Rewind,
+  Layers,
+  Search,
+} from "lucide-react";
+
+const TOOLS = [
+  {
+    href: "/dashboard/debugging/why",
+    label: "Causal Trace",
+    icon: GitBranch,
+    desc: "Trace an event back through its causal chain to the root cause — why did this happen?",
+  },
+  {
+    href: "/dashboard/debugging/impact",
+    label: "Impact Trace",
+    icon: GitFork,
+    desc: "See everything an event caused downstream — its blast radius.",
+  },
+  {
+    href: "/dashboard/debugging/errors",
+    label: "Error Explorer",
+    icon: AlertTriangle,
+    desc: "Every failure across your agents, grouped for triage. Jump to any root cause.",
+  },
+  {
+    href: "/dashboard/debugging/time-travel",
+    label: "Time Travel",
+    icon: Rewind,
+    desc: "Reconstruct an agent's state at any past moment — what did it know then?",
+  },
+  {
+    href: "/dashboard/debugging/sessions",
+    label: "Session Insights",
+    icon: Layers,
+    desc: "Summarize a session and see what was new or anomalous vs prior runs.",
+  },
+  {
+    href: "/dashboard/search",
+    label: "Semantic Search",
+    icon: Search,
+    desc: "Find events across your agents by natural-language meaning.",
+  },
+];
+
+export default function DebuggingHubPage() {
+  return (
+    <div className="p-6 sm:p-8 max-w-4xl mx-auto">
+      <div className="mb-6">
+        <h1 className="text-white font-semibold text-xl mb-1">Debugging</h1>
+        <p className="text-sm leading-relaxed" style={{ color: "#a3a3a3" }}>
+          Ready-made queries for investigating agent behavior. Pick a tool to trace
+          causality, reconstruct past state, triage failures, or search your history.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        {TOOLS.map((t) => {
+          const Icon = t.icon;
+          return (
+            <Link
+              key={t.href}
+              href={t.href}
+              className="rounded-xl p-4 transition group"
+              style={{ background: "#111", border: "1px solid #1f1f1f" }}
+            >
+              <div className="flex items-center gap-2 mb-1.5">
+                <Icon size={16} style={{ color: "#22c55e" }} />
+                <span className="text-sm font-semibold text-white">{t.label}</span>
+              </div>
+              <p className="text-xs leading-relaxed" style={{ color: "#a3a3a3" }}>
+                {t.desc}
+              </p>
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/dashboard/debugging/sessions/page.tsx
+++ b/dashboard/app/dashboard/debugging/sessions/page.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  getAgents,
+  getAgentSessions,
+  getMemoryDiff,
+  type Agent,
+  type AgentSession,
+} from "@/lib/api";
+import { requireAuth } from "@/lib/auth";
+import { format } from "date-fns";
+import { Layers, Loader2, AlertCircle, AlertTriangle, GitBranch } from "lucide-react";
+
+interface SessionDiff {
+  session_id: string;
+  agent: string;
+  event_count: number;
+  event_types: Record<string, number>;
+  causal_depth: number;
+  has_errors: boolean;
+  duration_seconds: number | null;
+  new_event_types: string[];
+  top_events: { event_id: string; event: string; data: unknown; timestamp: string }[];
+  summary: string;
+}
+
+export default function SessionInsightsPage() {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agent, setAgent] = useState("");
+  const [sessions, setSessions] = useState<AgentSession[]>([]);
+  const [sessionId, setSessionId] = useState("");
+  const [diff, setDiff] = useState<SessionDiff | null>(null);
+  const [loadingSessions, setLoadingSessions] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = requireAuth();
+        const list = await getAgents(token);
+        if (cancelled) return;
+        setAgents(list);
+        if (list.length > 0) setAgent(list[0].agent);
+      } catch {
+        /* noop */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load sessions when the agent changes.
+  useEffect(() => {
+    if (!agent) return;
+    let cancelled = false;
+    (async () => {
+      setLoadingSessions(true);
+      setSessions([]);
+      setSessionId("");
+      setDiff(null);
+      try {
+        const token = requireAuth();
+        const list = await getAgentSessions(token, agent);
+        if (!cancelled) setSessions(list);
+      } catch {
+        /* noop */
+      } finally {
+        if (!cancelled) setLoadingSessions(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [agent]);
+
+  async function inspect(sid: string) {
+    setSessionId(sid);
+    if (!sid) {
+      setDiff(null);
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const token = requireAuth();
+      const d = (await getMemoryDiff(token, sid)) as unknown as SessionDiff;
+      setDiff(d);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load session insights.");
+      setDiff(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="p-6 sm:p-8 max-w-4xl mx-auto">
+      <div className="mb-6">
+        <div className="flex items-center gap-2 mb-1.5">
+          <Layers size={17} style={{ color: "#22c55e" }} />
+          <h1 className="text-white font-semibold text-xl">Session Insights</h1>
+        </div>
+        <p className="text-sm leading-relaxed" style={{ color: "#a3a3a3" }}>
+          Summarize a session and see what was new or anomalous compared to the agent&apos;s
+          earlier runs.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 mb-6">
+        <div>
+          <label className="block text-xs font-medium mb-1.5" style={{ color: "#d4d4d4" }}>
+            Agent
+          </label>
+          {agents.length > 0 ? (
+            <select
+              value={agent}
+              onChange={(e) => setAgent(e.target.value)}
+              className="w-full rounded-lg px-3.5 py-2.5 text-sm font-mono text-white outline-none"
+              style={{ background: "#0d0d0d", border: "1px solid #262626" }}
+            >
+              {agents.map((a) => (
+                <option key={a.agent} value={a.agent}>
+                  {a.agent}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input
+              value={agent}
+              onChange={(e) => setAgent(e.target.value)}
+              placeholder="agent name"
+              className="w-full rounded-lg px-3.5 py-2.5 text-sm font-mono text-white outline-none"
+              style={{ background: "#0d0d0d", border: "1px solid #262626" }}
+            />
+          )}
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1.5" style={{ color: "#d4d4d4" }}>
+            Session {loadingSessions && <span style={{ color: "#666" }}>· loading…</span>}
+          </label>
+          <select
+            value={sessionId}
+            onChange={(e) => inspect(e.target.value)}
+            disabled={sessions.length === 0}
+            className="w-full rounded-lg px-3.5 py-2.5 text-sm font-mono text-white outline-none disabled:opacity-50"
+            style={{ background: "#0d0d0d", border: "1px solid #262626" }}
+          >
+            <option value="">
+              {sessions.length === 0 ? "no sessions" : `select a session (${sessions.length})`}
+            </option>
+            {sessions.map((s) => (
+              <option key={s.session_id} value={s.session_id}>
+                {s.session_id} · {s.event_count} events
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {loading && (
+        <div className="flex items-center gap-2 text-sm py-8" style={{ color: "#a3a3a3" }}>
+          <Loader2 size={14} className="animate-spin" />
+          Analyzing session…
+        </div>
+      )}
+
+      {error && !loading && (
+        <div
+          className="flex items-start gap-2.5 rounded-xl px-4 py-3 mb-6 text-sm"
+          style={{ background: "#1f1414", border: "1px solid #3a1f1f", color: "#f87171" }}
+        >
+          <AlertCircle size={15} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {diff && !loading && (
+        <div className="space-y-4">
+          {/* Summary */}
+          <div
+            className="rounded-xl p-5"
+            style={{ background: "#111", border: `1px solid ${diff.has_errors ? "#3a1f1f" : "#1f2a1f"}` }}
+          >
+            <div className="flex items-center gap-2 mb-2">
+              {diff.has_errors ? (
+                <AlertTriangle size={15} style={{ color: "#f87171" }} />
+              ) : (
+                <Layers size={15} style={{ color: "#22c55e" }} />
+              )}
+              <span
+                className="text-xs font-semibold uppercase tracking-wider"
+                style={{ color: diff.has_errors ? "#f87171" : "#22c55e" }}
+              >
+                {diff.has_errors ? "Errors detected" : "Clean session"}
+              </span>
+            </div>
+            <p className="text-sm leading-relaxed" style={{ color: "#e5e5e5" }}>
+              {diff.summary}
+            </p>
+            <div className="flex flex-wrap gap-x-5 gap-y-1.5 mt-3 text-xs" style={{ color: "#a3a3a3" }}>
+              <span>
+                <span style={{ color: "#666" }}>events</span> {diff.event_count}
+              </span>
+              <span>
+                <span style={{ color: "#666" }}>causal depth</span> {diff.causal_depth}
+              </span>
+              <span>
+                <span style={{ color: "#666" }}>duration</span>{" "}
+                {diff.duration_seconds != null ? `${diff.duration_seconds.toFixed(1)}s` : "—"}
+              </span>
+              <span>
+                <span style={{ color: "#666" }}>agent</span>{" "}
+                <span className="font-mono" style={{ color: "#d4d4d4" }}>
+                  {diff.agent}
+                </span>
+              </span>
+            </div>
+          </div>
+
+          {/* New event types */}
+          {diff.new_event_types.length > 0 && (
+            <div className="rounded-xl p-4" style={{ background: "#111", border: "1px solid #1f1f1f" }}>
+              <div className="text-xs font-medium mb-2" style={{ color: "#fbbf24" }}>
+                New in this session ({diff.new_event_types.length}) — not seen in prior runs
+              </div>
+              <div className="flex flex-wrap gap-1.5">
+                {diff.new_event_types.map((t) => (
+                  <span
+                    key={t}
+                    className="text-xs font-mono px-2 py-0.5 rounded"
+                    style={{ background: "#1f1a10", color: "#fcd34d" }}
+                  >
+                    {t}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Event type breakdown */}
+          <div className="rounded-xl p-4" style={{ background: "#111", border: "1px solid #1f1f1f" }}>
+            <div className="text-xs font-medium mb-2" style={{ color: "#a3a3a3" }}>
+              Event types
+            </div>
+            <div className="flex flex-wrap gap-1.5">
+              {Object.entries(diff.event_types).map(([t, c]) => (
+                <span
+                  key={t}
+                  className="text-xs font-mono px-2 py-0.5 rounded"
+                  style={{ background: "#1a1a1a", color: "#d4d4d4" }}
+                >
+                  {t} · {c}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Top events → trace */}
+          {diff.top_events.length > 0 && (
+            <div className="rounded-xl p-4" style={{ background: "#111", border: "1px solid #1f1f1f" }}>
+              <div className="text-xs font-medium mb-2" style={{ color: "#a3a3a3" }}>
+                First events
+              </div>
+              <div className="space-y-1.5">
+                {diff.top_events.map((e) => (
+                  <div key={e.event_id} className="flex items-center gap-2 text-xs">
+                    <span className="font-mono" style={{ color: "#d4d4d4" }}>
+                      {e.event}
+                    </span>
+                    <span className="font-mono" style={{ color: "#666" }}>
+                      {e.timestamp ? format(new Date(e.timestamp), "HH:mm:ss") : ""}
+                    </span>
+                    <Link
+                      href={`/dashboard/debugging/why?event_id=${encodeURIComponent(e.event_id)}`}
+                      className="flex items-center gap-1 ml-auto shrink-0 transition"
+                      style={{ color: "#22c55e" }}
+                    >
+                      <GitBranch size={11} /> Trace
+                    </Link>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+
+      {!diff && !loading && !error && (
+        <div
+          className="text-center py-16 px-6 rounded-xl text-sm"
+          style={{ background: "#0d0d0d", border: "1px dashed #262626", color: "#a3a3a3" }}
+        >
+          Pick an agent and a session to see its insights.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/app/dashboard/debugging/time-travel/page.tsx
+++ b/dashboard/app/dashboard/debugging/time-travel/page.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getAgents, timeTravel, type Agent } from "@/lib/api";
+import { requireAuth } from "@/lib/auth";
+import { format } from "date-fns";
+import { Rewind, Loader2, AlertCircle, Zap } from "lucide-react";
+
+interface TTResult {
+  agent: string;
+  at: string;
+  event_count: number;
+  state: Record<string, unknown>;
+}
+
+export default function TimeTravelPage() {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [agent, setAgent] = useState("");
+  const [ts, setTs] = useState("");
+  const [result, setResult] = useState<TTResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const token = requireAuth();
+        const list = await getAgents(token);
+        if (cancelled) return;
+        setAgents(list);
+        if (list.length > 0) setAgent(list[0].agent);
+      } catch {
+        /* leave agent empty; user can still type */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function reconstruct(e: React.FormEvent) {
+    e.preventDefault();
+    if (!agent) {
+      setError("Pick an agent first.");
+      return;
+    }
+    if (!ts) {
+      setError("Pick a date and time first.");
+      return;
+    }
+    setLoading(true);
+    setError("");
+    try {
+      const token = requireAuth();
+      const iso = new Date(ts).toISOString();
+      const res = (await timeTravel(token, agent, iso)) as unknown as TTResult;
+      setResult(res);
+    } catch (err) {
+      const m = (err instanceof Error ? err.message : "").toLowerCase();
+      setError(
+        m.includes("failed to fetch") || m.includes("networkerror")
+          ? "Couldn't reach the server. Check that the API is running, then retry."
+          : err instanceof Error
+            ? err.message
+            : "Failed to reconstruct state.",
+      );
+      setResult(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function quickPick(hoursAgo: number) {
+    const d = new Date(Date.now() - hoursAgo * 3600_000);
+    // format for datetime-local (local time, no seconds)
+    const pad = (n: number) => String(n).padStart(2, "0");
+    setTs(
+      `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`,
+    );
+  }
+
+  const state = result?.state ?? {};
+  const keys = Object.keys(state);
+  const onlyLastEvent = keys.length === 1 && keys[0] === "_last_event";
+  const isEmpty = keys.length === 0;
+
+  return (
+    <div className="p-6 sm:p-8 max-w-4xl mx-auto">
+      <div className="mb-6">
+        <div className="flex items-center gap-2 mb-1.5">
+          <Rewind size={17} style={{ color: "#22c55e" }} />
+          <h1 className="text-white font-semibold text-xl">Time Travel</h1>
+        </div>
+        <p className="text-sm leading-relaxed" style={{ color: "#a3a3a3" }}>
+          Reconstruct an agent&apos;s state at any past moment — everything it had logged
+          up to that point. Built from its{" "}
+          <span className="font-mono" style={{ color: "#d4d4d4" }}>
+            STATE_SET
+          </span>{" "}
+          events.
+        </p>
+      </div>
+
+      <form onSubmit={reconstruct} className="mb-6 space-y-4">
+        <div>
+          <label className="block text-xs font-medium mb-1.5" style={{ color: "#d4d4d4" }}>
+            Agent
+          </label>
+          {agents.length > 0 ? (
+            <select
+              value={agent}
+              onChange={(e) => setAgent(e.target.value)}
+              className="w-full rounded-lg px-3.5 py-2.5 text-sm font-mono text-white outline-none transition"
+              style={{ background: "#0d0d0d", border: "1px solid #262626" }}
+            >
+              {agents.map((a) => (
+                <option key={a.agent} value={a.agent}>
+                  {a.agent} ({a.event_count} events)
+                </option>
+              ))}
+            </select>
+          ) : (
+            <input
+              value={agent}
+              onChange={(e) => setAgent(e.target.value)}
+              placeholder="agent name"
+              className="w-full rounded-lg px-3.5 py-2.5 text-sm font-mono text-white outline-none transition"
+              style={{ background: "#0d0d0d", border: "1px solid #262626" }}
+            />
+          )}
+        </div>
+        <div>
+          <label className="block text-xs font-medium mb-1.5" style={{ color: "#d4d4d4" }}>
+            Point in time
+          </label>
+          <div className="flex flex-col sm:flex-row gap-2">
+            <input
+              type="datetime-local"
+              value={ts}
+              onChange={(e) => setTs(e.target.value)}
+              className="flex-1 rounded-lg px-3.5 py-2.5 text-sm font-mono text-white outline-none transition"
+              style={{ background: "#0d0d0d", border: "1px solid #262626", colorScheme: "dark" }}
+            />
+            <button
+              type="submit"
+              disabled={loading || !agent || !ts}
+              className="rounded-lg px-6 py-2.5 text-sm font-medium text-black disabled:opacity-40 transition shrink-0"
+              style={{ background: "#22c55e" }}
+            >
+              {loading ? <Loader2 size={14} className="animate-spin mx-auto" /> : "Reconstruct"}
+            </button>
+          </div>
+          <div className="flex flex-wrap gap-1.5 mt-2">
+            {[
+              { label: "1 hour ago", h: 1 },
+              { label: "6 hours ago", h: 6 },
+              { label: "1 day ago", h: 24 },
+              { label: "1 week ago", h: 168 },
+            ].map((q) => (
+              <button
+                key={q.h}
+                type="button"
+                onClick={() => quickPick(q.h)}
+                className="text-xs px-2.5 py-1 rounded-lg transition"
+                style={{ background: "#111", border: "1px solid #1f1f1f", color: "#a3a3a3" }}
+              >
+                {q.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      </form>
+
+      {error && (
+        <div
+          className="flex items-start gap-2.5 rounded-xl px-4 py-3 mb-6 text-sm"
+          style={{ background: "#1f1414", border: "1px solid #3a1f1f", color: "#f87171" }}
+        >
+          <AlertCircle size={15} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {result && (
+        <div className="space-y-4">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded-xl p-4" style={{ background: "#111", border: "1px solid #1f1f1f" }}>
+              <div className="text-xs mb-1" style={{ color: "#a3a3a3" }}>
+                Events at this time
+              </div>
+              <div className="text-2xl font-bold font-mono text-white">{result.event_count}</div>
+            </div>
+            <div className="rounded-xl p-4" style={{ background: "#111", border: "1px solid #1f1f1f" }}>
+              <div className="text-xs mb-1" style={{ color: "#a3a3a3" }}>
+                Reconstructed at
+              </div>
+              <div className="text-sm font-mono text-white">
+                {ts ? format(new Date(ts), "MMM d yyyy, HH:mm") : "—"}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-xl" style={{ background: "#111", border: "1px solid #1f1f1f" }}>
+            <div className="px-4 py-3 border-b flex items-center gap-2" style={{ borderColor: "#1f1f1f" }}>
+              <Zap size={13} style={{ color: "#22c55e" }} />
+              <span className="text-sm font-medium text-white">
+                {onlyLastEvent ? "Most recent event at this time" : "Reconstructed state"}
+              </span>
+            </div>
+            {onlyLastEvent && (
+              <div className="px-4 py-3 text-xs border-b" style={{ color: "#a3a3a3", borderColor: "#1f1f1f" }}>
+                This agent doesn&apos;t log{" "}
+                <span className="font-mono" style={{ color: "#d4d4d4" }}>
+                  STATE_SET
+                </span>
+                /
+                <span className="font-mono" style={{ color: "#d4d4d4" }}>
+                  STATE_DELETE
+                </span>{" "}
+                events, so there&apos;s no key/value state to rebuild. Showing the most recent event
+                before this time instead.
+              </div>
+            )}
+            {isEmpty ? (
+              <div className="p-4 text-xs" style={{ color: "#a3a3a3" }}>
+                No events had been logged for this agent yet at this time.
+              </div>
+            ) : (
+              <pre className="p-4 text-xs overflow-auto" style={{ color: "#86efac", maxHeight: 320 }}>
+                {JSON.stringify(state, null, 2)}
+              </pre>
+            )}
+          </div>
+        </div>
+      )}
+
+      {!result && !loading && !error && (
+        <div
+          className="text-center py-16 px-6 rounded-xl text-sm"
+          style={{ background: "#0d0d0d", border: "1px dashed #262626", color: "#a3a3a3" }}
+        >
+          Pick an agent and a point in time to reconstruct its state.
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/components/DashboardShell.tsx
+++ b/dashboard/components/DashboardShell.tsx
@@ -4,12 +4,12 @@ import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
 import { clearToken } from "@/lib/auth";
 import { BrandLogo } from "@/components/BrandLogo";
-import { Search, Settings, LogOut, Cpu, GitBranch, GitFork, AlertTriangle, Bug } from "lucide-react";
+import { Search, Settings, LogOut, Cpu, GitBranch, GitFork, AlertTriangle, Rewind, Layers, Bug } from "lucide-react";
 import { ConnectionStatus } from "@/components/ConnectionStatus";
 import { TenantPlanBanner } from "@/components/TenantPlanBanner";
 
 type NavLink = { href: string; label: string; icon: React.ElementType };
-type NavGroup = { label: string; icon: React.ElementType; children: NavLink[] };
+type NavGroup = { label: string; icon: React.ElementType; href?: string; children: NavLink[] };
 type NavEntry = NavLink | NavGroup;
 
 const nav: NavEntry[] = [
@@ -18,10 +18,13 @@ const nav: NavEntry[] = [
   {
     label: "Debugging",
     icon: Bug,
+    href: "/dashboard/debugging",
     children: [
       { href: "/dashboard/debugging/why", label: "Causal Trace", icon: GitBranch },
       { href: "/dashboard/debugging/impact", label: "Impact Trace", icon: GitFork },
       { href: "/dashboard/debugging/errors", label: "Error Explorer", icon: AlertTriangle },
+      { href: "/dashboard/debugging/time-travel", label: "Time Travel", icon: Rewind },
+      { href: "/dashboard/debugging/sessions", label: "Session Insights", icon: Layers },
     ],
   },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
@@ -97,13 +100,24 @@ export function DashboardShell({ children }: { children: React.ReactNode }) {
           {nav.map((entry) =>
             isGroup(entry) ? (
               <div key={entry.label} className="pt-3">
-                <div
-                  className="flex items-center gap-2 px-3 pb-1.5 text-[11px] font-semibold uppercase tracking-wider"
-                  style={{ color: "#666" }}
-                >
-                  <entry.icon size={13} />
-                  {entry.label}
-                </div>
+                {entry.href ? (
+                  <Link
+                    href={entry.href}
+                    className="flex items-center gap-2 px-3 pb-1.5 text-[11px] font-semibold uppercase tracking-wider transition"
+                    style={{ color: isNavActive(pathname, entry.href) ? "#a3a3a3" : "#666" }}
+                  >
+                    <entry.icon size={13} />
+                    {entry.label}
+                  </Link>
+                ) : (
+                  <div
+                    className="flex items-center gap-2 px-3 pb-1.5 text-[11px] font-semibold uppercase tracking-wider"
+                    style={{ color: "#666" }}
+                  >
+                    <entry.icon size={13} />
+                    {entry.label}
+                  </div>
+                )}
                 <div className="space-y-0.5">
                   {entry.children.map((child) => (
                     <SidebarLink


### PR DESCRIPTION
Closes #81. Stacked on `feat/error-explorer`; retarget to `main` as the stack merges.

## What
Gives the debugging tools a discoverable home and promotes two that were buried in
agent-detail tabs to first-class, picker-driven pages.

- **`/dashboard/debugging` hub** — cards for all six tools; the Debugging sidebar
  group header now links here.
- **Standalone Time Travel** — agent picker + datetime + quick-picks; reconstructs
  state; explains the no-`STATE_SET` case so output never looks broken.
- **Standalone Session Insights** (memory-diff, renamed) — agent → session pickers →
  summary, new-vs-prior event types, causal depth, error flag, duration, first
  events with one-click Causal Trace.
- Nav: Time Travel + Session Insights added to the Debugging group (5 tools + hub).

No backend change — reuses `getAgents`, `timeTravel`, `getMemoryDiff`,
`getAgentSessions`.

## Verified live
- Hub / time-travel / sessions pages load **200**; all five tools render in the nav.
- Dashboard production build compiles clean.
- Underlying endpoints previously verified against seeded data.

## Follow-ups (noted, not in this PR)
Shared-component extraction (G10); Memory Context preview + Forget UI (G8).

See `docs/DEBUGGING_SYSTEM_REVIEW.md` (F1, HIGH tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)