### PR TITLE
feat(infra): Phase 1 staging parity templates + prod-safe smoke

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Environment
 .env
 *.env
+.env.staging
+infra/.env.staging
 
 # Python
 __pycache__/

--- a/docs/staging.md
+++ b/docs/staging.md
@@ -1,0 +1,64 @@
+# Staging (Phase 1)
+
+Prod-like stack for rehearsing deploys. **Isolated data** — never share the production database.
+
+Managed cloud operators apply this on the EC2 that also runs `db.zizka.ai` (private `zizkadb-cloud` deploy path). Templates live in this public repo under `infra/`.
+
+## Shape
+
+| | Production | Staging |
+|---|---|---|
+| Hostname | `db.zizka.ai` | `staging-db.zizka.ai` |
+| Compose project | default / prod name | `zizkadb-staging` |
+| API host port | `8000` | `8001` |
+| Dashboard (PM2) | `3001` | `3002` |
+| Postgres / Redis / Qdrant ports | `5432` / `6379` / `6333` | `5433` / `6380` / `6335` |
+| Env file | prod secrets | `infra/.env.staging` (different JWTs) |
+| Flags | `ENV=production`, no `DEV_API_KEY`, `NEXT_PUBLIC_DEV_MODE=false` | **same** |
+
+## Bring up (API data plane)
+
+```bash
+cp infra/.env.staging.example infra/.env.staging
+# fill JWT secrets, DB password, email, OPENAI if needed
+
+export COMPOSE_PROJECT_NAME=zizkadb-staging
+docker compose \
+  -f infra/docker-compose.yml \
+  -f infra/docker-compose.staging.yml \
+  --env-file infra/.env.staging \
+  up -d --build
+```
+
+Health:
+
+```bash
+curl -sf http://127.0.0.1:8001/health/deep
+```
+
+## DNS / TLS / nginx
+
+1. Point `staging-db.zizka.ai` at the same EC2 as prod.
+2. Issue a TLS cert for that hostname.
+3. Add a server block — see [`infra/nginx.staging.snippet.conf`](../infra/nginx.staging.snippet.conf).
+4. Run staging dashboard on port `3002` with `NEXT_PUBLIC_DEV_MODE=false` and `NEXT_PUBLIC_API_URL=https://staging-db.zizka.ai`.
+
+## Deploy order
+
+1. Deploy candidate SHA to **staging**
+2. `curl -sf https://staging-db.zizka.ai/health/deep`
+3. OTP login (no “Open my dashboard” bypass)
+4. `ZIZKADB_API_KEY=... bash scripts/smoke-test.sh https://staging-db.zizka.ai`
+5. Only then deploy **prod**
+
+Never `docker compose down -v` on the production project.
+
+## Smoke
+
+```bash
+# Staging / production-like (requires a real API key from staging dashboard)
+ZIZKADB_API_KEY='zizkadb_live_...' bash scripts/smoke-test.sh https://staging-db.zizka.ai
+
+# Local development (dev key / dev-token still supported)
+bash scripts/smoke-test.sh http://localhost:8000
+```

--- a/infra/.env.staging.example
+++ b/infra/.env.staging.example
@@ -1,0 +1,33 @@
+# Copy to infra/.env.staging on the host (never commit real secrets).
+# Staging must use DIFFERENT secrets and volumes than production.
+
+POSTGRES_USER=zizkadb_staging
+POSTGRES_PASSWORD=change-me-staging-db-password
+POSTGRES_DB=zizkadb_staging
+
+# Generate: python -c "import secrets; print(secrets.token_hex(32))"
+JWT_SECRET=
+JWT_REFRESH_SECRET=
+
+ENV=production
+OTP_RATE_LIMIT_STORAGE=redis
+
+# Leave unset / empty — do not use zizkadb_dev_local on staging
+# DEV_API_KEY=
+
+DEPLOYMENT_MODE=managed
+
+PUBLIC_API_URL=https://staging-db.zizka.ai
+DASHBOARD_URL=https://staging-db.zizka.ai
+
+# Optional: embeddings / OTP email (can reuse non-secret host settings; use staging inbox if possible)
+OPENAI_API_KEY=
+EMAIL_HOST=
+EMAIL_PORT=465
+EMAIL_USER=
+EMAIL_PASS=
+EMAIL_FROM=
+
+# Dashboard build (host PM2 or compose dashboard overlay):
+# NEXT_PUBLIC_API_URL=https://staging-db.zizka.ai
+# NEXT_PUBLIC_DEV_MODE=false

--- a/infra/docker-compose.staging.yml
+++ b/infra/docker-compose.staging.yml
@@ -1,0 +1,66 @@
+# Staging overlay — same shape as prod, isolated data + ports.
+#
+# From repo root (or infra/), with a dedicated env file:
+#
+#   export COMPOSE_PROJECT_NAME=zizkadb-staging
+#   docker compose \
+#     -f infra/docker-compose.yml \
+#     -f infra/docker-compose.staging.yml \
+#     --env-file infra/.env.staging \
+#     up -d --build
+#
+# NEVER point DATABASE_URL / volumes at production data.
+# NEVER run `docker compose down -v` against the prod project by mistake —
+# always set COMPOSE_PROJECT_NAME=zizkadb-staging for this stack.
+
+services:
+  postgres:
+    container_name: zizkadb_staging_postgres
+    ports:
+      - "5433:5432"
+    volumes:
+      - staging_postgres_data:/var/lib/postgresql/data
+      - ../core/db/schema.sql:/docker-entrypoint-initdb.d/01_schema.sql
+
+  qdrant:
+    container_name: zizkadb_staging_qdrant
+    ports:
+      - "6335:6333"
+      - "6336:6334"
+    volumes:
+      - staging_qdrant_data:/qdrant/storage
+
+  redis:
+    container_name: zizkadb_staging_redis
+    ports:
+      - "6380:6379"
+    volumes:
+      - staging_redis_data:/data
+
+  api:
+    container_name: zizkadb_staging_api
+    ports:
+      - "8001:8000"
+    environment:
+      ENV: ${ENV:-production}
+      # Must be unset in infra/.env.staging — empty default avoids compose injecting the prod default key
+      DEV_API_KEY: ${DEV_API_KEY:-}
+      OTP_RATE_LIMIT_STORAGE: ${OTP_RATE_LIMIT_STORAGE:-redis}
+      PUBLIC_API_URL: ${PUBLIC_API_URL:-https://staging-db.zizka.ai}
+      DASHBOARD_URL: ${DASHBOARD_URL:-https://staging-db.zizka.ai}
+      JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in infra/.env.staging}
+      JWT_REFRESH_SECRET: ${JWT_REFRESH_SECRET:?set JWT_REFRESH_SECRET in infra/.env.staging}
+    volumes:
+      - staging_community_uploads:/data/community_uploads
+    command: uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4
+
+volumes:
+  staging_postgres_data:
+  staging_qdrant_data:
+  staging_redis_data:
+  staging_community_uploads:
+  # Suppress inheriting prod volume names from the base file for this project
+  postgres_data:
+  qdrant_data:
+  redis_data:
+  community_uploads:

--- a/infra/nginx.staging.snippet.conf
+++ b/infra/nginx.staging.snippet.conf
@@ -1,0 +1,56 @@
+# Example nginx server block for staging on the same host as prod.
+# Install under your nginx conf.d / sites-enabled; adjust certificate paths.
+# Upstream ports match infra/docker-compose.staging.yml (API :8001, dash :3002).
+
+# upstream zizkadb_staging_api { server 127.0.0.1:8001; }
+# upstream zizkadb_staging_dash { server 127.0.0.1:3002; }
+
+server {
+    listen 443 ssl http2;
+    server_name staging-db.zizka.ai;
+
+    # ssl_certificate     /etc/letsencrypt/live/staging-db.zizka.ai/fullchain.pem;
+    # ssl_certificate_key /etc/letsencrypt/live/staging-db.zizka.ai/privkey.pem;
+
+    location /health {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /health/deep {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /v1/ {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /swagger {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /openapi.json {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:3002;
+        proxy_set_header Host $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,26 +1,26 @@
 #!/usr/bin/env bash
 # Smoke test against a running ZizkaDB stack.
-# Usage: bash scripts/smoke-test.sh [API_BASE_URL]
+#
+# Usage:
+#   bash scripts/smoke-test.sh [API_BASE_URL]
+#
+# Local (development):
+#   bash scripts/smoke-test.sh http://localhost:8000
+#   Uses DEV_API_KEY / zizkadb_dev_local and /v1/auth/dev-token when available.
+#
+# Staging / production-like (ENV=production):
+#   ZIZKADB_API_KEY='zizkadb_live_...' bash scripts/smoke-test.sh https://staging-db.zizka.ai
+#   Requires a real API key — dev-token is disabled when ENV=production.
+#
+# Optional:
+#   SKIP_SEARCH=1          skip semantic search check
+#   SKIP_DEEP_HEALTH=1     skip /health/deep (not recommended)
 
 set -euo pipefail
 
 BASE="${1:-http://localhost:8000}"
-DEV_KEY="${DEV_API_KEY:-zizkadb_dev_local}"
+BASE="${BASE%/}"
 
-echo "→ Health"
-curl -sf "$BASE/health" | grep -q '"status":"ok"'
-
-echo "→ Dev token"
-curl -sf -X POST "$BASE/v1/auth/dev-token" | grep -q 'access_token'
-
-echo "→ Log event (dev key)"
-curl -sf -X POST "$BASE/v1/events" \
-  -H "Authorization: Bearer $DEV_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"agent":"support-bot","event":"smoke","data":{"ok":true}}' \
-  | grep -q 'event_id'
-
-# Gate 8 — semantic search (requires real OPENAI_API_KEY in infra/.env)
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 if [ -f "$ROOT/infra/.env" ]; then
   set -a
@@ -29,14 +29,49 @@ if [ -f "$ROOT/infra/.env" ]; then
   set +a
 fi
 
+API_KEY="${ZIZKADB_API_KEY:-${SMOKE_API_KEY:-}}"
+DEV_KEY="${DEV_API_KEY:-zizkadb_dev_local}"
+
+echo "→ Health ($BASE/health)"
+curl -sf "$BASE/health" | grep -q '"status":"ok"'
+
+if [ "${SKIP_DEEP_HEALTH:-}" != "1" ]; then
+  echo "→ Deep health ($BASE/health/deep)"
+  deep="$(curl -sf "$BASE/health/deep")"
+  if ! echo "$deep" | grep -q '"status"[[:space:]]*:[[:space:]]*"ok"'; then
+    echo "✗ /health/deep is not ok:" >&2
+    echo "$deep" >&2
+    exit 1
+  fi
+fi
+
+if [ -n "$API_KEY" ]; then
+  echo "→ Auth via ZIZKADB_API_KEY / SMOKE_API_KEY"
+  AUTH_HEADER="Authorization: Bearer $API_KEY"
+elif curl -sf -X POST "$BASE/v1/auth/dev-token" | grep -q 'access_token'; then
+  echo "→ Dev token (local / ENV=development only)"
+  AUTH_HEADER="Authorization: Bearer $DEV_KEY"
+else
+  echo "✗ No API key and /v1/auth/dev-token unavailable." >&2
+  echo "  For staging/prod set: ZIZKADB_API_KEY='zizkadb_live_...'" >&2
+  exit 1
+fi
+
+echo "→ Log event"
+curl -sf -X POST "$BASE/v1/events" \
+  -H "$AUTH_HEADER" \
+  -H "Content-Type: application/json" \
+  -d '{"agent":"support-bot","event":"smoke","data":{"ok":true}}' \
+  | grep -q 'event_id'
+
 if [ "${SKIP_SEARCH:-}" = "1" ]; then
   echo "→ Semantic search skipped (SKIP_SEARCH=1)"
 elif [ -z "${OPENAI_API_KEY:-}" ] || [ "$OPENAI_API_KEY" = "sk-..." ] || [ "${#OPENAI_API_KEY}" -lt 20 ]; then
-  echo "→ Semantic search skipped (set OPENAI_API_KEY in infra/.env)"
+  echo "→ Semantic search skipped (set OPENAI_API_KEY)"
 else
-  echo "→ Semantic search (Gate 8)"
+  echo "→ Semantic search"
   curl -sf -X POST "$BASE/v1/search" \
-    -H "Authorization: Bearer $DEV_KEY" \
+    -H "$AUTH_HEADER" \
     -H "Content-Type: application/json" \
     -d '{"agent":"support-bot","query":"test","limit":1}' \
     | grep -q '"results"'

--- a/wiki/Self-Hosting.md
+++ b/wiki/Self-Hosting.md
@@ -102,6 +102,19 @@ bash infra/deploy-selfhost.sh
 
 **Never** `docker compose down -v` on a server with real users.
 
+## Staging (prod-like rehearsal)
+
+Same host can run a second Compose project with isolated volumes and ports. Templates and deploy order: [docs/staging.md](../docs/staging.md).
+
+```bash
+export COMPOSE_PROJECT_NAME=zizkadb-staging
+docker compose -f infra/docker-compose.yml -f infra/docker-compose.staging.yml \
+  --env-file infra/.env.staging up -d --build
+ZIZKADB_API_KEY='...' bash scripts/smoke-test.sh https://staging-db.zizka.ai
+```
+
+Use `ENV=production`, `NEXT_PUBLIC_DEV_MODE=false`, and **different** JWT secrets than production.
+
 Local laptop reset only:
 
 ```bash


### PR DESCRIPTION
## Summary
- Same-host staging Compose overlay, env/nginx examples, and [docs/staging.md](docs/staging.md) for isolated prod-like rehearsals.
- Smoke script checks `/health/deep` and supports `ZIZKADB_API_KEY` when `ENV=production` (no dev-token).
- Branched from `feat/phase0-otp-redis-rate-limit` (not behind `main`).

Closes #88

## Why
Without staging, every deploy is a prod gamble. This gives a second stack (ports/volumes/secrets) on the same EC2 so Phase 0+ changes can be verified first.

## Architect / DevOps review
**Verdict: ship templates; you must apply AWS/host steps.** Low code risk (scripts/docs/compose overlay only). No API contract change. Main risk is operator error (wrong `DATABASE_URL` / `down -v` on prod) — mitigated by `COMPOSE_PROJECT_NAME=zizkadb-staging` and docs.

## AWS / env (after merge — on EC2)
1. DNS + TLS for `staging-db.zizka.ai`
2. `infra/.env.staging` from example (new JWTs, `ENV=production`, empty `DEV_API_KEY`)
3. Compose up with staging overlay + project name
4. Nginx → `:8001` / `:3002`; dashboard `NEXT_PUBLIC_DEV_MODE=false`
5. Smoke with real staging API key
6. Rollback staging: stop staging compose project only

## Test plan
- [ ] Review compose port/volume isolation vs prod
- [ ] Local: `bash scripts/smoke-test.sh http://localhost:8000` (dev)
- [ ] On host after bring-up: deep health + OTP login + smoke with `ZIZKADB_API_KEY`
- [ ] Confirm no shared DB with prod


Made with [Cursor](https://cursor.com)