### PR TITLE
fix(dashboard): duplicate Print/Download button, loading-state hang; tagline update

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # ZizkaDB
 
-**Know why your agent did what it did.**
+**Dont Observe - Audit your AI Agent.**
 
 Operational database for AI agents — replay sessions, trace decisions, detect drift.
 

--- a/dashboard/components/dashboard/report/ReportToolbar.tsx
+++ b/dashboard/components/dashboard/report/ReportToolbar.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Download, Printer, RefreshCw } from 'lucide-react'
+import { Printer, RefreshCw } from 'lucide-react'
 import { Button } from '@/components/ui'
 import { Select } from '@/components/ui/Select'
 import { colors, radii } from '@/lib/design-tokens'
@@ -8,8 +8,9 @@ import { PERIOD_OPTIONS, type PeriodType, validateCustomRange } from '@/lib/repo
 
 /**
  * Report controls: period picker, custom date range (only for Custom), and the
- * Regenerate / Print / Download-PDF actions. Print & Download are disabled
- * until a report is available so a skeleton is never printed.
+ * Regenerate / Print actions. Print opens the browser print dialog, where
+ * "Save as PDF" is a destination option — disabled until a report is
+ * available so a skeleton is never printed.
  */
 export function ReportToolbar({
   period,
@@ -37,7 +38,7 @@ export function ReportToolbar({
   refreshing: boolean
   /** Override the period dropdown's options (default: the full shared list). */
   periodOptions?: typeof PERIOD_OPTIONS
-  /** Hide Print/Download PDF for tabs where export doesn't make sense (default: shown). */
+  /** Hide the Print action for tabs where export doesn't make sense (default: shown). */
   showExport?: boolean
   /** Hide Regenerate for tabs that already refetch automatically on every filter change (default: shown). */
   showRegenerate?: boolean
@@ -92,16 +93,10 @@ export function ReportToolbar({
           </Button>
         )}
         {showExport && (
-          <>
-            <Button onClick={onPrint} disabled={!canExport}>
-              <Printer size={14} />
-              Print
-            </Button>
-            <Button onClick={onPrint} tone="primary" disabled={!canExport}>
-              <Download size={14} />
-              Download PDF
-            </Button>
-          </>
+          <Button onClick={onPrint} tone="primary" disabled={!canExport}>
+            <Printer size={14} />
+            Print / Save as PDF
+          </Button>
         )}
       </div>
     </div>

--- a/dashboard/hooks/useAgentTokenOptimization.ts
+++ b/dashboard/hooks/useAgentTokenOptimization.ts
@@ -40,7 +40,10 @@ export function useAgentTokenOptimization(
       return
     }
     const token = getToken()
-    if (!token) return
+    if (!token) {
+      setLoading(false)
+      return
+    }
 
     let cancelled = false
     const isRegen = nonce > 0

--- a/dashboard/hooks/useAgentTokenUsage.ts
+++ b/dashboard/hooks/useAgentTokenUsage.ts
@@ -41,7 +41,10 @@ export function useAgentTokenUsage(
       return
     }
     const token = getToken()
-    if (!token) return
+    if (!token) {
+      setLoading(false)
+      return
+    }
 
     let cancelled = false
     const isRegen = nonce > 0

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,6 +1,6 @@
 # ZizkaDB Wiki
 
-**Know why your agent did what it did.** — causal lineage, time travel, semantic search, and dashboards for AI agents.
+**Dont Observe - Audit your AI Agent.** — causal lineage, time travel, semantic search, and dashboards for AI agents.
 
 | Resource | Link |
 |----------|------|


### PR DESCRIPTION
## Summary
Ports the applicable parts of `zizkadb-cloud` PR [#22](https://github.com/ZIZKA-AI-SL/zizkadb-cloud/pull/22) and [#23](https://github.com/ZIZKA-AI-SL/zizkadb-cloud/pull/23) to this OSS mirror. The enterprise-page and marketing-site-only changes in those PRs don't apply here — this repo's landing page (`dashboard/app/page.tsx`) and marketing components differ from the cloud marketing site (no `/enterprise` page, no `marketing-theme.ts`, no `MarketingFooter.tsx`).

- **ReportToolbar**: Print and Download PDF called the identical `onPrint` handler and never produced a distinct file, so the two-button UI was misleading. Collapsed to one "Print / Save as PDF" button — `window.print()` already lets the user choose Save as PDF as a destination.
- **useAgentTokenUsage / useAgentTokenOptimization**: the early return on a missing auth token skipped `setLoading(false)`, so the UI spun forever if the token went missing mid-session.
- **README.md / wiki/Home.md**: tagline updated to "Dont Observe - Audit your AI Agent." to match the cloud rebrand.

Note: the `globals.css` `.btn-hover`/`.opt-hover`/`.report-cover` bugs fixed in cloud PR #22 don't exist in this repo — the OSS `globals.css` already has working equivalents.

## Test plan
- [ ] `cd dashboard && npm run lint && npm run build`
- [ ] Manually verify Reports tab: single "Print / Save as PDF" button opens print dialog
- [ ] Manually verify Token Usage / Token Optimization pages don't spin indefinitely when auth token is cleared mid-session

🤖 Generated with [Claude Code](https://claude.com/claude-code)