### PR TITLE
fix: /health/deep status code, self-host SDK error clarity, agent-scoped key isolation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ cd dashboard && npm run lint && npm run build
 
 1. **Auth deps**: never put `require_dashboard_session` routes on `get_tenant` — API-key holders must not be able to manage keys or access user data.
 2. **Route paths**: never rename `/v1/...` paths without updating `dashboard/lib/api.ts` — there is no runtime contract enforcement between backend and dashboard.
-3. **`assert_agent_allowed()`**: every per-agent analytics route (`agent_stats`, `list_sessions`, `agent_baseline`, `agent_behavior_change`, `time_travel`) must call this.
+3. **`assert_agent_allowed()`**: every per-agent route (`agent_stats`, `list_sessions`, `agent_baseline`, `agent_behavior_change`, `time_travel`, `why`, `memory/context`, `memory/diff`) must call this before touching event/session data. `memory/forget` is the one exception: instead of blocking, it scopes its `WHERE` clause to the caller's bound agent when the key is agent-scoped, since a tenant-wide key must still be able to erase a user's data across all of that tenant's agents for GDPR requests.
 4. **Entitlements single source**: plan caps live only in `core/services/entitlements.py::PLAN_ENTITLEMENTS`.
 5. **Idempotent DDL**: all schema changes must use `IF NOT EXISTS` / `IF EXISTS` — the same migration runs on fresh installs and live databases.
 6. **`docker-compose.yml` is production**: never add `--reload` or `../core:/app` volume mounts to the base compose file. Those belong in `docker-compose.dev.yml`.

--- a/core/api/events.py
+++ b/core/api/events.py
@@ -124,6 +124,14 @@ async def why(
     except ValueError:
         raise not_found("Event not found")
 
+    target = await pool.fetchrow(
+        "SELECT agent_id FROM events WHERE event_id = $1 AND tenant_id = $2",
+        event_id, tenant_id,
+    )
+    if not target:
+        raise not_found("Event not found")
+    assert_agent_allowed(tenant, target["agent_id"])
+
     rows = await pool.fetch(
         """
         WITH RECURSIVE causal_chain AS (

--- a/core/api/memory.py
+++ b/core/api/memory.py
@@ -14,7 +14,7 @@ from typing import Any
 import json
 import logging
 
-from api.deps import get_tenant
+from api.deps import assert_agent_allowed, get_tenant
 from db.connection import get_pool, get_qdrant
 from services.embeddings import generate_embedding
 
@@ -59,6 +59,7 @@ async def get_context(
             {"role": "user", "content": user_message}
         ]
     """
+    assert_agent_allowed(tenant, body.agent)
     tenant_id = tenant["tenant_id"]
     pool = get_pool()
 
@@ -226,6 +227,7 @@ async def session_diff(
         raise not_found("Session not found")
 
     agent_id = rows[0]["agent_id"]
+    assert_agent_allowed(tenant, agent_id)
     events = []
     event_types: dict[str, int] = {}
     has_error = False
@@ -321,17 +323,25 @@ async def forget(
     tenant_id = tenant["tenant_id"]
     pool = get_pool()
 
+    # An agent-scoped API key must only ever be able to forget events that
+    # belong to its own agent -- otherwise a key minted for one agent could
+    # erase another agent's data in the same tenant. A tenant-wide key (no
+    # scoped agent_id) keeps the original tenant-wide GDPR erasure behavior.
+    scoped_agent = tenant.get("agent_id")
+    conditions = ["tenant_id = $1", "data->$2 = to_jsonb($3::text)"]
+    params: list = [tenant_id, body.filter_key, body.filter_value]
+    if scoped_agent:
+        conditions.append(f"agent_id = ${len(params) + 1}")
+        params.append(scoped_agent)
+
     # Find matching event IDs
     rows = await pool.fetch(
-        """
+        f"""
         SELECT event_id
         FROM events
-        WHERE tenant_id = $1
-          AND data->$2 = to_jsonb($3::text)
+        WHERE {" AND ".join(conditions)}
         """,
-        tenant_id,
-        body.filter_key,
-        body.filter_value,
+        *params,
     )
 
     if not rows:

--- a/core/main.py
+++ b/core/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.openapi.docs import get_swagger_ui_html
 from contextlib import asynccontextmanager
 import logging
@@ -113,10 +113,14 @@ async def health():
 
 @app.get("/health/deep")
 async def health_deep():
+    """Per-subsystem health. Returns 503 (not 200) when any check fails, so
+    orchestrators that gate on status code — not response body — see the
+    failure instead of treating a degraded backend as healthy."""
     checks = {
         "postgres": await check_postgres(),
         "redis": await check_redis(),
         "qdrant": await check_qdrant(),
     }
-    status = "ok" if all(check.get("ok") for check in checks.values()) else "degraded"
-    return {"status": status, "checks": checks}
+    healthy = all(check.get("ok") for check in checks.values())
+    body = {"status": "ok" if healthy else "degraded", "checks": checks}
+    return JSONResponse(content=body, status_code=200 if healthy else 503)

--- a/core/tests/test_agent_scope_isolation.py
+++ b/core/tests/test_agent_scope_isolation.py
@@ -1,0 +1,163 @@
+"""Regression tests: an agent-scoped API key must never read or delete
+another agent's events within the same tenant.
+
+Covers four routes that used to skip assert_agent_allowed() entirely --
+GET /v1/events/{id}/why, POST /v1/memory/context, GET /v1/memory/diff/{id},
+and DELETE /v1/memory/forget -- unlike every comparable per-agent route
+(agent_stats, list_sessions, agent_baseline, behavior-change, time_travel),
+which already called it.
+
+No live Postgres needed: get_tenant is overridden via FastAPI's
+dependency_overrides, and each module's get_pool() is monkeypatched to a
+fake pool returning canned rows.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.deps import get_tenant
+from main import app
+
+client = TestClient(app)
+
+SCOPED_TENANT = {"tenant_id": "11111111-1111-1111-1111-111111111111", "agent_id": "bot-a"}
+UNSCOPED_TENANT = {"tenant_id": "11111111-1111-1111-1111-111111111111"}
+EVENT_ID = "22222222-2222-2222-2222-222222222222"
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.pop(get_tenant, None)
+
+
+def _as_tenant(tenant: dict) -> None:
+    app.dependency_overrides[get_tenant] = lambda: tenant
+
+
+class TestWhyAgentScope:
+    def test_scoped_key_cannot_trace_another_agents_event(self, monkeypatch):
+        _as_tenant(SCOPED_TENANT)
+        pool = AsyncMock()
+        pool.fetchrow.return_value = {"agent_id": "bot-b"}  # event belongs to a different agent
+        monkeypatch.setattr("api.events.get_pool", lambda: pool)
+
+        response = client.get(f"/v1/events/{EVENT_ID}/why")
+
+        assert response.status_code == 403
+        pool.fetch.assert_not_called()  # never runs the recursive CTE for a disallowed event
+
+    def test_scoped_key_can_trace_its_own_agents_event(self, monkeypatch):
+        _as_tenant(SCOPED_TENANT)
+        pool = AsyncMock()
+        pool.fetchrow.return_value = {"agent_id": "bot-a"}
+        pool.fetch.return_value = [{
+            "event_id": EVENT_ID,
+            "agent_id": "bot-a",
+            "timestamp": __import__("datetime").datetime(2026, 1, 1),
+            "event_type": "tool_call",
+            "data": {},
+            "parent_event_id": None,
+            "session_id": None,
+            "sequence_no": 1,
+        }]
+        monkeypatch.setattr("api.events.get_pool", lambda: pool)
+
+        response = client.get(f"/v1/events/{EVENT_ID}/why")
+
+        assert response.status_code == 200
+        assert response.json()["chain_length"] == 1
+
+    def test_unscoped_key_can_trace_any_agent(self, monkeypatch):
+        _as_tenant(UNSCOPED_TENANT)
+        pool = AsyncMock()
+        pool.fetchrow.return_value = {"agent_id": "bot-b"}
+        pool.fetch.return_value = [{
+            "event_id": EVENT_ID,
+            "agent_id": "bot-b",
+            "timestamp": __import__("datetime").datetime(2026, 1, 1),
+            "event_type": "tool_call",
+            "data": {},
+            "parent_event_id": None,
+            "session_id": None,
+            "sequence_no": 1,
+        }]
+        monkeypatch.setattr("api.events.get_pool", lambda: pool)
+
+        response = client.get(f"/v1/events/{EVENT_ID}/why")
+
+        assert response.status_code == 200
+
+
+class TestMemoryContextAgentScope:
+    def test_scoped_key_cannot_pull_context_for_another_agent(self, monkeypatch):
+        _as_tenant(SCOPED_TENANT)
+        pool = AsyncMock()
+        monkeypatch.setattr("api.memory.get_pool", lambda: pool)
+
+        response = client.post(
+            "/v1/memory/context",
+            json={"agent": "bot-b", "task": "anything"},
+        )
+
+        assert response.status_code == 403
+        pool.fetch.assert_not_called()
+
+
+class TestMemoryDiffAgentScope:
+    def test_scoped_key_cannot_diff_another_agents_session(self, monkeypatch):
+        _as_tenant(SCOPED_TENANT)
+        pool = AsyncMock()
+        pool.fetch.return_value = [{
+            "event_id": EVENT_ID,
+            "agent_id": "bot-b",
+            "event_type": "user_message",
+            "data": {},
+            "timestamp": __import__("datetime").datetime(2026, 1, 1),
+            "parent_event_id": None,
+        }]
+        monkeypatch.setattr("api.memory.get_pool", lambda: pool)
+
+        response = client.get("/v1/memory/diff/some-session")
+
+        assert response.status_code == 403
+
+
+class TestForgetAgentScope:
+    def test_scoped_key_forget_is_restricted_to_its_own_agent(self, monkeypatch):
+        _as_tenant(SCOPED_TENANT)
+        pool = AsyncMock()
+        pool.fetch.return_value = []  # nothing matches once agent-scoped
+        monkeypatch.setattr("api.memory.get_pool", lambda: pool)
+
+        response = client.request(
+            "DELETE",
+            "/v1/memory/forget",
+            json={"filter_key": "user_id", "filter_value": "user_123"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["deleted_events"] == 0
+
+        select_sql, *select_params = pool.fetch.call_args.args
+        assert "agent_id" in select_sql
+        assert "bot-a" in select_params
+
+    def test_unscoped_key_forget_stays_tenant_wide(self, monkeypatch):
+        _as_tenant(UNSCOPED_TENANT)
+        pool = AsyncMock()
+        pool.fetch.return_value = []
+        monkeypatch.setattr("api.memory.get_pool", lambda: pool)
+
+        response = client.request(
+            "DELETE",
+            "/v1/memory/forget",
+            json={"filter_key": "user_id", "filter_value": "user_123"},
+        )
+
+        assert response.status_code == 200
+        select_sql, *select_params = pool.fetch.call_args.args
+        assert "agent_id" not in select_sql
+        assert "bot-a" not in select_params

--- a/core/tests/test_health.py
+++ b/core/tests/test_health.py
@@ -1,0 +1,63 @@
+"""Unit tests for /health and /health/deep.
+
+No live Postgres/Redis/Qdrant needed: main.check_postgres/check_redis/
+check_qdrant are monkeypatched directly, and TestClient(app) (used without a
+`with` block, matching test_rate_limiting.py) never runs the app lifespan, so
+/health never touches a real dependency either.
+"""
+
+from unittest.mock import AsyncMock
+
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+OK = {"ok": True}
+
+
+def test_health_shallow_is_always_ok_and_ignores_dependencies(monkeypatch):
+    """Shallow /health is a liveness probe: it must stay 200 even if every
+    dependency is down, and it must not call the dependency checks at all."""
+    monkeypatch.setattr("main.check_postgres", AsyncMock(side_effect=RuntimeError("down")))
+    monkeypatch.setattr("main.check_redis", AsyncMock(side_effect=RuntimeError("down")))
+    monkeypatch.setattr("main.check_qdrant", AsyncMock(side_effect=RuntimeError("down")))
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok", "version": "0.1.0"}
+
+
+def test_health_deep_all_ok_returns_200(monkeypatch):
+    monkeypatch.setattr("main.check_postgres", AsyncMock(return_value=OK))
+    monkeypatch.setattr("main.check_redis", AsyncMock(return_value=OK))
+    monkeypatch.setattr("main.check_qdrant", AsyncMock(return_value={"ok": True, "collections": []}))
+
+    response = client.get("/health/deep")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["checks"]["postgres"]["ok"] is True
+
+
+def test_health_deep_reports_503_and_names_failed_subsystem(monkeypatch):
+    """A degraded backend must fail the HTTP status, not just the JSON body --
+    orchestrators that gate on status code (not body) need this to detect it."""
+    monkeypatch.setattr("main.check_postgres", AsyncMock(return_value=OK))
+    monkeypatch.setattr(
+        "main.check_redis",
+        AsyncMock(return_value={"ok": False, "error": "Redis connection refused"}),
+    )
+    monkeypatch.setattr("main.check_qdrant", AsyncMock(return_value=OK))
+
+    response = client.get("/health/deep")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "degraded"
+    assert body["checks"]["postgres"]["ok"] is True
+    assert body["checks"]["redis"]["ok"] is False
+    assert "Redis connection refused" in body["checks"]["redis"]["error"]
+    assert body["checks"]["qdrant"]["ok"] is True

--- a/docs/adr/004-auth-dependency-split.md
+++ b/docs/adr/004-auth-dependency-split.md
@@ -47,7 +47,9 @@ def assert_agent_allowed(tenant: dict, agent_id: str) -> None:
         raise HTTPException(403, ...)
 ```
 
-Call at the top of any per-agent analytics route (stats, sessions, baseline, behavior-change, time-travel). Agent-scoped API keys can only access data for their bound agent.
+Call at the top of any per-agent route (stats, sessions, baseline, behavior-change, time-travel, why, memory/context, memory/diff). Agent-scoped API keys can only access data for their bound agent.
+
+`memory/forget` doesn't call this directly — it's a filter-match bulk delete, not a single-agent lookup, so instead it adds `agent_id = <scoped agent>` to its own `WHERE` clause when the calling key is agent-scoped. A tenant-wide key keeps the original cross-agent behavior, since GDPR erasure needs to reach a user's data across every agent in the tenant.
 
 ---
 

--- a/sdk/python/tests/test_client_errors.py
+++ b/sdk/python/tests/test_client_errors.py
@@ -1,0 +1,59 @@
+"""Tests for ZizkaDB._handle() error surfacing (Issue: wrong API key on self-host)."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from zizkadb.client import ZizkaDB
+from zizkadb.exceptions import AgentScopeError, AuthError, NotFoundError, RateLimitError
+
+
+def _response(status_code: int, detail: str) -> httpx.Response:
+    request = httpx.Request("POST", "http://testserver/v1/events")
+    return httpx.Response(status_code, json={"detail": detail}, request=request)
+
+
+def test_self_hosted_401_surfaces_server_detail_and_self_host_hint():
+    """Before this fix, every 401 raised a hardcoded cloud-only message that
+    discarded the server's actual detail and pointed self-hosters at a cloud
+    dashboard they don't have."""
+    db = ZizkaDB(host="http://localhost:8000", api_key="bad_key")
+
+    with pytest.raises(AuthError) as exc:
+        db._handle(_response(401, "Invalid or revoked API key"))
+
+    message = str(exc.value)
+    assert "Invalid or revoked API key" in message
+    assert "localhost:8000" in message
+    assert "db.zizka.ai/dashboard" not in message
+
+
+def test_cloud_401_points_to_dashboard():
+    db = ZizkaDB(api_key="zizkadb_live_bad")
+
+    with pytest.raises(AuthError) as exc:
+        db._handle(_response(401, "Invalid or revoked API key"))
+
+    message = str(exc.value)
+    assert "Invalid or revoked API key" in message
+    assert "db.zizka.ai/dashboard" in message
+
+
+def test_403_still_surfaces_agent_scope_detail():
+    db = ZizkaDB(host="http://localhost:8000", api_key="scoped_key")
+
+    with pytest.raises(AgentScopeError) as exc:
+        db._handle(_response(403, "This API key is scoped to agent 'bot-a' only"))
+
+    assert "bot-a" in str(exc.value)
+
+
+def test_404_and_429_unchanged():
+    db = ZizkaDB(host="http://localhost:8000", api_key="k")
+
+    with pytest.raises(NotFoundError):
+        db._handle(_response(404, "not found"))
+
+    with pytest.raises(RateLimitError):
+        db._handle(_response(429, "slow down"))

--- a/sdk/python/zizkadb/client.py
+++ b/sdk/python/zizkadb/client.py
@@ -503,17 +503,29 @@ class ZizkaDB:
             if not self._client:
                 await client.aclose()
 
+    @staticmethod
+    def _error_detail(resp: httpx.Response) -> str:
+        """Best-effort extraction of the server's {"detail": ...} message."""
+        try:
+            return resp.json().get("detail", resp.text)
+        except Exception:
+            return resp.text
+
     def _handle(self, resp: httpx.Response) -> Any:
         if resp.status_code == 401:
-            raise AuthError(
-                "Invalid API key. Create an agent at db.zizka.ai/dashboard and copy its key.",
-                status_code=401,
-            )
+            detail = self._error_detail(resp)
+            if _is_local_host(self._base_url):
+                hint = (
+                    f"Self-hosted at {self._base_url}: check that ZIZKADB_API_KEY matches "
+                    "a key from your dashboard, or that DEV_API_KEY / ENV=development is set "
+                    "on the server if you're using the local dev key "
+                    "(see wiki/Self-Hosting.md#troubleshooting)."
+                )
+            else:
+                hint = "Create an agent at db.zizka.ai/dashboard and copy its key."
+            raise AuthError(f"{detail}. {hint}", status_code=401)
         if resp.status_code == 403:
-            try:
-                detail = resp.json().get("detail", resp.text)
-            except Exception:
-                detail = resp.text
+            detail = self._error_detail(resp)
             raise AgentScopeError(
                 f"Agent mismatch (403): {detail}",
                 status_code=403,
@@ -523,10 +535,7 @@ class ZizkaDB:
         if resp.status_code == 429:
             raise RateLimitError("Rate limit exceeded", status_code=429)
         if resp.status_code >= 400:
-            try:
-                detail = resp.json().get("detail", resp.text)
-            except Exception:
-                detail = resp.text
+            detail = self._error_detail(resp)
             raise ZizkaDBError(
                 f"ZizkaDB error ({resp.status_code}): {detail}",
                 status_code=resp.status_code,


### PR DESCRIPTION
## Summary

Three independent, self-contained fixes:

- **`/health/deep` now returns HTTP 503 when a subsystem is down**, instead of always 200. Orchestrators that gate on status code (not response body) previously couldn't detect a degraded backend. `/health` (shallow) is unchanged — it stays a dependency-free liveness probe.
- **Python SDK 401 errors now surface the real server detail and a host-appropriate hint.** Previously every 401 raised a hardcoded message pointing self-hosted users at `db.zizka.ai/dashboard`, discarding the actual server-side reason (e.g. "revoked" vs "invalid") and giving self-host users advice that doesn't apply to them.
- **Agent-scoped API keys can no longer read another agent's data within the same tenant.** `why()`, `memory/context`, and `memory/diff/{session_id}` never called `assert_agent_allowed()`, unlike every comparable per-agent route (`agent_stats`, `list_sessions`, `agent_baseline`, `agent_behavior_change`, `time_travel`). A key scoped to one agent could trace another agent's causal chain, pull its memory context, or read its session diff. `memory/forget` is handled differently since it's a filter-match bulk delete with no single owning agent — instead of blocking, it now scopes its `WHERE` clause to the caller's bound agent when the key is agent-scoped, while a tenant-wide key keeps the original cross-agent GDPR-erasure behavior.

`CLAUDE.md` and `docs/adr/004-auth-dependency-split.md` are updated so the documented route list for `assert_agent_allowed()` matches what the code actually enforces.

## Test plan

- `core/tests/test_health.py` (new, 3 tests): shallow `/health` stays 200 and skips dependency checks even when all three are mocked to fail; `/health/deep` returns 200 when all checks pass; returns 503 and names the failed subsystem when one fails.
- `sdk/python/tests/test_client_errors.py` (new, 4 tests): self-hosted 401 includes server detail + self-host hint and omits the cloud dashboard pointer; cloud 401 still points to the dashboard; 403/404/429 handling unchanged.
- `core/tests/test_agent_scope_isolation.py` (new, 7 tests): scoped key blocked from `why` / `memory/context` / `memory/diff` on another agent's data; scoped key allowed on its own agent's data; unscoped (tenant-wide) key unaffected; `forget` scopes its query to the bound agent for scoped keys and stays tenant-wide for unscoped keys.
- Full suite: `pytest core/tests/ -m "not integration"` → 143 passed, 6 deselected (integration tests need a live stack, skipped per repo convention).
- `ruff check core/ sdk/python/zizkadb/client.py` → clean.

No live stack (Docker/Postgres/Qdrant/Redis) was needed to write or verify any of these — all three are exercised through mocked dependencies / FastAPI dependency overrides.
