### PR TITLE
feat(dashboard): OSS first-run onboarding + clean edition separation

### DIFF
--- a/dashboard/app/dashboard/activity/page.tsx
+++ b/dashboard/app/dashboard/activity/page.tsx
@@ -3,11 +3,13 @@
 import { Suspense, useState } from 'react'
 import { formatDistanceToNow } from 'date-fns'
 import { GettingStartedChecklist } from '@/components/ConnectionStatus'
+import { CreateApiKeyCard } from '@/components/dashboard/CreateApiKeyCard'
 import { EmptyState, ErrorState, PageHeader, Skeleton } from '@/components/ui'
 import { EventsSegment } from '@/components/dashboard/EventsSegment'
 import { SessionsSegment } from '@/components/dashboard/SessionsSegment'
 import { TimeTravelSegment } from '@/components/dashboard/TimeTravelSegment'
 import { useAgents } from '@/hooks/useAgents'
+import { useEdition } from '@/hooks/useEdition'
 import { useSelectedAgent } from '@/hooks/useSelectedAgent'
 import { useAgentEvents } from '@/hooks/useAgentEvents'
 import { useAgentStats } from '@/hooks/useAgentStats'
@@ -65,6 +67,7 @@ function SegmentedControl({
 function ActivityContent() {
   const { agents, loading: agentsLoading, error: agentsError } = useAgents()
   const { agentId, invalidAgent } = useSelectedAgent(agents)
+  const isOss = useEdition().edition === 'oss'
   const [segment, setSegment] = useState<Segment>('events')
 
   // Hooks must run unconditionally; they no-op on a null agent.
@@ -85,13 +88,28 @@ function ActivityContent() {
           title="Activity"
           description="Everything your agents record, as it happens."
         />
-        <EmptyState
-          title="No agents yet"
-          description="An agent is created automatically the first time it logs an event. Follow the steps below to send your first one."
-        />
-        <div className="mt-5">
-          <GettingStartedChecklist />
-        </div>
+        {isOss ? (
+          <>
+            <p className="text-sm mb-4" style={{ color: colors.textMuted }}>
+              Welcome to ZizkaDB. Create an API key, add it to your app, and your
+              first agent appears here the moment it logs an event.
+            </p>
+            <div className="mb-5">
+              <CreateApiKeyCard />
+            </div>
+            <GettingStartedChecklist />
+          </>
+        ) : (
+          <>
+            <EmptyState
+              title="No agents yet"
+              description="An agent is created automatically the first time it logs an event. Follow the steps below to send your first one."
+            />
+            <div className="mt-5">
+              <GettingStartedChecklist />
+            </div>
+          </>
+        )}
       </>
     )
   }

--- a/dashboard/app/dashboard/settings/page.tsx
+++ b/dashboard/app/dashboard/settings/page.tsx
@@ -246,8 +246,16 @@ export default function SettingsPage() {
             <div className="flex items-center gap-3">
               <button
                 type="submit"
-                disabled={embSaving}
-                className="px-4 py-2 rounded-lg text-sm font-medium text-black disabled:opacity-40"
+                disabled={
+                  embSaving ||
+                  ((isOss || !usePlatformKey) && !customApiKey.trim())
+                }
+                title={
+                  (isOss || !usePlatformKey) && !customApiKey.trim()
+                    ? "Enter your OpenAI API key first"
+                    : undefined
+                }
+                className="px-4 py-2 rounded-lg text-sm font-medium text-black disabled:opacity-40 disabled:cursor-not-allowed"
                 style={{ background: "#22c55e" }}
               >
                 {embSaving ? "Saving…" : "Save embeddings"}

--- a/dashboard/components/AgentApiKeys.tsx
+++ b/dashboard/components/AgentApiKeys.tsx
@@ -3,6 +3,7 @@
 import { ApiKeyUsage } from "@/components/ApiKeyUsage";
 import { useApiKeyQuota } from "@/hooks/useApiKeyQuota";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { useEdition } from "@/hooks/useEdition";
 import {
   createAgentApiKey,
   getAgentApiKeys,
@@ -30,6 +31,7 @@ export function AgentApiKeys({
   const [revokingId, setRevokingId] = useState<string | null>(null);
   const [newKey, setNewKey] = useState<string | null>(null);
   const { copied, copy } = useCopyToClipboard();
+  const isOss = useEdition().edition === "oss";
   const [err, setErr] = useState("");
   const [testBusy, setTestBusy] = useState(false);
   const [testMsg, setTestMsg] = useState("");
@@ -143,7 +145,9 @@ export function AgentApiKeys({
               onClick={handleCreate}
               title={
                 quota.at_limit
-                  ? "API key limit reached — upgrade your plan to create more"
+                  ? isOss
+                    ? "API key limit reached — raise API_KEY_LIMIT_<plan> in your server env"
+                    : "API key limit reached — upgrade your plan to create more"
                   : undefined
               }
               className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium text-black disabled:opacity-40 disabled:cursor-not-allowed"

--- a/dashboard/components/ConnectionStatus.tsx
+++ b/dashboard/components/ConnectionStatus.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { IS_DEV_MODE as IS_DEV } from "@/lib/constants";
+import { useEdition } from "@/hooks/useEdition";
 
 // Note: the old full-width ConnectionStatus banner has been folded into the
 // header AccountMenu (see components/dashboard/AccountMenu.tsx) so the content
@@ -9,8 +9,9 @@ import { IS_DEV_MODE as IS_DEV } from "@/lib/constants";
 // checklist shown in the Activity zero-agent state.
 
 export function GettingStartedChecklist() {
-  const snippet = IS_DEV
-    ? `# OSS — same tenant as "Open my dashboard →"
+  const isOss = useEdition().edition === "oss";
+  const snippet = isOss
+    ? `# Self-hosted — SDK points at your own instance
 pip install zizkadb-sdk
 zizkadb demo`
     : `# Managed cloud — use your key from Settings
@@ -24,7 +25,7 @@ async def main():
         print('Logged:', r.event_id)
 asyncio.run(main())"`
 
-  const steps = IS_DEV
+  const steps = isOss
     ? [
         {
           title: 'Run OSS quickstart',
@@ -61,7 +62,7 @@ asyncio.run(main())"`
     >
       <h3 className="text-white font-medium mb-1">Getting started</h3>
       <p className="text-sm mb-6" style={{ color: '#e8edf5' }}>
-        {IS_DEV
+        {isOss
           ? 'OSS quickstart — taste causal lineage, then connect your stack.'
           : 'Three steps to see your first agent in the dashboard.'}
       </p>
@@ -90,7 +91,7 @@ asyncio.run(main())"`
         {snippet}
       </pre>
       <p className="text-xs mt-4" style={{ color: '#e8edf5' }}>
-        {IS_DEV ? (
+        {isOss ? (
           <>
             Connect guide:{' '}
             <a

--- a/dashboard/components/dashboard/AccountMenu.tsx
+++ b/dashboard/components/dashboard/AccountMenu.tsx
@@ -9,6 +9,7 @@ import { clearToken, getSessionEmail, getToken } from '@/lib/auth'
 import { IS_DEV_MODE } from '@/lib/constants'
 import { colors, radii } from '@/lib/design-tokens'
 import { useConnectionHealth, type HealthState } from '@/hooks/useConnectionHealth'
+import { useEdition } from '@/hooks/useEdition'
 
 const PLAN_LABELS: Record<string, string> = { pro: 'Pro', team: 'Team', enterprise: 'Enterprise' }
 
@@ -48,6 +49,7 @@ export function AccountMenu() {
   // disagree and React throws a hydration mismatch, so resolve it after mount.
   const [email, setEmail] = useState<string | null>(null)
   const health = useConnectionHealth()
+  const isOss = useEdition().edition === 'oss'
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -86,6 +88,11 @@ export function AccountMenu() {
   const trialing = billing?.subscription_status === 'trialing'
   const hm = HEALTH_META[health]
   const initial = (email?.[0] ?? 'U').toUpperCase()
+  // Plan/trial is a managed-cloud billing concept — never meaningful on a
+  // self-hosted install, so hide it there. The email in dev mode is the
+  // synthetic `dev@localhost` login placeholder, so hide that too.
+  const showBilling = !isOss && !!planLabel
+  const showEmail = !!email && !IS_DEV_MODE
 
   function signOut() {
     clearToken()
@@ -132,7 +139,7 @@ export function AccountMenu() {
             }}
           />
         </span>
-        {planLabel && (
+        {showBilling && (
           <span className="text-xs font-medium hidden sm:inline" style={{ color: colors.textMuted }}>
             {planLabel}
           </span>
@@ -152,38 +159,40 @@ export function AccountMenu() {
             boxShadow: '0 12px 32px rgba(0,0,0,0.5)',
           }}
         >
-          {/* Identity */}
-          <div className="px-4 py-3" style={{ borderBottom: `1px solid ${colors.border}` }}>
-            <div className="flex items-center gap-2 flex-wrap">
-              {planLabel && (
-                <span
-                  className="text-xs font-semibold px-2 py-0.5"
-                  style={{
-                    background: colors.surfaceHover,
-                    color: colors.text,
-                    borderRadius: radii.full,
-                  }}
-                >
-                  {planLabel}
-                </span>
+          {/* Identity — plan/trial (managed only) + email (real accounts only) */}
+          {(showBilling || showEmail) && (
+            <div className="px-4 py-3" style={{ borderBottom: `1px solid ${colors.border}` }}>
+              {showBilling && (
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className="text-xs font-semibold px-2 py-0.5"
+                    style={{
+                      background: colors.surfaceHover,
+                      color: colors.text,
+                      borderRadius: radii.full,
+                    }}
+                  >
+                    {planLabel}
+                  </span>
+                  {trialing && billing?.trial_ends_at && (
+                    <span className="text-xs" style={{ color: colors.textMuted }}>
+                      Trial ends {formatDate(billing.trial_ends_at)}
+                    </span>
+                  )}
+                  {billing?.subscription_status === 'active' && !trialing && (
+                    <span className="text-xs" style={{ color: colors.success }}>
+                      Active
+                    </span>
+                  )}
+                </div>
               )}
-              {trialing && billing?.trial_ends_at && (
-                <span className="text-xs" style={{ color: colors.textMuted }}>
-                  Trial ends {formatDate(billing.trial_ends_at)}
-                </span>
-              )}
-              {billing?.subscription_status === 'active' && !trialing && (
-                <span className="text-xs" style={{ color: colors.success }}>
-                  Active
-                </span>
+              {showEmail && (
+                <p className="text-sm mt-1.5 truncate" style={{ color: colors.text }} title={email ?? undefined}>
+                  {email}
+                </p>
               )}
             </div>
-            {email && (
-              <p className="text-sm mt-1.5 truncate" style={{ color: colors.text }} title={email}>
-                {email}
-              </p>
-            )}
-          </div>
+          )}
 
           {/* Connection */}
           <div className="px-4 py-3" style={{ borderBottom: `1px solid ${colors.border}` }}>

--- a/dashboard/components/dashboard/AgentKeysSection.tsx
+++ b/dashboard/components/dashboard/AgentKeysSection.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense } from 'react'
 import { AgentApiKeys } from '@/components/AgentApiKeys'
+import { CreateApiKeyCard } from '@/components/dashboard/CreateApiKeyCard'
 import { LoadingLine } from '@/components/ui'
 import { useAgents } from '@/hooks/useAgents'
 import { useSelectedAgent } from '@/hooks/useSelectedAgent'
@@ -14,6 +15,9 @@ function Inner() {
   const isOss = useEdition().edition === 'oss'
 
   if (loading) return <LoadingLine label="Loading agents…" />
+
+  // First-run OSS: no agent yet → offer key creation instead of a dead end.
+  if (!agentId && isOss) return <CreateApiKeyCard />
 
   return (
     <div

--- a/dashboard/components/dashboard/CreateApiKeyCard.test.tsx
+++ b/dashboard/components/dashboard/CreateApiKeyCard.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+
+const createApiKey = vi.fn()
+vi.mock('@/lib/api', () => ({
+  API: 'http://localhost:8000',
+  createApiKey: (...a: unknown[]) => createApiKey(...a),
+}))
+vi.mock('@/lib/auth', () => ({ getToken: () => 'tok' }))
+
+import { CreateApiKeyCard } from './CreateApiKeyCard'
+
+beforeEach(() => createApiKey.mockReset())
+
+describe('CreateApiKeyCard', () => {
+  it('renders the name input and create button', () => {
+    render(<CreateApiKeyCard />)
+    expect(screen.getByLabelText('API key name')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /create key/i })).toBeInTheDocument()
+  })
+
+  it('creates a key and reveals it once, with the host in the usage snippet', async () => {
+    createApiKey.mockResolvedValueOnce({ key: 'zizkadb_live_abc123', prefix: 'zizkadb_live_abc', name: 'my-app' })
+    const onCreated = vi.fn()
+    render(<CreateApiKeyCard onCreated={onCreated} />)
+
+    fireEvent.change(screen.getByLabelText('API key name'), { target: { value: 'my-app' } })
+    fireEvent.click(screen.getByRole('button', { name: /create key/i }))
+
+    await waitFor(() => expect(screen.getByText('zizkadb_live_abc123')).toBeInTheDocument())
+    expect(createApiKey).toHaveBeenCalledWith('tok', 'my-app')
+    // usage snippet points the app at the local host (the fix for cloud-vs-local 401s)
+    expect(screen.getByText(/ZIZKADB_HOST=http:\/\/localhost:8000/)).toBeInTheDocument()
+    expect(onCreated).toHaveBeenCalled()
+  })
+
+  it('defaults an empty name to "default"', async () => {
+    createApiKey.mockResolvedValueOnce({ key: 'zizkadb_live_x', prefix: 'zizkadb_live_x', name: 'default' })
+    render(<CreateApiKeyCard />)
+    fireEvent.click(screen.getByRole('button', { name: /create key/i }))
+    await waitFor(() => expect(createApiKey).toHaveBeenCalledWith('tok', 'default'))
+  })
+
+  it('surfaces an error when creation fails', async () => {
+    createApiKey.mockRejectedValueOnce(new Error('API key limit reached'))
+    render(<CreateApiKeyCard />)
+    fireEvent.click(screen.getByRole('button', { name: /create key/i }))
+    await waitFor(() => expect(screen.getByText(/API key limit reached/)).toBeInTheDocument())
+  })
+})

--- a/dashboard/components/dashboard/CreateApiKeyCard.tsx
+++ b/dashboard/components/dashboard/CreateApiKeyCard.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useState } from 'react'
+import { KeyRound, Plus } from 'lucide-react'
+import { Button, CopyButton } from '@/components/ui'
+import { API, createApiKey } from '@/lib/api'
+import { getToken } from '@/lib/auth'
+import { colors, radii } from '@/lib/design-tokens'
+
+/**
+ * First-run / OSS key creation. Creates a tenant-wide named key (works for ANY
+ * agent name — no agent needs to exist first), reveals it once, and shows how to
+ * wire it into an app. This is the entry point that breaks the chicken-and-egg
+ * where a key used to require a pre-existing agent.
+ */
+export function CreateApiKeyCard({ onCreated }: { onCreated?: () => void }) {
+  const [name, setName] = useState('')
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [newKey, setNewKey] = useState<string | null>(null)
+
+  const host = API || 'http://localhost:8000'
+
+  async function handleCreate(e: React.FormEvent) {
+    e.preventDefault()
+    const token = getToken()
+    if (!token) {
+      setError('Please sign in again.')
+      return
+    }
+    setCreating(true)
+    setError(null)
+    try {
+      const res = await createApiKey(token, name.trim() || 'default')
+      setNewKey(res.key)
+      setName('')
+      onCreated?.()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create API key')
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  return (
+    <div
+      className="p-5"
+      style={{ background: colors.surface, border: `1px solid ${colors.border}`, borderRadius: radii.lg }}
+    >
+      <div className="flex items-center gap-2 mb-1">
+        <KeyRound size={15} style={{ color: colors.textMuted }} />
+        <h2 className="text-sm font-medium" style={{ color: colors.textStrong }}>
+          Create your API key
+        </h2>
+      </div>
+      <p className="text-xs mb-4" style={{ color: colors.textMuted }}>
+        Name a key, drop it into your app, and start logging. One key works for any
+        agent — the agent is created automatically the first time it logs an event.
+      </p>
+
+      {newKey ? (
+        <KeyReveal apiKey={newKey} host={host} onDone={() => setNewKey(null)} />
+      ) : (
+        <form className="flex flex-col sm:flex-row gap-2" onSubmit={handleCreate}>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="Key name (e.g. my-app production)"
+            disabled={creating}
+            aria-label="API key name"
+            className="flex-1 px-3 py-2 text-sm outline-none disabled:opacity-40"
+            style={{
+              background: colors.bg,
+              border: `1px solid ${colors.border}`,
+              borderRadius: radii.md,
+              color: colors.text,
+            }}
+          />
+          <Button type="submit" tone="primary" disabled={creating}>
+            <Plus size={14} />
+            {creating ? 'Creating…' : 'Create key'}
+          </Button>
+        </form>
+      )}
+
+      {error && (
+        <p className="text-xs mt-2" style={{ color: colors.danger }}>
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}
+
+function KeyReveal({ apiKey, host, onDone }: { apiKey: string; host: string; onDone: () => void }) {
+  const snippet = `ZIZKADB_HOST=${host}\nZIZKADB_API_KEY=${apiKey}`
+  return (
+    <div className="space-y-3">
+      <div
+        className="p-3"
+        style={{ background: colors.successBg, border: `1px solid ${colors.success}40`, borderRadius: radii.md }}
+      >
+        <div className="flex items-center justify-between mb-2">
+          <p className="text-xs font-medium" style={{ color: colors.success }}>
+            Your API key — copy it now, it won&apos;t be shown again
+          </p>
+          <CopyButton value={apiKey} label="Copy key" />
+        </div>
+        <code
+          className="block text-xs font-mono px-2 py-1.5 overflow-x-auto"
+          style={{ background: colors.bg, color: colors.text, borderRadius: radii.sm }}
+        >
+          {apiKey}
+        </code>
+      </div>
+
+      <div>
+        <div className="flex items-center justify-between mb-1.5">
+          <p className="text-xs font-medium uppercase tracking-wide" style={{ color: colors.textFaint }}>
+            Use it in your app
+          </p>
+          <CopyButton value={snippet} label="Copy" />
+        </div>
+        <pre
+          className="text-xs font-mono p-3 overflow-x-auto"
+          style={{ background: colors.bg, color: colors.text, borderRadius: radii.md }}
+        >
+          {snippet}
+        </pre>
+        <p className="text-xs mt-1.5" style={{ color: colors.textMuted }}>
+          Point your SDK at this host (self-hosted keys only work against your own
+          instance, not the cloud). Log one event and your agent appears here.
+        </p>
+      </div>
+
+      <button
+        type="button"
+        onClick={onDone}
+        className="text-xs"
+        style={{ color: colors.textMuted }}
+      >
+        Done
+      </button>
+    </div>
+  )
+}


### PR DESCRIPTION
First-run onboarding (fixes the chicken-and-egg where a key required a pre-existing agent, leaving self-hosters stuck at an empty dashboard):
- New CreateApiKeyCard — creates a tenant-wide named key (no agent needed, works for any agent, so no agent-name-mismatch 403), reveals it once with copy, and shows a ZIZKADB_HOST/ZIZKADB_API_KEY usage snippet.
- Wired into the Activity empty state and the Settings no-agent case (OSS), replacing the previous instructional dead-ends.

Edition separation (OSS/self-host vs managed cloud):
- AccountMenu: hide plan/trial (managed-only billing concept) on OSS and the synthetic dev@localhost email in dev mode; identity block only renders when there is something real to show.
- ConnectionStatus getting-started checklist now gates on edition (not dev mode) so managed never shows localhost content and OSS never shows cloud.
- AgentApiKeys: at-limit hint is edition-aware (OSS points at API_KEY_LIMIT_* env, not "upgrade your plan").

UX:
- Settings "Save embeddings" is disabled until the OpenAI key field has text (when a key is required), with a tooltip + not-allowed cursor.

Tests: CreateApiKeyCard (create/reveal/host-snippet/error). 102 FE tests pass.