### PR TITLE
fix(core): rate-limit event writes and make 429s usable for clients

### DIFF
--- a/core/api/events.py
+++ b/core/api/events.py
@@ -1,4 +1,7 @@
-from fastapi import APIRouter, Depends, Query
+import os
+import logging
+
+from fastapi import APIRouter, Depends, Query, HTTPException
 from pydantic import BaseModel, Field
 from services.exceptions import not_found
 from typing import Any
@@ -9,8 +12,58 @@ import json
 from api.deps import get_tenant, assert_agent_allowed
 from db.connection import get_pool
 from services.event_write import write_event
+from services.exceptions import rate_limit_exceeded
+from services.rate_limiter import (
+    RateLimiter,
+    InMemoryStorage,
+    RedisStorage,
+    RateLimitStorage,
+    SlidingWindowStrategy,
+)
 
 router = APIRouter()
+log = logging.getLogger(__name__)
+
+# Per-agent burst limit on event writes (issue #3 -- Rate limit), keyed on
+# (tenant, agent) rather than tenant alone so one runaway agent can't starve
+# its sibling agents' write budget within the same tenant. Default allows
+# ~5 writes/sec sustained with headroom for bursts; tune via env without a
+# code change.
+#
+# 300/60s is a reasonable-sounding default, not a number benchmarked against
+# Postgres/Qdrant's actual write throughput -- issue #85 doesn't specify a
+# target either. Worth a maintainer call on the right ceiling before this
+# ships to production traffic.
+_EVENTS_RATE_WINDOW_SEC = int(os.getenv("EVENTS_RATE_LIMIT_WINDOW_SEC", "60"))
+_EVENTS_RATE_MAX = int(os.getenv("EVENTS_RATE_LIMIT_MAX", "300"))
+
+
+def _events_write_storage() -> RateLimitStorage:
+    """
+    EVENTS_RATE_LIMIT_STORAGE=redis|memory overrides the default. Default:
+    redis when ENV=production (shared across uvicorn workers — same
+    rationale as the OTP limiter, see api/auth.py::_otp_storage and
+    docs/adr/005-in-process-rate-limiting.md), memory otherwise (local dev
+    + unit tests).
+    """
+    choice = (os.getenv("EVENTS_RATE_LIMIT_STORAGE") or "").strip().lower()
+    if not choice:
+        choice = "redis" if os.getenv("ENV", "development") == "production" else "memory"
+    if choice == "redis":
+        return RedisStorage(key_prefix="events-write")
+    return InMemoryStorage()
+
+
+write_limiter = RateLimiter(
+    limit=_EVENTS_RATE_MAX,
+    window_sec=_EVENTS_RATE_WINDOW_SEC,
+    storage=_events_write_storage(),
+    strategy=SlidingWindowStrategy(),
+    detail=(
+        f"Too many events written for this agent. "
+        f"Limit is {_EVENTS_RATE_MAX} per {_EVENTS_RATE_WINDOW_SEC}s — see Retry-After header."
+    ),
+)
 
 
 # ─────────────────────────────────────────
@@ -36,6 +89,33 @@ async def log_event(
     tenant: dict = Depends(get_tenant),
 ):
     assert_agent_allowed(tenant, body.agent)
+
+    try:
+        await write_limiter.check(f"{tenant['tenant_id']}:{body.agent}")
+    except HTTPException as exc:
+        if exc.status_code == 429:
+            # Re-raise with a structured body (message + numeric fields) on
+            # top of the existing headers, instead of the shared limiter's
+            # plain-text `detail`. Done here rather than in rate_limiter.py
+            # so OTP -- which shares that limiter and asserts `detail` is a
+            # bare string -- is unaffected.
+            retry_after = int((exc.headers or {}).get("Retry-After", _EVENTS_RATE_WINDOW_SEC))
+            raise rate_limit_exceeded(
+                detail={
+                    "message": exc.detail,
+                    "retry_after_seconds": retry_after,
+                    "limit": _EVENTS_RATE_MAX,
+                    "window_seconds": _EVENTS_RATE_WINDOW_SEC,
+                },
+                headers=exc.headers,
+            ) from None
+        raise
+    except Exception:
+        # Fail open: unlike OTP (a brute-force guard), losing burst
+        # protection during a backend blip is cheaper than blocking all
+        # event ingestion because of it.
+        log.exception("Event rate limit backend unavailable; allowing write")
+
     return await write_event(
         tenant_id=tenant["tenant_id"],
         agent=body.agent,

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -33,6 +33,24 @@ class RateLimitStorage(ABC):
         pass
 
     @abstractmethod
+    async def check_and_increment(
+        self, key: str, limit: int, window_sec: int
+    ) -> tuple[bool, list[float]]:
+        """
+        Atomically check whether ``key`` is under ``limit`` within ``window_sec``
+        and, if so, record a hit -- as a single indivisible operation.
+
+        Strategies must use this instead of composing ``get_hits`` +
+        ``record_hit``: that two-step sequence has a check-then-act race --
+        concurrent callers can all read the same under-limit count before any
+        of them records a hit, letting a burst overshoot the limit by up to
+        the burst size. Returns ``(allowed, hits)`` where ``hits`` are the
+        active timestamps within the window after the operation (including
+        the new hit when allowed).
+        """
+        pass
+
+    @abstractmethod
     async def clear(self) -> None:
         """Clear all rate limit entries (useful for test resets)."""
         pass
@@ -125,6 +143,26 @@ class InMemoryStorage(RateLimitStorage):
                 self._data[key] = []
             self._data[key].append(timestamp)
 
+    async def check_and_increment(
+        self, key: str, limit: int, window_sec: int
+    ) -> tuple[bool, list[float]]:
+        """
+        Atomic within this process: the read-compare-append sequence runs
+        entirely inside the lock with no ``await`` in between, so no other
+        coroutine can interleave. (Across multiple worker processes this
+        storage doesn't coordinate at all -- use ``RedisStorage`` in
+        production for that.)
+        """
+        now = time.time()
+        cutoff = now - window_sec
+        with self._lock:
+            hits = [t for t in self._data.get(key, []) if t > cutoff]
+            allowed = len(hits) < limit
+            if allowed:
+                hits.append(now)
+            self._data[key] = hits
+            return allowed, hits
+
     async def clear(self) -> None:
         """Clear all rate limit entries from memory."""
         with self._lock:
@@ -196,6 +234,59 @@ class RedisStorage(RateLimitStorage):
         # Set expiry to prevent memory leak
         await redis_client.expire(rkey, window_sec)
 
+    async def check_and_increment(
+        self, key: str, limit: int, window_sec: int, _max_retries: int = 5
+    ) -> tuple[bool, list[float]]:
+        """
+        Atomic via optimistic locking (WATCH/MULTI/EXEC): the prune-count-add
+        sequence is guarded by a WATCH on the key, so if another client
+        touches it between our read and our write, EXEC aborts (returns
+        ``None``) and we retry with a fresh read. This closes the
+        check-then-act race that plain ``get_hits`` + ``record_hit`` has
+        under concurrent load.
+
+        (A Lua ``EVAL`` script would do this in one round trip instead of
+        the WATCH retry loop, but the fakeredis backend this is tested
+        against doesn't implement scripting -- see core/tests/test_rate_limiting.py.)
+        """
+        redis_client = get_redis()
+        rkey = self._get_redis_key(key)
+
+        for _ in range(_max_retries):
+            now = time.time()
+            cutoff = now - window_sec
+            member = f"{now}:{uuid.uuid4().hex}"
+
+            async with redis_client.pipeline(transaction=True) as pipe:
+                await pipe.watch(rkey)
+                await pipe.zremrangebyscore(rkey, "-inf", cutoff)
+                count = await pipe.zcard(rkey)
+                oldest = await pipe.zrange(rkey, 0, 0, withscores=True)
+                allowed = count < limit
+
+                pipe.multi()
+                if allowed:
+                    pipe.zadd(rkey, {member: now})
+                    pipe.expire(rkey, window_sec)
+                result = await pipe.execute()
+
+            if result is None:
+                # Watched key changed concurrently -- another caller raced
+                # us between our read and our write. Retry with fresh state.
+                continue
+
+            hits = [oldest[0][1]] if oldest else []
+            if allowed:
+                hits.append(now)
+            return allowed, hits
+
+        # Sustained contention on one key across every retry is not a normal
+        # rate-limiting workload -- fail closed rather than let a caller
+        # bypass the limit after silently exhausting retries.
+        raise rate_limit_exceeded(
+            detail="Rate limiter temporarily unavailable due to contention. Please retry."
+        )
+
     async def clear(self) -> None:
         """Remove all rate limit keys matching the configured prefix from Redis."""
         redis_client = get_redis()
@@ -209,6 +300,24 @@ class RedisStorage(RateLimitStorage):
 # ──────────────────────────────────────────────────────────────────────────────
 # Rate Limiting Strategies
 # ──────────────────────────────────────────────────────────────────────────────
+
+
+def _rate_limit_headers(limit: int, retry_after_sec: float) -> dict[str, str]:
+    """
+    Build standard rate-limit headers for a 429 response.
+
+    ``Retry-After`` is what well-behaved HTTP clients (and SDKs) back off on;
+    the ``X-RateLimit-*`` triplet lets clients self-throttle before they hit
+    the limit at all. Without these, a 429 body's prose is the only signal
+    and callers are left guessing how long to wait.
+    """
+    retry_after = max(1, int(retry_after_sec + 0.999))  # round up, never 0
+    return {
+        "Retry-After": str(retry_after),
+        "X-RateLimit-Limit": str(limit),
+        "X-RateLimit-Remaining": "0",
+        "X-RateLimit-Reset": str(int(time.time()) + retry_after),
+    }
 
 
 class RateLimitStrategy(ABC):
@@ -237,14 +346,15 @@ class SlidingWindowStrategy(RateLimitStrategy):
         Check the limit using a sliding window algorithm.
         Raises HTTPException 429 if the request count exceeds the limit.
         """
-        hits = await storage.get_hits(key, window_sec)
-        if len(hits) >= limit:
+        allowed, hits = await storage.check_and_increment(key, limit, window_sec)
+        if not allowed:
             logger.warning(
                 f"Rate limit exceeded (SlidingWindow) for key: {key} (limit={limit}, window={window_sec}s)"
             )
-            raise rate_limit_exceeded(detail=detail)
-
-        await storage.record_hit(key, time.time(), window_sec)
+            retry_after = (min(hits) + window_sec - time.time()) if hits else window_sec
+            raise rate_limit_exceeded(
+                detail=detail, headers=_rate_limit_headers(limit, retry_after)
+            )
 
 
 class FixedWindowStrategy(RateLimitStrategy):
@@ -265,14 +375,15 @@ class FixedWindowStrategy(RateLimitStrategy):
         window_start = int(now // window_sec)
         fixed_key = f"{key}:fixed:{window_start}"
 
-        hits = await storage.get_hits(fixed_key, window_sec)
-        if len(hits) >= limit:
+        allowed, _hits = await storage.check_and_increment(fixed_key, limit, window_sec)
+        if not allowed:
             logger.warning(
                 f"Rate limit exceeded (FixedWindow) for key: {key} (limit={limit}, window={window_sec}s)"
             )
-            raise rate_limit_exceeded(detail=detail)
-
-        await storage.record_hit(fixed_key, now, window_sec)
+            retry_after = (window_start + 1) * window_sec - now
+            raise rate_limit_exceeded(
+                detail=detail, headers=_rate_limit_headers(limit, retry_after)
+            )
 
 
 # ──────────────────────────────────────────────────────────────────────────────

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -12,6 +12,8 @@ import pytest
 from fastapi.testclient import TestClient
 from main import app
 from api.auth import otp_limiter, _otp_storage, _OTP_RATE_MAX, _OTP_RATE_WINDOW_SEC
+from api.deps import get_tenant
+from api import events as events_module
 from services.rate_limiter import (
     InMemoryStorage,
     RedisStorage,
@@ -214,6 +216,56 @@ class TestRateLimiterFeatures:
             f"concurrency again"
         )
 
+    def test_in_memory_check_and_increment_holds_limit_under_concurrency(self):
+        """
+        Plain get_hits() + record_hit() has a check-then-act race: concurrent
+        callers can all read the same under-limit count before any of them
+        records, so a burst can overshoot the limit. check_and_increment()
+        does both atomically under a single lock acquisition -- exactly
+        `limit` of N concurrent callers must be let through, never more.
+        """
+        storage = InMemoryStorage()
+        limit = 10
+
+        async def fire(n: int) -> int:
+            results = await asyncio.gather(*(
+                storage.check_and_increment("burst-key", limit, 60) for _ in range(n)
+            ))
+            return sum(1 for allowed, _hits in results if allowed)
+
+        allowed_count = asyncio.run(fire(50))
+        assert allowed_count == limit, (
+            f"expected exactly {limit} of 50 concurrent callers to be allowed, "
+            f"got {allowed_count} -- check_and_increment() is not holding the "
+            f"limit atomically"
+        )
+
+    def test_redis_check_and_increment_holds_limit_under_concurrency(self):
+        """Same guarantee as the in-memory case above, but against a real
+        (fake) Redis backend via the WATCH/MULTI/EXEC optimistic-lock loop."""
+        if fakeredis_aioredis is None:
+            pytest.skip("fakeredis not installed (see core/requirements-dev.txt)")
+
+        with patch("services.rate_limiter.get_redis") as mock_get_redis:
+            fake_redis = fakeredis_aioredis.FakeRedis(decode_responses=False)
+            mock_get_redis.return_value = fake_redis
+
+            storage = RedisStorage(key_prefix="ratelimit-atomic-test")
+            limit = 10
+
+            async def fire(n: int) -> int:
+                results = await asyncio.gather(*(
+                    storage.check_and_increment("burst-key", limit, 60) for _ in range(n)
+                ))
+                return sum(1 for allowed, _hits in results if allowed)
+
+            allowed_count = asyncio.run(fire(50))
+            assert allowed_count == limit, (
+                f"expected exactly {limit} of 50 concurrent callers to be allowed, "
+                f"got {allowed_count} -- the WATCH/MULTI/EXEC loop is not holding "
+                f"the limit atomically"
+            )
+
 
 class TestOtpStorageSelection:
     def test_explicit_redis(self, monkeypatch):
@@ -255,4 +307,145 @@ class TestOtpRateLimitFailClosed:
         assert response.status_code == 503
         assert "temporarily unavailable" in response.json()["detail"]
         mock_request_otp.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Event Write Rate Limiting Tests (issue #3 -- Rate limit)
+# ──────────────────────────────────────────────────────────────────────────────
+
+class TestEventWriteRateLimiting:
+    def setup_method(self):
+        events_module.write_limiter.storage = InMemoryStorage()
+        asyncio.run(events_module.write_limiter.storage.clear())
+        app.dependency_overrides[get_tenant] = lambda: {"tenant_id": "rl-tenant"}
+
+    def teardown_method(self):
+        app.dependency_overrides.pop(get_tenant, None)
+
+    @patch("api.events.write_event", new_callable=AsyncMock)
+    def test_writes_under_limit_succeed(self, mock_write):
+        mock_write.return_value = {"event_id": "e1", "sequence_no": 1}
+        start_time = 1000000.0
+        with patch("time.time", return_value=start_time):
+            for _ in range(events_module._EVENTS_RATE_MAX):
+                response = client.post(
+                    "/v1/events",
+                    json={"agent": "agent1", "event": "test", "data": {}},
+                )
+                assert response.status_code == 201
+            assert mock_write.await_count == events_module._EVENTS_RATE_MAX
+
+    @patch("api.events.write_event", new_callable=AsyncMock)
+    def test_burst_exceeds_limit_returns_usable_429(self, mock_write):
+        """The 429 must be usable by clients: a structured body plus
+        standard rate-limit headers, not just a bare status code."""
+        mock_write.return_value = {"event_id": "e1", "sequence_no": 1}
+        start_time = 1000000.0
+        with patch("time.time", return_value=start_time):
+            for _ in range(events_module._EVENTS_RATE_MAX):
+                response = client.post(
+                    "/v1/events",
+                    json={"agent": "agent1", "event": "test", "data": {}},
+                )
+                assert response.status_code == 201
+
+            response = client.post(
+                "/v1/events",
+                json={"agent": "agent1", "event": "test", "data": {}},
+            )
+            assert response.status_code == 429
+
+            body = response.json()["detail"]
+            assert "Too many events" in body["message"]
+            assert body["retry_after_seconds"] == events_module._EVENTS_RATE_WINDOW_SEC
+            assert body["limit"] == events_module._EVENTS_RATE_MAX
+            assert body["window_seconds"] == events_module._EVENTS_RATE_WINDOW_SEC
+
+            assert response.headers["Retry-After"] == str(events_module._EVENTS_RATE_WINDOW_SEC)
+            assert response.headers["X-RateLimit-Limit"] == str(events_module._EVENTS_RATE_MAX)
+            assert response.headers["X-RateLimit-Remaining"] == "0"
+            assert response.headers["X-RateLimit-Reset"] == str(
+                int(start_time) + events_module._EVENTS_RATE_WINDOW_SEC
+            )
+            # The blocked request must not reach the write path.
+            assert mock_write.await_count == events_module._EVENTS_RATE_MAX
+
+    @patch("api.events.write_event", new_callable=AsyncMock)
+    def test_burst_recovers_after_window_rolls_over(self, mock_write):
+        mock_write.return_value = {"event_id": "e1", "sequence_no": 1}
+        current_time = [1000000.0]
+
+        with patch("time.time", side_effect=lambda: current_time[0]):
+            for _ in range(events_module._EVENTS_RATE_MAX):
+                response = client.post(
+                    "/v1/events",
+                    json={"agent": "agent1", "event": "test", "data": {}},
+                )
+                assert response.status_code == 201
+
+            blocked = client.post(
+                "/v1/events",
+                json={"agent": "agent1", "event": "test", "data": {}},
+            )
+            assert blocked.status_code == 429
+
+            current_time[0] += events_module._EVENTS_RATE_WINDOW_SEC + 1
+
+            response = client.post(
+                "/v1/events",
+                json={"agent": "agent1", "event": "test", "data": {}},
+            )
+            assert response.status_code == 201
+
+    @patch("api.events.write_event", new_callable=AsyncMock)
+    def test_partitioned_by_tenant_and_agent(self, mock_write):
+        mock_write.return_value = {"event_id": "e1", "sequence_no": 1}
+        start_time = 1000000.0
+        with patch("time.time", return_value=start_time):
+            for _ in range(events_module._EVENTS_RATE_MAX):
+                response = client.post(
+                    "/v1/events",
+                    json={"agent": "agent1", "event": "test", "data": {}},
+                )
+                assert response.status_code == 201
+
+            # (rl-tenant, agent1) is now at its limit
+            blocked = client.post(
+                "/v1/events",
+                json={"agent": "agent1", "event": "test", "data": {}},
+            )
+            assert blocked.status_code == 429
+
+            # a sibling agent under the *same* tenant has its own budget --
+            # one runaway agent must not starve another agent's writes.
+            response = client.post(
+                "/v1/events",
+                json={"agent": "agent2", "event": "test", "data": {}},
+            )
+            assert response.status_code == 201
+
+            # a different tenant is unaffected too
+            app.dependency_overrides[get_tenant] = lambda: {"tenant_id": "rl-tenant-2"}
+            response = client.post(
+                "/v1/events",
+                json={"agent": "agent1", "event": "test", "data": {}},
+            )
+            assert response.status_code == 201
+
+    @patch("api.events.write_event", new_callable=AsyncMock)
+    def test_limiter_backend_error_fails_open(self, mock_write):
+        """Unlike OTP (a brute-force guard), a rate-limit backend outage must
+        not block event ingestion — burst protection is best-effort here."""
+        mock_write.return_value = {"event_id": "e1", "sequence_no": 1}
+        events_module.write_limiter.storage = MagicMock()
+        events_module.write_limiter.storage.check_and_increment = AsyncMock(
+            side_effect=RuntimeError("redis down")
+        )
+
+        response = client.post(
+            "/v1/events",
+            json={"agent": "agent1", "event": "test", "data": {}},
+        )
+        assert response.status_code == 201
+        mock_write.assert_awaited_once()
 


### PR DESCRIPTION
## What & why

`POST /v1/events` had **no rate limit at all** — a burst of writes from a
misbehaving agent or client could hit Postgres/Qdrant unbounded. Separately,
the shared `RateLimiter` (used today by OTP) raised bare 429s with no
headers, and its `get_hits()` + `record_hit()` pattern had a check-then-act
race: concurrent callers could all read the same under-limit count before
any of them recorded a hit, letting a burst overshoot the limit by up to the
burst size.

Changes:

- **`core/api/events.py`** — added a per-**(tenant, agent)** limiter on
  `POST /v1/events` (not per-tenant alone, so one runaway agent can't starve
  its sibling agents' write budget). Limit/window are env-tunable
  (`EVENTS_RATE_LIMIT_MAX`, default 300; `EVENTS_RATE_LIMIT_WINDOW_SEC`,
  default 60 — **a reasonable-sounding default, not benchmarked against
  Postgres/Qdrant's actual write throughput**; issue #85 doesn't specify a
  target either, so this is worth a maintainer call before it ships to real
  traffic). Storage is chosen the same way as the OTP limiter — Redis in
  production (correct across `--workers`), in-memory in dev/tests
  (`EVENTS_RATE_LIMIT_STORAGE` overrides). Fails **open** on a rate-limit
  backend error — unlike OTP (a brute-force guard, which fails closed),
  losing burst protection for a few seconds during a Redis blip is cheaper
  than blocking ingestion. The 429 body is structured
  (`message` / `retry_after_seconds` / `limit` / `window_seconds`), layered
  on top of the shared limiter's plain-text `detail` so OTP — which shares
  that limiter and asserts `detail` is a bare string — is unaffected.
- **`core/services/rate_limiter.py`** — replaced the racy
  `get_hits()` + `record_hit()` sequence with an atomic
  `check_and_increment()` on both storages:
  - `InMemoryStorage`: read-compare-append happens under a single lock
    acquisition with no `await` in between.
  - `RedisStorage`: `WATCH`/`MULTI`/`EXEC` optimistic-lock retry loop. (A
    Lua `EVAL` script would do this in one round trip instead of a retry
    loop, but the `fakeredis` backend the test suite runs against doesn't
    implement scripting, so this stays test-friendly without adding a new
    dependency.)
  - Both `SlidingWindowStrategy` and `FixedWindowStrategy` now attach
    `Retry-After` and `X-RateLimit-{Limit,Remaining,Reset}` headers to
    every 429 they raise — a shared primitive, so OTP's 429s get the same
    headers for free.

## How to test

```bash
cd core
pip install -r requirements.txt -r requirements-dev.txt
pip install -e ../sdk/python
pytest tests/test_rate_limiting.py -v
pytest -m "not integration"
```

`test_rate_limiting.py` includes two concurrency regression tests
(`test_in_memory_check_and_increment_holds_limit_under_concurrency`,
`test_redis_check_and_increment_holds_limit_under_concurrency`) that fire 50
concurrent callers at a limit of 10 and assert exactly 10 are allowed —
these fail against the old `get_hits()`/`record_hit()` composition and pass
against `check_and_increment()`.

Manual burst check against a running stack:

```bash
for i in $(seq 1 305); do
  curl -s -o /dev/null -w "%{http_code} " \
    -X POST http://localhost:8000/v1/events \
    -H "Authorization: Bearer zizkadb_dev_local" \
    -H "Content-Type: application/json" \
    -d '{"agent":"a1","event":"test","data":{}}'
done
# tail of the output should flip from 201 to 429

curl -i -X POST http://localhost:8000/v1/events \
  -H "Authorization: Bearer zizkadb_dev_local" \
  -H "Content-Type: application/json" \
  -d '{"agent":"a1","event":"test","data":{}}'
# once limited: 429, with Retry-After / X-RateLimit-* headers and a
# structured {"detail": {"message": ..., "retry_after_seconds": ..., "limit": ..., "window_seconds": ...}} body
```

## Areas touched

- Core API (`core/api/events.py`, `core/services/rate_limiter.py`)
- Tests only — no schema, SDK, dashboard, or MCP changes

## Breaking changes

None for existing callers. `POST /v1/events` behaves identically under
normal load; only sustained bursts above the configured per-(tenant, agent)
limit are affected. OTP's 429 `detail` stays a plain string (unchanged
shape) — it only gains new headers, which is additive. The events 429 body
does change shape (`detail` becomes an object instead of a string) but this
endpoint had no rate limiting before this PR, so there's no prior contract
to break.

## Open question for maintainers

Is 300 events / 60s per (tenant, agent) the right ceiling, or is there a
target events/sec already benchmarked against what Postgres/Qdrant can
absorb? I picked a conservative-sounding default; landing on (and
documenting) the real number feels like it should be a maintainer decision
rather than something silently baked into this PR.

## Related issue

Fixes task 3 (Rate limit) from #85.