### PR TITLE
Fix: Resolve Issue #2

### DIFF
--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -415,7 +415,7 @@ async def _baseline_for(
             p.event_type || ' -> ' || c.event_type AS key,
             COUNT(*) AS count
         FROM events c
-        JOIN events p ON c.parent_event_id = p.event_id
+        JOIN events p ON c.parent_event_id = p.event_id AND p.tenant_id = c.tenant_id
         WHERE c.tenant_id = $1 AND c.agent_id = $2 AND c.session_id = ANY($3::text[])
         GROUP BY p.event_type, c.event_type
         ORDER BY count DESC
@@ -620,7 +620,7 @@ async def _baseline_for_timewindow(
             p.event_type || ' -> ' || c.event_type AS key,
             COUNT(*) AS count
         FROM events c
-        JOIN events p ON c.parent_event_id = p.event_id
+        JOIN events p ON c.parent_event_id = p.event_id AND p.tenant_id = c.tenant_id
         WHERE c.tenant_id = $1 AND c.agent_id = $2 AND c.{ts_filter.replace('timestamp', 'c.timestamp')}
         GROUP BY p.event_type, c.event_type
         ORDER BY count DESC

--- a/core/services/event_write.py
+++ b/core/services/event_write.py
@@ -9,6 +9,7 @@ import logging
 from db.connection import get_pool, get_qdrant
 from qdrant_client.models import PointStruct
 from services.embeddings import generate_embedding, event_to_text
+from services.exceptions import bad_request
 
 logger = logging.getLogger(__name__)
 
@@ -24,6 +25,16 @@ async def write_event(
     metadata: dict | None = None,
 ) -> dict:
     pool = get_pool()
+
+    if parent_id:
+        parent_tenant_id = await pool.fetchval(
+            "SELECT tenant_id FROM events WHERE event_id = $1",
+            parent_id,
+        )
+        if parent_tenant_id is None or str(parent_tenant_id) != str(tenant_id):
+            raise bad_request(
+                f"parent_id '{parent_id}' does not exist or belongs to a different tenant"
+            )
 
     await pool.execute(
         """

--- a/core/tests/test_tenant_isolation.py
+++ b/core/tests/test_tenant_isolation.py
@@ -1,0 +1,114 @@
+"""Regression tests for cross-tenant leaks via parent_event_id (write_event validation + baseline transitions query)."""
+
+from unittest.mock import AsyncMock
+import datetime
+
+import pytest
+from fastapi import HTTPException
+
+from services.event_write import write_event
+from api.agents import _baseline_for, _baseline_for_timewindow
+
+
+TENANT_A = "11111111-1111-1111-1111-111111111111"
+TENANT_B = "22222222-2222-2222-2222-222222222222"
+PARENT_EVENT_ID = "33333333-3333-3333-3333-333333333333"
+
+
+@pytest.fixture
+def mock_pool(monkeypatch):
+    pool = AsyncMock()
+    monkeypatch.setattr("services.event_write.get_pool", lambda: pool)
+    monkeypatch.setattr("services.event_write.get_qdrant", lambda: AsyncMock())
+    monkeypatch.setattr(
+        "services.event_write.generate_embedding", AsyncMock(return_value=None)
+    )
+    return pool
+
+
+@pytest.mark.asyncio
+async def test_write_event_rejects_cross_tenant_parent(mock_pool):
+    """Tenant B must not be able to link a new event to tenant A's event_id."""
+    mock_pool.fetchval.return_value = TENANT_A  # parent belongs to a different tenant
+
+    with pytest.raises(HTTPException) as exc_info:
+        await write_event(
+            tenant_id=TENANT_B,
+            agent="agent-b",
+            event="child_event",
+            data={},
+            parent_id=PARENT_EVENT_ID,
+        )
+
+    assert exc_info.value.status_code == 400
+    mock_pool.execute.assert_not_called()  # never reaches the INSERT
+
+
+@pytest.mark.asyncio
+async def test_write_event_rejects_nonexistent_parent(mock_pool):
+    mock_pool.fetchval.return_value = None
+
+    with pytest.raises(HTTPException) as exc_info:
+        await write_event(
+            tenant_id=TENANT_B,
+            agent="agent-b",
+            event="child_event",
+            data={},
+            parent_id=PARENT_EVENT_ID,
+        )
+
+    assert exc_info.value.status_code == 400
+    mock_pool.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_event_allows_same_tenant_parent(mock_pool):
+    mock_pool.fetchval.return_value = TENANT_A
+    mock_pool.fetchrow.return_value = {
+        "event_id": "44444444-4444-4444-4444-444444444444",
+        "timestamp": datetime.datetime.now(datetime.timezone.utc),
+        "sequence_no": 2,
+    }
+
+    result = await write_event(
+        tenant_id=TENANT_A,
+        agent="agent-a",
+        event="child_event",
+        data={},
+        parent_id=PARENT_EVENT_ID,
+    )
+
+    assert result["event_id"] == "44444444-4444-4444-4444-444444444444"
+
+
+def _transition_sql(pool):
+    """Pull the SQL text of the transitions query (the one joining events p)."""
+    calls = [c for c in pool.fetch.await_args_list if "JOIN events p" in c.args[0]]
+    assert calls, "transitions query was not executed"
+    return calls[0].args[0]
+
+
+@pytest.mark.asyncio
+async def test_baseline_transitions_query_scopes_parent_by_tenant():
+    """The event_type -> event_type transition query must not join across tenants."""
+    pool = AsyncMock()
+    pool.fetch.return_value = []
+    pool.fetchrow.return_value = {"avg_events": 0, "avg_dur": 0, "pct": 0}
+
+    await _baseline_for(pool, TENANT_A, "agent-a", ["session-1"])
+
+    sql = _transition_sql(pool)
+    assert "p.tenant_id" in sql
+
+
+@pytest.mark.asyncio
+async def test_behavior_change_transitions_query_scopes_parent_by_tenant():
+    pool = AsyncMock()
+    pool.fetch.return_value = []
+    pool.fetchrow.return_value = {"pct": 0}
+
+    now = datetime.datetime(2026, 1, 1)
+    await _baseline_for_timewindow(pool, TENANT_A, "agent-a", None, now)
+
+    sql = _transition_sql(pool)
+    assert "p.tenant_id" in sql


### PR DESCRIPTION
Fix: Prevent cross-tenant data leaks via parent_event_id (Resolves 2)

Description:
This PR resolves Issue 2 by enforcing strict tenant isolation for both read and write operations regarding parent_event_id.

Key Changes:

1)Read Isolation (agent.py): Hardened the transition queries by adding the p.tenant_id = c.tenant_id condition directly to the JOIN clause, preventing cross-tenant data exposure at the database level.

2)Write Validation (services/event_write.py): Implemented strict pre-insertion checks. The API now validates that the provided parent_id exists and belongs to the requesting tenant_id. Returns a 400 Bad Request otherwise.

3)Regression Testing (test_tenant_isolation.py): Added a comprehensive test suite using AsyncMock to verify write rejections (cross-tenant and non-existent parents) and to guarantee the presence of the tenant-scoping condition in the generated SQL queries.

Tested locally and passing all isolation constraints.