### PR TITLE
feat(core): add agent-to-agent communication

### DIFF
--- a/core/api/a2a.py
+++ b/core/api/a2a.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel, Field
+
+from api.deps import get_tenant
+from db.connection import get_pool
+from services.event_write import write_event
+from services.exceptions import bad_request, forbidden, not_found
+
+
+router = APIRouter()
+
+
+class A2AMessageRequest(BaseModel):
+    recipient_agent: str = Field(..., min_length=1, max_length=255)
+    message: str = Field(..., min_length=1, max_length=100_000)
+    session_id: str | None = Field(default=None, max_length=255)
+    correlation_id: str | None = Field(default=None, max_length=255)
+    metadata: dict[str, Any] | None = None
+
+
+@router.post("/messages", status_code=201)
+async def send_message(
+    body: A2AMessageRequest,
+    tenant: dict = Depends(get_tenant),
+):
+    """
+    Send a message from the authenticated agent to another
+    agent belonging to the same tenant.
+
+    The sender is derived exclusively from the authenticated
+    agent-scoped API key and cannot be supplied by the client.
+    """
+
+    tenant_id = tenant["tenant_id"]
+    sender_agent = tenant.get("agent_id")
+
+    # A2A requires an agent identity. Tenant-wide credentials must
+    # not be allowed to impersonate arbitrary agents.
+    if not sender_agent:
+        raise forbidden(
+            detail=(
+                "Agent-to-agent communication requires an "
+                "agent-scoped API key"
+            )
+        )
+
+    recipient_agent = body.recipient_agent
+
+    if sender_agent == recipient_agent:
+        raise bad_request(
+            "Sender and recipient must be different agents"
+        )
+
+    pool = get_pool()
+
+    # Recipient must already exist in the authenticated tenant.
+    recipient_exists = await pool.fetchval(
+        """
+        SELECT 1
+        FROM agents
+        WHERE tenant_id = $1
+          AND agent_id = $2
+        LIMIT 1
+        """,
+        tenant_id,
+        recipient_agent,
+    )
+
+    if not recipient_exists:
+        raise not_found(
+            f"Recipient agent '{recipient_agent}' not found"
+        )
+
+    message_id = str(uuid4())
+
+    event_data = {
+        "message_id": message_id,
+        "sender_agent": sender_agent,
+        "recipient_agent": recipient_agent,
+        "message": body.message,
+        "direction": "request",
+        "correlation_id": body.correlation_id,
+    }
+
+    result = await write_event(
+        tenant_id=tenant_id,
+        agent=sender_agent,
+        event="a2a.message",
+        data=event_data,
+        session_id=body.session_id,
+        metadata=body.metadata,
+    )
+
+    return {
+        "message_id": message_id,
+        "event_id": result["event_id"],
+        "sender_agent": sender_agent,
+        "recipient_agent": recipient_agent,
+        "session_id": body.session_id,
+        "correlation_id": body.correlation_id,
+        "timestamp": result["timestamp"],
+        "sequence_no": result["sequence_no"],
+        "checksum": result["checksum"],
+        "indexed": result["indexed"],
+    }

--- a/core/main.py
+++ b/core/main.py
@@ -11,6 +11,7 @@ from api.auth import _ensure_dev_tenant
 from api.events import router as events_router
 from api.agents import router as agents_router
 from api.auth import router as auth_router
+from api.a2a import router as a2a_router
 from api.search import router as search_router
 from api.memory import router as memory_router
 from api.telemetry import router as telemetry_router
@@ -104,6 +105,7 @@ app.add_middleware(
 app.include_router(auth_router,      prefix="/v1/auth",      tags=["auth"])
 app.include_router(events_router,    prefix="/v1/events",    tags=["events"])
 app.include_router(agents_router,    prefix="/v1/agents",    tags=["agents"])
+app.include_router(a2a_router,       prefix="/v1/a2a",       tags=["a2a"])
 app.include_router(search_router,    prefix="/v1/search",    tags=["search"])
 app.include_router(memory_router,    prefix="/v1/memory",    tags=["memory"])
 app.include_router(telemetry_router, prefix="/v1/telemetry", tags=["telemetry"])

--- a/core/tests/test_a2a.py
+++ b/core/tests/test_a2a.py
@@ -1,0 +1,284 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from api.a2a import A2AMessageRequest, send_message
+
+
+TENANT = {
+    "tenant_id": "tenant-1",
+    "agent_id": "agent-a",
+}
+
+TENANT_WIDE_KEY = {
+    "tenant_id": "tenant-1",
+}
+
+
+@pytest.fixture
+def mock_pool(monkeypatch):
+    pool = AsyncMock()
+
+    monkeypatch.setattr(
+        "api.a2a.get_pool",
+        lambda: pool,
+    )
+
+    return pool
+
+
+@pytest.fixture
+def mock_write_event(monkeypatch):
+    write_event = AsyncMock(
+        return_value={
+            "event_id": "event-123",
+            "timestamp": "2026-08-13T12:00:00+00:00",
+            "sequence_no": 7,
+            "checksum": "abc123",
+            "indexed": False,
+        }
+    )
+
+    monkeypatch.setattr(
+        "api.a2a.write_event",
+        write_event,
+    )
+
+    return write_event
+
+
+@pytest.mark.asyncio
+async def test_send_a2a_message_success(
+    mock_pool,
+    mock_write_event,
+):
+    mock_pool.fetchval.return_value = 1
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Hello agent B",
+        session_id="session-1",
+        correlation_id="corr-1",
+    )
+
+    result = await send_message(
+        body,
+        tenant=TENANT,
+    )
+
+    assert result["event_id"] == "event-123"
+    assert result["sender_agent"] == "agent-a"
+    assert result["recipient_agent"] == "agent-b"
+    assert result["session_id"] == "session-1"
+    assert result["correlation_id"] == "corr-1"
+    assert result["sequence_no"] == 7
+    assert result["indexed"] is False
+
+    mock_write_event.assert_awaited_once()
+
+    kwargs = mock_write_event.await_args.kwargs
+
+    assert kwargs["tenant_id"] == "tenant-1"
+    assert kwargs["agent"] == "agent-a"
+    assert kwargs["event"] == "a2a.message"
+    assert kwargs["session_id"] == "session-1"
+
+    data = kwargs["data"]
+
+    assert data["sender_agent"] == "agent-a"
+    assert data["recipient_agent"] == "agent-b"
+    assert data["message"] == "Hello agent B"
+    assert data["direction"] == "request"
+    assert data["correlation_id"] == "corr-1"
+    assert data["message_id"]
+
+
+@pytest.mark.asyncio
+async def test_sender_is_derived_from_authenticated_agent(
+    mock_pool,
+    mock_write_event,
+):
+    mock_pool.fetchval.return_value = 1
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Do not trust client sender",
+    )
+
+    await send_message(
+        body,
+        tenant={
+            "tenant_id": "tenant-1",
+            "agent_id": "agent-a",
+        },
+    )
+
+    kwargs = mock_write_event.await_args.kwargs
+
+    assert kwargs["agent"] == "agent-a"
+    assert kwargs["data"]["sender_agent"] == "agent-a"
+
+
+@pytest.mark.asyncio
+async def test_tenant_wide_key_cannot_send_a2a_message():
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Hello",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await send_message(
+            body,
+            tenant=TENANT_WIDE_KEY,
+        )
+
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_recipient_must_exist(mock_pool):
+    mock_pool.fetchval.return_value = None
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-does-not-exist",
+        message="Hello",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await send_message(
+            body,
+            tenant=TENANT,
+        )
+
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_recipient_is_rejected(mock_pool):
+    # The recipient lookup is explicitly constrained by tenant_id.
+    mock_pool.fetchval.return_value = None
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-other-tenant",
+        message="Hello",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await send_message(
+            body,
+            tenant=TENANT,
+        )
+
+    assert exc.value.status_code == 404
+
+    sql, tenant_id, recipient = (
+        mock_pool.fetchval.await_args.args
+    )
+
+    assert "tenant_id = $1" in sql
+    assert "agent_id = $2" in sql
+    assert tenant_id == "tenant-1"
+    assert recipient == "agent-other-tenant"
+
+
+@pytest.mark.asyncio
+async def test_agent_cannot_send_message_to_itself(
+    mock_pool,
+):
+    body = A2AMessageRequest(
+        recipient_agent="agent-a",
+        message="Self message",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await send_message(
+            body,
+            tenant=TENANT,
+        )
+
+    assert exc.value.status_code == 400
+
+    mock_pool.fetchval.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_message_metadata_is_preserved(
+    mock_pool,
+    mock_write_event,
+):
+    mock_pool.fetchval.return_value = 1
+
+    metadata = {
+        "priority": "high",
+        "source": "test",
+    }
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Important message",
+        metadata=metadata,
+    )
+
+    await send_message(
+        body,
+        tenant=TENANT,
+    )
+
+    kwargs = mock_write_event.await_args.kwargs
+
+    assert kwargs["metadata"] == metadata
+
+
+@pytest.mark.asyncio
+async def test_message_without_session_or_correlation_is_allowed(
+    mock_pool,
+    mock_write_event,
+):
+    mock_pool.fetchval.return_value = 1
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Simple message",
+    )
+
+    result = await send_message(
+        body,
+        tenant=TENANT,
+    )
+
+    assert result["session_id"] is None
+    assert result["correlation_id"] is None
+
+    kwargs = mock_write_event.await_args.kwargs
+
+    assert kwargs["session_id"] is None
+    assert kwargs["data"]["correlation_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_write_event_failure_propagates(
+    mock_pool,
+    monkeypatch,
+):
+    mock_pool.fetchval.return_value = 1
+
+    write_event = AsyncMock(
+        side_effect=RuntimeError("database unavailable")
+    )
+
+    monkeypatch.setattr(
+        "api.a2a.write_event",
+        write_event,
+    )
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Hello",
+    )
+
+    with pytest.raises(RuntimeError, match="database unavailable"):
+        await send_message(
+            body,
+            tenant=TENANT,
+        )


### PR DESCRIPTION
## Summary

Adds authenticated agent-to-agent communication within a tenant.

## Changes

- Add `POST /v1/a2a/messages`
- Require agent-scoped API keys for A2A communication
- Derive the sender exclusively from the authenticated API key
- Prevent cross-tenant recipient access
- Prevent agents from messaging themselves
- Persist A2A messages through the existing event write path
- Preserve session and correlation identifiers
- Support optional message metadata
- Add comprehensive A2A tests

## Testing

- `python -m pytest core/tests/test_a2a.py -v` — 9 passed
- `python -m pytest core/tests/test_a2a.py core/tests/test_route_authz.py core/tests/test_tenant_isolation.py -v` — 24 passed
- `python -m compileall core` — passed
- `git diff --check` — passed