### PR TITLE
refactor(core): make embedding authentication provider-aware

### DIFF
--- a/core/services/embeddings.py
+++ b/core/services/embeddings.py
@@ -1,7 +1,7 @@
 import httpx
 import json
 import logging
-from typing import Any
+from typing import Any, Awaitable, Callable
 
 from db.connection import get_redis
 from services.embedding_config import (
@@ -14,6 +14,11 @@ from services.embedding_config import (
 logger = logging.getLogger(__name__)
 
 CACHE_TTL = 86400  # 24 hours
+
+EmbeddingProvider = Callable[
+    [str, TenantEmbeddingConfig],
+    Awaitable[list[float] | None],
+]
 
 
 async def generate_embedding(text: str, tenant_id: str) -> list[float] | None:
@@ -44,12 +49,13 @@ async def generate_embedding_with_config(
     except Exception:
         pass
 
+    provider = EMBEDDING_PROVIDERS.get(config.provider)
+    if provider is None:
+        logger.warning("Unsupported embedding provider: %s", config.provider)
+        return None
+
     try:
-        if config.provider == "openai":
-            embedding = await _openai_embedding(text, config)
-        else:
-            logger.warning("Unsupported embedding provider: %s", config.provider)
-            return None
+        embedding = await provider(text, config)
 
         if not embedding:
             return None
@@ -90,7 +96,10 @@ async def _openai_embedding(
     }
 
     for model in EMBEDDING_MODELS.get("openai", []):
-        if model["id"] == config.model and model.get("dimensions_param"):
+        if (
+            model["id"] == config.model
+            and model.get("dimensions_param") is not None
+        ):
             payload["dimensions"] = model["dimensions_param"]
             break
 
@@ -106,6 +115,11 @@ async def _openai_embedding(
         response.raise_for_status()
 
         return response.json()["data"][0]["embedding"]
+
+
+EMBEDDING_PROVIDERS: dict[str, EmbeddingProvider] = {
+    "openai": _openai_embedding,
+}
 
 
 def _flatten_data(value: Any, prefix: str = "") -> list[str]:

--- a/core/services/embeddings.py
+++ b/core/services/embeddings.py
@@ -15,6 +15,10 @@ logger = logging.getLogger(__name__)
 
 CACHE_TTL = 86400  # 24 hours
 
+API_KEY_REQUIRED_PROVIDERS = {
+     "openai",
+}     
+
 EmbeddingProvider = Callable[
     [str, TenantEmbeddingConfig],
     Awaitable[list[float] | None],
@@ -31,7 +35,10 @@ async def generate_embedding_with_config(
     text: str,
     config: TenantEmbeddingConfig,
 ) -> list[float] | None:
-    if not config.api_key:
+    if (
+        config.provider in API_KEY_REQUIRED_PROVIDERS
+        and not config.api_key
+    ):
         logger.warning(
             "No embedding API key for tenant %s (platform=%s)",
             config.tenant_id,


### PR DESCRIPTION
## Summary

This PR makes embedding authentication provider-aware as preparation for additional embedding providers.

### Changes

- Require API keys only for providers that need them
- Keep existing OpenAI behavior unchanged
- Prepare the embedding pipeline for providers that don't require API keys (e.g. self-hosted providers)

### Testing

- Ran the complete test suite
