### PR TITLE
fix(oss): align API key limits and gate self-host embeddings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,9 @@ REDIS_URL=redis://localhost:6379
 # Emergency rollback (not for normal prod): OTP_RATE_LIMIT_STORAGE=memory
 # OTP_RATE_LIMIT_STORAGE=memory
 
-# OpenAI — required for semantic search, memory context, drift/baseline embeddings
-# Logging and why() work without this; search/embeddings return 400 until set.
+# OpenAI — optional on self-host (see EMBEDDINGS_ENABLED). Required for semantic
+# search, memory context, and vector indexing when embeddings are enabled.
+# Logging and why() work without this; search/context return 400 until configured.
 OPENAI_API_KEY=sk-...
 
 # Anthropic — required for the AI Suggestions tab. Without it, Suggestions shows
@@ -53,7 +54,9 @@ DEV_API_KEY=zizkadb_dev_local
 # the users.plan column. Managed cloud must leave this unset (defaults to
 # "managed").
 DEPLOYMENT_MODE=self_hosted
-# API_KEY_LIMITS_ENFORCED=false   # set to true to enforce per-plan key caps (Pro: 3, Team: 10, Enterprise: 50)
+# Self-hosted: vector indexing and semantic search are OFF unless you opt in.
+EMBEDDINGS_ENABLED=false
+# API_KEY_LIMITS_ENFORCED=false   # set to true to enforce per-plan key caps (Self-Hosted: 1, Pro: 2, Team: 5, Enterprise: 50)
 
 # Email — optional; enables OTP login on self-hosted dashboard (same as managed cloud)
 # Gmail: Settings → Security → App Passwords → generate one
@@ -91,8 +94,8 @@ TRIAL_DAYS=30
 
 # ── API key plan overrides ─────────────────────────────────────────────────────
 # Override the default per-plan API key caps at runtime (requires API_KEY_LIMITS_ENFORCED=true).
-# API_KEY_LIMIT_PRO=3
-# API_KEY_LIMIT_TEAM=10
+# API_KEY_LIMIT_PRO=2
+# API_KEY_LIMIT_TEAM=5
 # API_KEY_LIMIT_ENTERPRISE=50
 
 # ── Email tuning ───────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Expected response:
 | `db.agents()` | List all agents in your project | Manage multiple agents |
 
 > `db.log()`, `db.why()`, and `db.at()` work without an OpenAI key.
-> `db.search()` and `db.context_for()` require `OPENAI_API_KEY` for embeddings.
+> `db.search()` and `db.context_for()` require `OPENAI_API_KEY` for embeddings. On self-hosted deployments, also set `EMBEDDINGS_ENABLED=true` (default off).
 
 ---
 
@@ -317,7 +317,8 @@ Expected response:
 | `ZIZKADB_API_KEY` | Your Zizka Cloud API key | `zizkadb_live_...` |
 | `ZIZKADB_HOST` | URL of your local or self-hosted ZizkaDB | `http://localhost:8000` |
 | `ZIZKADB_AGENT` | Default agent name (used in templates) | `my-bot` |
-| `OPENAI_API_KEY` | Required for `db.search()` and `db.context_for()` | `sk-...` |
+| `OPENAI_API_KEY` | Required for `db.search()` and `db.context_for()` when embeddings are enabled | `sk-...` |
+| `EMBEDDINGS_ENABLED` | Self-host only: set `true` to index events for semantic search (requires `OPENAI_API_KEY`) | `false` |
 | `ZIZKADB_TELEMETRY` | Set to `false` to turn off anonymous usage data | `false` |
 
 > **Local dev tip:** When connecting to `localhost:8000`, no API key is needed — the local stack uses a built-in dev key automatically.

--- a/core/api/memory.py
+++ b/core/api/memory.py
@@ -17,6 +17,7 @@ import logging
 from api.deps import get_tenant, assert_agent_allowed
 from db.connection import get_pool, get_qdrant
 from services.embeddings import generate_embedding
+from services.entitlements import embeddings_enabled, is_self_hosted_deployment
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -79,6 +80,16 @@ async def get_context(
 
     # 2. Semantically relevant events via Qdrant
     semantic_rows = []
+    if not embeddings_enabled():
+        if is_self_hosted_deployment():
+            raise bad_request(
+                detail=(
+                    "Semantic memory is disabled on this self-hosted install. "
+                    "Set EMBEDDINGS_ENABLED=true in infra/.env, restart the API, "
+                    "then add your embedding API key in Dashboard → Settings."
+                ),
+            )
+        raise bad_request(detail="Semantic memory is disabled for this deployment.")
     embedding = await generate_embedding(body.task, tenant_id)
     if not embedding:
         raise bad_request(

--- a/core/api/search.py
+++ b/core/api/search.py
@@ -8,6 +8,7 @@ from qdrant_client.models import FieldCondition, Filter, MatchValue
 from api.deps import assert_agent_allowed, get_tenant
 from db.connection import get_pool, get_qdrant
 from services.embeddings import generate_embedding
+from services.entitlements import embeddings_enabled, is_self_hosted_deployment
 
 router = APIRouter()
 
@@ -27,6 +28,15 @@ async def semantic_search(
     agent = body.agent or tenant.get("agent_id")
     if agent:
         assert_agent_allowed(tenant, agent)
+
+    if not embeddings_enabled():
+        if is_self_hosted_deployment():
+            raise bad_request(
+                "Semantic search is disabled on this self-hosted install. "
+                "Set EMBEDDINGS_ENABLED=true in infra/.env, restart the API, "
+                "then add your embedding API key in Dashboard → Settings."
+            )
+        raise bad_request("Semantic search is disabled for this deployment.")
 
     embedding = await generate_embedding(body.query, tenant_id)
     if not embedding:

--- a/core/services/entitlements.py
+++ b/core/services/entitlements.py
@@ -34,8 +34,8 @@ class PlanEntitlements:
 # The only plans with entitlement caps. Extend this dict to add plans.
 PLAN_ENTITLEMENTS: dict[str, PlanEntitlements] = {
     "self_hosted": PlanEntitlements(max_api_keys=1),
-    "pro": PlanEntitlements(max_api_keys=3),
-    "team": PlanEntitlements(max_api_keys=10),
+    "pro": PlanEntitlements(max_api_keys=2),
+    "team": PlanEntitlements(max_api_keys=5),
     "enterprise": PlanEntitlements(max_api_keys=50),
 }
 
@@ -96,3 +96,20 @@ def is_self_hosted_deployment() -> bool:
     (which self-host installs never populate).
     """
     return os.getenv("DEPLOYMENT_MODE", "managed").strip().lower() == "self_hosted"
+
+
+def embeddings_enabled() -> bool:
+    """Whether event indexing and semantic search may call an embedding provider.
+
+    Managed cloud: enabled (tenant/platform embedding config applies).
+    Self-hosted OSS: disabled unless ``EMBEDDINGS_ENABLED=true`` — avoids
+    silently using the operator's OpenAI key or platform defaults.
+    """
+    if not is_self_hosted_deployment():
+        return True
+    return os.getenv("EMBEDDINGS_ENABLED", "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )

--- a/core/services/event_write.py
+++ b/core/services/event_write.py
@@ -9,6 +9,7 @@ import logging
 from db.connection import get_pool, get_qdrant
 from qdrant_client.models import PointStruct
 from services.embeddings import generate_embedding, event_to_text
+from services.entitlements import embeddings_enabled
 from services.exceptions import bad_request
 
 logger = logging.getLogger(__name__)
@@ -80,6 +81,8 @@ async def write_event(
 
     indexed = False
     try:
+        if not embeddings_enabled():
+            raise RuntimeError("embeddings disabled for this deployment")
         text = event_to_text(event, data)
         embedding = await generate_embedding(text, tenant_id)
         if embedding:

--- a/core/tests/test_api_key_limit_endpoints.py
+++ b/core/tests/test_api_key_limit_endpoints.py
@@ -85,16 +85,16 @@ class TestCreateApiKeyEndpoint:
     @patch.dict("os.environ", {"API_KEY_LIMITS_ENFORCED": "true"})
     @patch("api.auth.get_pool")
     def test_blocked_at_limit(self, mock_get_pool):
-        mock_get_pool.return_value = FakePool(FakeConn(plan="pro", count=3))  # limit 3, full
+        mock_get_pool.return_value = FakePool(FakeConn(plan="pro", count=2))  # limit 2, full
         response = client.post("/v1/auth/api-keys", json={"name": "prod key"})
         assert response.status_code == 409
         assert response.json()["detail"]["code"] == "api_key_limit_reached"
-        assert response.json()["detail"]["limit"] == 3
+        assert response.json()["detail"]["limit"] == 2
 
     @patch.dict("os.environ", {"API_KEY_LIMITS_ENFORCED": "true"})
     @patch("api.auth.get_pool")
     def test_allowed_under_limit(self, mock_get_pool):
-        mock_get_pool.return_value = FakePool(FakeConn(plan="pro", count=2))  # limit 3, one free slot
+        mock_get_pool.return_value = FakePool(FakeConn(plan="pro", count=1))  # limit 2, one free slot
         response = client.post("/v1/auth/api-keys", json={"name": "prod key"})
         assert response.status_code == 200
         assert "key" in response.json()
@@ -128,7 +128,7 @@ class TestApiKeyUsageEndpoint:
         response = client.get("/v1/auth/api-keys/usage")
         assert response.status_code == 200
         body = response.json()
-        assert body == {"plan": "team", "limit": 10, "used": 3, "unlimited": False, "at_limit": False}
+        assert body == {"plan": "team", "limit": 5, "used": 3, "unlimited": False, "at_limit": False}
 
     @patch.dict("os.environ", {"API_KEY_LIMITS_ENFORCED": "false"})
     @patch("api.auth.get_pool")

--- a/core/tests/test_entitlements.py
+++ b/core/tests/test_entitlements.py
@@ -11,6 +11,7 @@ from services import api_keys, billing
 from services.entitlements import (
     PLAN_ENTITLEMENTS,
     api_key_limit_for_plan,
+    embeddings_enabled,
     entitlements_for_plan,
     is_self_hosted_deployment,
     limits_enforced,
@@ -25,11 +26,11 @@ class TestApiKeyLimitForPlan:
     def test_self_hosted_plan_capped_at_one(self):
         assert api_key_limit_for_plan("self_hosted") == 1
 
-    def test_pro_plan_capped_at_three(self):
-        assert api_key_limit_for_plan("pro") == 3
+    def test_pro_plan_capped_at_two(self):
+        assert api_key_limit_for_plan("pro") == 2
 
-    def test_team_plan_capped_at_ten(self):
-        assert api_key_limit_for_plan("team") == 10
+    def test_team_plan_capped_at_five(self):
+        assert api_key_limit_for_plan("team") == 5
 
     def test_enterprise_plan_capped_at_fifty(self):
         assert api_key_limit_for_plan("enterprise") == 50
@@ -37,14 +38,14 @@ class TestApiKeyLimitForPlan:
     def test_config_dict_matches_expected(self):
         assert {plan: e.max_api_keys for plan, e in PLAN_ENTITLEMENTS.items()} == {
             "self_hosted": 1,
-            "pro": 3,
-            "team": 10,
+            "pro": 2,
+            "team": 5,
             "enterprise": 50,
         }
 
     def test_plan_is_case_and_whitespace_insensitive(self):
-        assert api_key_limit_for_plan("  TEAM  ") == 10
-        assert api_key_limit_for_plan("Pro") == 3
+        assert api_key_limit_for_plan("  TEAM  ") == 5
+        assert api_key_limit_for_plan("Pro") == 2
         assert api_key_limit_for_plan("Self_Hosted") == 1
 
     def test_unknown_plan_is_unlimited(self):
@@ -66,7 +67,7 @@ class TestApiKeyLimitForPlan:
 class TestLimitOverride:
     def test_no_override_uses_config_default(self, monkeypatch):
         monkeypatch.delenv("API_KEY_LIMIT_PRO", raising=False)
-        assert api_key_limit_for_plan("pro") == 3
+        assert api_key_limit_for_plan("pro") == 2
 
     def test_override_replaces_config_default(self, monkeypatch):
         monkeypatch.setenv("API_KEY_LIMIT_PRO", "7")
@@ -75,15 +76,15 @@ class TestLimitOverride:
     def test_override_is_per_plan(self, monkeypatch):
         monkeypatch.setenv("API_KEY_LIMIT_TEAM", "20")
         assert api_key_limit_for_plan("team") == 20
-        assert api_key_limit_for_plan("pro") == 3  # unaffected
+        assert api_key_limit_for_plan("pro") == 2  # unaffected
 
     def test_blank_override_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("API_KEY_LIMIT_PRO", "  ")
-        assert api_key_limit_for_plan("pro") == 3
+        assert api_key_limit_for_plan("pro") == 2
 
     def test_invalid_override_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("API_KEY_LIMIT_PRO", "not-a-number")
-        assert api_key_limit_for_plan("pro") == 3
+        assert api_key_limit_for_plan("pro") == 2
 
     def test_override_works_for_unknown_plan_too(self, monkeypatch):
         # An override can grant a cap to a plan with no PLAN_ENTITLEMENTS
@@ -132,6 +133,24 @@ class TestIsSelfHostedDeployment:
     def test_managed_value_disables(self, monkeypatch):
         monkeypatch.setenv("DEPLOYMENT_MODE", "managed")
         assert is_self_hosted_deployment() is False
+
+
+class TestEmbeddingsEnabled:
+    def test_managed_defaults_on(self, monkeypatch):
+        monkeypatch.setenv("DEPLOYMENT_MODE", "managed")
+        monkeypatch.delenv("EMBEDDINGS_ENABLED", raising=False)
+        assert embeddings_enabled() is True
+
+    def test_self_hosted_defaults_off(self, monkeypatch):
+        monkeypatch.setenv("DEPLOYMENT_MODE", "self_hosted")
+        monkeypatch.delenv("EMBEDDINGS_ENABLED", raising=False)
+        assert embeddings_enabled() is False
+
+    @pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+    def test_self_hosted_opt_in(self, monkeypatch, value):
+        monkeypatch.setenv("DEPLOYMENT_MODE", "self_hosted")
+        monkeypatch.setenv("EMBEDDINGS_ENABLED", value)
+        assert embeddings_enabled() is True
 
 
 # ─────────────────────────────────────────
@@ -202,30 +221,30 @@ async def test_guard_no_op_when_enforcement_off(monkeypatch):
 
 
 async def test_guard_allows_under_limit(enforce):
-    conn = FakeConn(plan="pro", count=2)  # limit 3
+    conn = FakeConn(plan="pro", count=1)  # limit 2
     await api_keys.assert_and_reserve_api_key_slot(conn, tenant_id="t1")
     # Advisory lock must be taken before the count check.
     assert any("pg_advisory_xact_lock" in q for q, _ in conn.executed)
 
 
 async def test_guard_blocks_at_limit(enforce):
-    conn = FakeConn(plan="pro", count=3)  # limit 3, already full
+    conn = FakeConn(plan="pro", count=2)  # limit 2, already full
     with pytest.raises(HTTPException) as exc:
         await api_keys.assert_and_reserve_api_key_slot(conn, tenant_id="t1")
     assert exc.value.status_code == 409
     assert exc.value.detail["code"] == "api_key_limit_reached"
-    assert exc.value.detail["limit"] == 3
-    assert exc.value.detail["used"] == 3
+    assert exc.value.detail["limit"] == 2
+    assert exc.value.detail["used"] == 2
 
 
-async def test_guard_team_limit_is_ten(enforce):
-    conn_ok = FakeConn(plan="team", count=9)  # under limit of 10
+async def test_guard_team_limit_is_five(enforce):
+    conn_ok = FakeConn(plan="team", count=4)  # under limit of 5
     await api_keys.assert_and_reserve_api_key_slot(conn_ok, tenant_id="t1")
 
-    conn_full = FakeConn(plan="team", count=10)
+    conn_full = FakeConn(plan="team", count=5)
     with pytest.raises(HTTPException) as exc:
         await api_keys.assert_and_reserve_api_key_slot(conn_full, tenant_id="t1")
-    assert exc.value.detail["limit"] == 10
+    assert exc.value.detail["limit"] == 5
 
 
 async def test_guard_respects_env_override(enforce, monkeypatch):

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -2,7 +2,7 @@
 
 > Single source of truth for the Dashboard module. Reverse-engineered directly from the codebase.
 >
-> **Last verified:** 2026-07-08 · **No payment provider:** signup is plan → consent → OTP → `/dashboard` with a 30-day trial. Legacy `/signup/checkout` redirects to `/signup/plan`; `/signup/success` redirects to `/dashboard`. API key limits: Self-Hosted 1 / Pro 3 / Team 10 / Enterprise 50 (enforcement via `API_KEY_LIMITS_ENFORCED`, default OFF; self-hosted resolved via `DEPLOYMENT_MODE`, not `users.plan`).
+> **Last verified:** 2026-07-26 · API key limits: Self-Hosted 1 / Pro 2 / Team 5 / Enterprise 50 (enforcement via `API_KEY_LIMITS_ENFORCED`, default OFF; self-hosted resolved via `DEPLOYMENT_MODE`, not `users.plan`). Self-host embeddings off unless `EMBEDDINGS_ENABLED=true`.
 >
 > **Important finding:** There is **no "Pricing Modal"** in this codebase. Pricing is a static section on the landing page (`app/page.tsx`, `#pricing`). The only actual modal is the **Calendly "Book demo" modal** (`components/marketing/CalendlyBookModal.tsx`).
 >

--- a/dashboard/app/dashboard/settings/page.tsx
+++ b/dashboard/app/dashboard/settings/page.tsx
@@ -155,7 +155,7 @@ export default function SettingsPage() {
         <h2 className="text-sm font-medium text-white mb-1">Embeddings</h2>
         <p className="text-xs mb-4" style={{ color: "#9aa7b8" }}>
           {isOss
-            ? "Add your OpenAI API key to enable semantic search and context injection (OpenAI text-embedding-3-small)."
+            ? "Self-hosted installs do not index vectors by default. Set EMBEDDINGS_ENABLED=true in infra/.env, restart the API, then add your OpenAI API key here to enable semantic search and context injection (OpenAI text-embedding-3-small)."
             : "Choose the model used for semantic search and context injection (like Pinecone's embedding choice). All models use 1536 dimensions. New events use this model; existing vectors are not re-indexed automatically."}
         </p>
         {embLoading ? (

--- a/docs/DEVELOPER_TECHNICAL_BRIEF.md
+++ b/docs/DEVELOPER_TECHNICAL_BRIEF.md
@@ -288,8 +288,8 @@ Stack: postgres (pgvector), qdrant, redis, api. Dashboard optional (`npm run dev
 | Plan | Price | Highlights |
 |------|-------|------------|
 | **Self-Hosted** | Free forever | Full feature set, your infra, Docker, community support |
-| **Pro** | €29/mo | 50k events/mo, 2 projects, 90-day retention, email support, **30-day free trial**, no credit card to start |
-| **Team** | €69/mo | 100k events/mo, 5 projects, 1-year retention, priority support, 30-day free trial |
+| **Pro** | €29/mo | 50k events/mo, 2 active API keys, 90-day retention, email support, **30-day free trial**, no credit card to start |
+| **Team** | €69/mo | 100k events/mo, 5 active API keys, 1-year retention, priority support, 30-day free trial |
 
 **Line for developers:** “Free if you self-host; paid if you don’t want to run Postgres/Qdrant yourself.”
 

--- a/docs/REPO_SPLIT.md
+++ b/docs/REPO_SPLIT.md
@@ -8,3 +8,5 @@
 Public clones and all GitHub / website “Star on GitHub” links must use **ZizkaDB** only.
 
 EC2 (`db.zizka.ai`) should deploy from **zizkadb-cloud**, not from the slim public tree.
+
+When merging OSS product changes into cloud, take only `/dashboard/*` product routes, core API/services, and tests. **Do not** replace cloud marketing pages (`/`, `/signup`, `/enterprise`, `/admin`), `infra/nginx.conf`, or `infra/deploy-dashboard.sh`.

--- a/wiki/REST-API.md
+++ b/wiki/REST-API.md
@@ -75,7 +75,7 @@ GET /v1/events/{event_id}/why?depth=10
 | GET | `/v1/auth/api-keys/usage` | Plan key quota `{plan, limit, used, unlimited, at_limit}` |
 | DELETE | `/v1/auth/api-keys/{id}` | Revoke key |
 
-**API key creation** requires a dashboard login session (JWT), not an API key. Active keys per tenant are limited by plan (Self-Hosted 1, Pro 3, Team 10, Enterprise 50; unknown/no plan unlimited); exceeding the limit returns `409` with `{detail:{code:"api_key_limit_reached", plan, limit, used}}`. Enforcement is gated by the `API_KEY_LIMITS_ENFORCED` server flag; self-hosted deployments resolve their plan via `DEPLOYMENT_MODE=self_hosted`, not the `users.plan` column.
+**API key creation** requires a dashboard login session (JWT), not an API key. Active keys per tenant are limited by plan (Self-Hosted 1, Pro 2, Team 5, Enterprise 50; unknown/no plan unlimited); exceeding the limit returns `409` with `{detail:{code:"api_key_limit_reached", plan, limit, used}}`. Enforcement is gated by the `API_KEY_LIMITS_ENFORCED` server flag; self-hosted deployments resolve their plan via `DEPLOYMENT_MODE=self_hosted`, not the `users.plan` column.
 
 ## Health
 

--- a/wiki/Self-Hosting.md
+++ b/wiki/Self-Hosting.md
@@ -94,9 +94,11 @@ ZIZKADB_RUN_INTEGRATION=1 .venv/bin/pytest -m integration core/tests/test_integr
 
 ## Production self-host
 
-```bash
 Self-host deploy uses `infra/deploy-selfhost.sh` and Docker Compose.
-Managed cloud (`db.zizka.ai`) deploys from the private `zizkadb-cloud` repository — not this public product repo.
+
+Managed cloud (`db.zizka.ai`) deploys from the private `zizkadb-cloud` repository — **not** this public product repo.
+
+```bash
 bash infra/deploy-selfhost.sh
 ```
 
@@ -131,7 +133,8 @@ Configure in `infra/.env`:
 - `ENV=production` (disables dev key bypass)
 - **Do not set** `DEV_API_KEY` in production
 - `DEPLOYMENT_MODE=self_hosted` — keep this set even in production. `ENV=production` alone doesn't distinguish a self-hosted install from managed cloud (both use it), so this separate flag is what makes plan-based entitlement checks (e.g. API key limits) resolve to the Self-Hosted plan instead of whatever is in `users.plan`.
-- `API_KEY_LIMITS_ENFORCED=true` — enable per-plan API key caps (Pro: 3, Team: 10, Enterprise: 50). Default `false`; self-hosted installs are uncapped unless you set this.
+- `EMBEDDINGS_ENABLED=false` — default for self-host. Set to `true` only when you want semantic search / vector indexing; then configure `OPENAI_API_KEY` (or your provider key in Dashboard → Settings).
+- `API_KEY_LIMITS_ENFORCED=true` — enable per-plan API key caps (Self-Hosted: 1, Pro: 2, Team: 5, Enterprise: 50). Default `false`; self-hosted installs are uncapped unless you set this.
 
 Validate production config before deploy:
 


### PR DESCRIPTION
Pro/Team caps become 2 and 5 active keys; self-hosted installs skip Qdrant indexing unless EMBEDDINGS_ENABLED=true, with clear search/memory errors and updated docs.