### PR TITLE
fix(mcp): pin mcp SDK below 2.0 to restore FastMCP imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r core/requirements.txt -r core/requirements-dev.txt
+          pip install "mcp[cli]>=1.0.0,<2.0.0"
           pip install -e sdk/python -e integrations/langchain -e integrations/crewai -e mcp
 
       - name: Ruff lint

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "mcp[cli]>=1.0.0",
+    "mcp[cli]>=1.0.0,<2.0.0",
     "httpx>=0.27.0",
 ]
 


### PR DESCRIPTION
MCP Python SDK v2 removed mcp.server.fastmcp; unpinned installs broke CI. Re-add <2.0.0 and install the cap explicitly in the workflow.