### PR TITLE
fix(mcp): make auth failures obvious and actionable

### DIFF
--- a/mcp/tests/test_server.py
+++ b/mcp/tests/test_server.py
@@ -8,6 +8,7 @@ mocked httpx responses. No running server or database required.
 from __future__ import annotations
 
 import json
+import httpx
 import pytest
 import importlib
 import sys
@@ -31,6 +32,16 @@ def _patch_api(body: dict | list, status: int = 200):
         "zizkadb_mcp.server._api",
         new=AsyncMock(return_value=body if status < 400 else {"error": str(body), "status": status}),
     )
+
+
+def _client(return_value=None, side_effect=None):
+    """Mock httpx.AsyncClient where every HTTP method shares the same stub."""
+    client = AsyncMock()
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=None)
+    for method in ("get", "post", "request"):
+        setattr(client, method, AsyncMock(return_value=return_value, side_effect=side_effect))
+    return client
 
 
 # ── _api helper ────────────────────────────────────────────────────────────
@@ -269,3 +280,171 @@ class TestMemoryDiff:
             await memory_diff(session_id="sess/with/slashes")
 
         assert "sess/with/slashes" not in captured["path"]
+
+
+# ── Auth error clarity (issue #85, task 8) ─────────────────────────────────
+#
+# Connecting the MCP server with wrong credentials must produce obvious,
+# actionable errors — never raw JSON blobs, uncaught exceptions, or (worst)
+# silent empty responses.
+
+class TestAuthErrorClarity:
+    @pytest.mark.asyncio
+    async def test_401_surfaces_server_detail_and_cloud_hint(self, monkeypatch):
+        """Wrong key on cloud: the server's detail AND a remediation hint."""
+        monkeypatch.setattr("zizkadb_mcp.server._KEY", "bad_key")
+        monkeypatch.setattr("zizkadb_mcp.server._HOST", "https://db.zizka.ai")
+        resp = _mock_response(401, {"detail": "Invalid or revoked API key"})
+
+        with patch("zizkadb_mcp.server.httpx.AsyncClient", return_value=_client(return_value=resp)):
+            from zizkadb_mcp.server import _api
+            result = await _api("GET", "/events")
+
+        assert result["status"] == 401
+        assert "Invalid or revoked API key" in result["error"]  # server detail kept
+        assert "Authentication failed" in result["error"]
+        assert "db.zizka.ai" in result["error"]  # where to fix it
+        # Not the old raw-JSON-blob behaviour:
+        assert result["error"] != '{"detail": "Invalid or revoked API key"}'
+
+    @pytest.mark.asyncio
+    async def test_401_self_host_hint_on_localhost(self, monkeypatch):
+        """Wrong key on self-host: hint must point at the LOCAL dashboard,
+        not at the cloud signup page."""
+        monkeypatch.setattr("zizkadb_mcp.server._KEY", "bad_key")
+        monkeypatch.setattr("zizkadb_mcp.server._HOST", "http://localhost:8000")
+        resp = _mock_response(401, {"detail": "Invalid or revoked API key"})
+
+        with patch("zizkadb_mcp.server.httpx.AsyncClient", return_value=_client(return_value=resp)):
+            from zizkadb_mcp.server import _api
+            result = await _api("GET", "/events")
+
+        assert result["status"] == 401
+        assert "localhost:3001" in result["error"]  # local dashboard
+        assert "ENV=development" in result["error"]  # dev-key escape hatch
+        assert "Sign up at https://db.zizka.ai" not in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_403_explains_agent_scope(self, monkeypatch):
+        """Scoped-key mismatch: surface the server's detail and say 'scoped'."""
+        monkeypatch.setattr("zizkadb_mcp.server._KEY", "scoped_key")
+        detail = "This API key is scoped to agent 'bot-a' only"
+        resp = _mock_response(403, {"detail": detail})
+
+        with patch("zizkadb_mcp.server.httpx.AsyncClient", return_value=_client(return_value=resp)):
+            from zizkadb_mcp.server import _api
+            result = await _api("GET", "/events")
+
+        assert result["status"] == 403
+        assert "bot-a" in result["error"]
+        assert "scoped" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_unreachable_host_returns_error_not_exception(self, monkeypatch):
+        """Server down / wrong ZIZKADB_HOST: previously an uncaught
+        httpx.ConnectError traceback — now a clear error naming the host."""
+        monkeypatch.setattr("zizkadb_mcp.server._KEY", "any_key")
+        monkeypatch.setattr("zizkadb_mcp.server._HOST", "http://localhost:8000")
+
+        with patch(
+            "zizkadb_mcp.server.httpx.AsyncClient",
+            return_value=_client(side_effect=httpx.ConnectError("Connection refused")),
+        ):
+            from zizkadb_mcp.server import _api
+            result = await _api("GET", "/events")  # must NOT raise
+
+        assert result["status"] == 0
+        assert "Cannot reach" in result["error"]
+        assert "localhost:8000" in result["error"]  # names the host it tried
+        assert "ZIZKADB_HOST" in result["error"]  # points at the config knob
+
+    @pytest.mark.asyncio
+    async def test_non_json_error_body_falls_back_to_text(self, monkeypatch):
+        """e.g. an nginx 502 HTML page has no {"detail": ...} — show the body."""
+        monkeypatch.setattr("zizkadb_mcp.server._KEY", "any_key")
+        resp = MagicMock()
+        resp.status_code = 502
+        resp.is_success = False
+        resp.text = "<html>Bad Gateway</html>"
+        resp.json = MagicMock(side_effect=ValueError("not json"))
+
+        with patch("zizkadb_mcp.server.httpx.AsyncClient", return_value=_client(return_value=resp)):
+            from zizkadb_mcp.server import _api
+            result = await _api("GET", "/events")
+
+        assert result["status"] == 502
+        assert "Bad Gateway" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_missing_key_self_host_hint(self, monkeypatch):
+        """No key configured against localhost: point at the local dashboard
+        and the dev-key escape hatch, not the cloud signup."""
+        monkeypatch.setattr("zizkadb_mcp.server._KEY", "")
+        monkeypatch.setattr("zizkadb_mcp.server._HOST", "http://localhost:8000")
+
+        from zizkadb_mcp.server import _api
+        result = await _api("GET", "/events")
+
+        assert result["status"] == 401
+        assert "ZIZKADB_API_KEY is not set" in result["error"]
+        assert "localhost:3001" in result["error"]
+        assert "ENV=development" in result["error"]
+        assert "Sign up at https://db.zizka.ai" not in result["error"]
+
+
+class TestGetContextAuthFailure:
+    @pytest.mark.asyncio
+    async def test_auth_error_is_visible_not_silent(self):
+        """Regression: get_context used to return "" on any API error,
+        making an auth failure indistinguishable from 'agent has no memory'."""
+        error_dict = {
+            "error": "Authentication failed (401 Unauthorized): Invalid or revoked API key. Hint: ...",
+            "status": 401,
+        }
+        with patch("zizkadb_mcp.server._api", new=AsyncMock(return_value=error_dict)):
+            from zizkadb_mcp.server import get_context
+            result = await get_context(agent="bot", task="help user")
+
+        assert result != ""
+        assert "Authentication failed" in result
+
+    @pytest.mark.asyncio
+    async def test_legitimate_empty_context_stays_empty(self):
+        """A real 'no memory' response must still return "" — only errors change."""
+        with patch(
+            "zizkadb_mcp.server._api",
+            new=AsyncMock(return_value={"context": "", "event_count": 0}),
+        ):
+            from zizkadb_mcp.server import get_context
+            result = await get_context(agent="bot", task="something")
+
+        assert result == ""
+
+
+class TestStartupKeyWarning:
+    """The server prints a stderr warning at startup when no key is configured
+    (stdout stays clean because it carries the MCP protocol)."""
+
+    def test_warns_on_stderr_when_key_missing(self, monkeypatch, capsys):
+        import zizkadb_mcp.server as srv
+
+        for var in ("ZIZKADB_API_KEY", "AGENTDB_API_KEY", "DEV_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("ZIZKADB_HOST", "https://db.zizka.ai")
+
+        importlib.reload(srv)
+        try:
+            assert "ZIZKADB_API_KEY is not set" in capsys.readouterr().err
+        finally:
+            importlib.reload(srv)  # restore module state for other tests
+
+    def test_no_warning_when_key_present(self, monkeypatch, capsys):
+        import zizkadb_mcp.server as srv
+
+        monkeypatch.setenv("ZIZKADB_API_KEY", "zizkadb_live_test")
+        importlib.reload(srv)
+        try:
+            assert "ZIZKADB_API_KEY is not set" not in capsys.readouterr().err
+        finally:
+            monkeypatch.delenv("ZIZKADB_API_KEY", raising=False)
+            importlib.reload(srv)

--- a/mcp/zizkadb_mcp/server.py
+++ b/mcp/zizkadb_mcp/server.py
@@ -55,6 +55,15 @@ def _is_local_host(host: str) -> bool:
 if not _KEY and _HOST and _is_local_host(_HOST):
     _KEY = os.getenv("DEV_API_KEY", DEFAULT_DEV_API_KEY)
 
+# MCP runs over stdio — stdout is protocol, so diagnostics go to stderr only.
+if not _KEY:
+    print(
+        f"zizkadb-mcp: ZIZKADB_API_KEY is not set — every tool call against {_HOST} "
+        "will fail with 401. Add it to the env block of your MCP config "
+        "(~/.cursor/mcp.json, claude_desktop_config.json, ...).",
+        file=sys.stderr,
+    )
+
 # ── Anonymous telemetry (opt-out: ZIZKADB_TELEMETRY=false) ────────────────────
 
 def _get_install_id() -> str:
@@ -100,32 +109,93 @@ def _telemetry_ping() -> None:
 threading.Thread(target=_telemetry_ping, daemon=True).start()
 
 
+def _error_detail(resp: httpx.Response) -> str:
+    """Best-effort extraction of the server's {"detail": ...} message."""
+    try:
+        detail = resp.json().get("detail")
+        if detail:
+            return str(detail)
+    except Exception:
+        pass
+    return resp.text
+
+
+def _missing_key_error() -> dict:
+    if _is_local_host(_HOST):
+        hint = (
+            f"Self-hosted at {_HOST}: create a key in your dashboard "
+            "(http://localhost:3001 → Settings → API keys) or run the server "
+            "with ENV=development to use the built-in dev key."
+        )
+    else:
+        hint = (
+            "Sign up at https://db.zizka.ai → Settings → Create API key, "
+            "then add it to your MCP config env."
+        )
+    return {"error": f"ZIZKADB_API_KEY is not set. {hint}", "status": 401}
+
+
+def _auth_hint() -> str:
+    """Host-aware remediation hint attached to 401 responses."""
+    if _is_local_host(_HOST):
+        return (
+            f"Hint for self-hosted {_HOST}: check that ZIZKADB_API_KEY matches a key "
+            "from your own dashboard (http://localhost:3001 → Settings → API keys), "
+            "or that the server runs with ENV=development if you rely on the built-in "
+            "dev key. A key created on db.zizka.ai will NOT work on a self-hosted "
+            "instance (and vice versa)."
+        )
+    return (
+        f"Hint: check that ZIZKADB_API_KEY in your MCP config is a valid, non-revoked "
+        f"key for {_HOST} (manage keys at https://db.zizka.ai → Settings → API keys). "
+        "A key from a self-hosted instance will NOT work on db.zizka.ai (and vice versa)."
+    )
+
+
 async def _api(method: str, path: str, body: dict | None = None) -> dict:
     if not _KEY:
-        return {
-            "error": (
-                "ZIZKADB_API_KEY is not set. "
-                "Sign up at https://db.zizka.ai → Settings → Create API key, "
-                "then add it to your MCP config env."
-            ),
-            "status": 401,
-        }
+        return _missing_key_error()
     headers = {"Content-Type": "application/json", "Authorization": f"Bearer {_KEY}"}
 
-    async with httpx.AsyncClient(timeout=15) as client:
-        url = f"{_HOST}/v1{path}"
-        if method == "GET":
-            r = await client.get(url, headers=headers)
-        elif method == "POST":
-            r = await client.post(url, headers=headers, json=body or {})
-        elif method == "DELETE":
-            r = await client.request("DELETE", url, headers=headers, json=body or {})
-        else:
-            raise ValueError(f"Unsupported method: {method}")
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            url = f"{_HOST}/v1{path}"
+            if method == "GET":
+                r = await client.get(url, headers=headers)
+            elif method == "POST":
+                r = await client.post(url, headers=headers, json=body or {})
+            elif method == "DELETE":
+                r = await client.request("DELETE", url, headers=headers, json=body or {})
+            else:
+                raise ValueError(f"Unsupported method: {method}")
+    except httpx.RequestError as e:
+        return {
+            "error": (
+                f"Cannot reach ZizkaDB at {_HOST} ({type(e).__name__}). "
+                "Check that the server is running and that ZIZKADB_HOST in your "
+                "MCP config points at it (default: https://db.zizka.ai)."
+            ),
+            "status": 0,
+        }
 
-    if not r.is_success:
-        return {"error": r.text, "status": r.status_code}
-    return r.json()
+    if r.is_success:
+        return r.json()
+
+    detail = _error_detail(r)
+    if r.status_code == 401:
+        return {
+            "error": f"Authentication failed (401 Unauthorized): {detail}. {_auth_hint()}",
+            "status": 401,
+        }
+    if r.status_code == 403:
+        return {
+            "error": (
+                f"Forbidden (403): {detail}. This usually means the API key is scoped "
+                "to a different agent than the one in your request."
+            ),
+            "status": 403,
+        }
+    return {"error": detail, "status": r.status_code}
 
 
 # ── Tools ──────────────────────────────────────────────────────────────────
@@ -223,6 +293,10 @@ async def get_context(
         body["session_id"] = session_id
     result = await _api("POST", "/memory/context", body)
     if isinstance(result, dict):
+        if "error" in result:
+            # Never fail silently: an empty string would look like "no memory"
+            # and hide auth/connectivity problems from the user entirely.
+            return f"ZizkaDB error: {result['error']}"
         return result.get("context", "")
     return str(result)
 


### PR DESCRIPTION
## Summary

Fixes task 8 of #85 — **MCP auth failures are now obvious**.

Connecting `zizkadb-mcp` to a self-host (or cloud) with wrong credentials produced
three bad outcomes, all reproduced locally before fixing:

| Failure mode | Before | After |
|---|---|---|
| Wrong/revoked key (401) | `{"error": "{\"detail\": \"Invalid...\"}"}` — raw JSON blob, no hint | `Authentication failed (401 Unauthorized): <server detail>. Hint: ...` — host-aware remediation |
| Server down / wrong `ZIZKADB_HOST` | **uncaught `httpx.ConnectError`** traceback | `Cannot reach ZizkaDB at <host> (ConnectError). Check that the server is running and ZIZKADB_HOST points at it` |
| `get_context()` on any API error | **silent `""`** — indistinguishable from "agent has no memory" | `ZizkaDB error: <message>` |
| No key configured | cloud-only signup hint, even against localhost | host-aware hint: self-host → local dashboard + `ENV=development` dev key |

Since a key created on cloud never works on self-host (and vice versa) — the most
common self-host setup mistake — every 401 hint now says so explicitly.

## Changes (`mcp/zizkadb_mcp/server.py`)

- **Startup stderr warning** when `ZIZKADB_API_KEY` is unset and the target host has
  no dev-key fallback. stdout is untouched — it carries the MCP protocol.
- **`_error_detail()`** — extracts the server's `{"detail": ...}`; falls back to raw
  text for non-JSON error bodies (e.g. nginx 502 pages).
- **`_missing_key_error()` / `_auth_hint()`** — self-host hints point at
  `http://localhost:3001 → Settings → API keys` and the `ENV=development` dev key;
  cloud hints at db.zizka.ai. Both note that keys don't cross deployments.
- **`_api()`** — HTTP calls wrapped in `try/except httpx.RequestError` (connection
  failures return a named-host error instead of raising); 401 and 403 get distinct,
  actionable messages (403 explains agent-scoped keys).
- **`get_context()`** — returns `"ZizkaDB error: ..."` instead of `""` on error.
  A legitimate empty memory response still returns `""`.

## Test plan

10 new mocked tests in `mcp/tests/test_server.py` — no live server, DB, or API key
required (same mocking style as the existing suite):

- **`TestAuthErrorClarity`** (6): 401 cloud hint · 401 self-host hint (asserts local
  dashboard + `ENV=development`, and NO cloud signup advice) · 403 agent-scope
  explanation · unreachable host returns error instead of raising · non-JSON error
  body fallback · missing-key self-host hint
- **`TestGetContextAuthFailure`** (2): auth error is visible, never silent ·
  legitimate empty context still returns `""`
- **`TestStartupKeyWarning`** (2): stderr warning when key missing · silent when present

Verification:
- `pytest mcp/tests/ -v` → **28 passed** (18 pre-existing + 10 new)
- `ruff check mcp/` → clean