### PR TITLE
Restore marketing site and public API routes from zizkadb-cloud

### DIFF
--- a/.cursor/rules/enterprise-page-knowledge-base.mdc
+++ b/.cursor/rules/enterprise-page-knowledge-base.mdc
@@ -1,0 +1,47 @@
+---
+description: Enterprise marketing page — copy guardrails, lead capture, QA, and cross-links
+globs: dashboard/app/enterprise/**,dashboard/components/marketing/enterprise/**,dashboard/components/marketing/MarketingFooter.tsx,dashboard/components/marketing/MarketingPageStyles.tsx,dashboard/components/SiteNav.tsx,dashboard/lib/demo.ts,core/api/demo_requests.py,core/db/migrations/007_demo_requests_enterprise.sql,docs/enterprise-page-qa.md,docs/enterprise-product-overview.md
+alwaysApply: false
+---
+
+# Enterprise Page — Agent Guide
+
+**Route:** `/enterprise` · **QA checklist:** `docs/enterprise-page-qa.md` · **Product overview:** `docs/enterprise-product-overview.md` · **Dashboard KB:** §20.6 · **Copy source:** `dashboard/components/marketing/enterprise/enterprise-copy.ts`
+
+## Page composition (order)
+
+Live route (`app/enterprise/page.tsx`): Hero → What is → Fleet → Capabilities → Why enterprises choose → Security → Deployment → Pricing → FAQ → Contact form (`#contact`) → Technical resources → footer. This is a single monolithic client component — there is no componentized alternative build; a previously-unused modular shell (`EnterprisePageClient` + 9 section components) was confirmed dead (zero live referrers) and deleted 2026-07-08. Do not resurrect those files from history as a starting point — if a componentized rebuild is wanted later, start fresh against the copy/QA rules below, since the live page has since diverged from what that shell had.
+
+Shared shell: `SiteNav active="enterprise"`, `MarketingPageStyles`, `CalendlyBookModal`.
+
+## Lead capture
+
+- Form: `EnterpriseConnectForm` → `submitDemoRequest` (`lib/demo.ts`) → `POST /v1/demo-requests`
+- Always sends `source: 'enterprise'`; optional `position` (role/title)
+- Honeypot field name: **`botcheck`** (not `website`); client silently drops if filled
+- Backend allowlist: `enterprise`, `landing`, `newsletter` — else **422**
+- Admin demo tab shows Role + Source; search includes both
+- DB: nullable `position VARCHAR(120)`, `source VARCHAR(64)` — migration `007_demo_requests_enterprise.sql` + runtime DDL in `connection.py`
+
+## Copy guardrails (must NOT claim on `/enterprise`)
+
+SOC 2, HIPAA, SSO/SAML/SCIM **as shipped**, Slack/PagerDuty alerts, SLA guarantees, hallucination **detection** (negation OK).
+
+**Must stay honest:** behavioral drift (not hallucination detection), VPC deployment (Model A), commercial license, install package, fleet UI + audit export **in customer VPC** (not on public cloud today). SSO/SAML only as **roadmap** footnote in platform section.
+
+## Cross-page consistency
+
+- Trust `#deployment`, `#limits`, `#licensing`: Enterprise row + links to `/enterprise`
+- Landing `#pricing`: fourth **Enterprise** card (`Annual License` / `1 Year`, Let's Connect → `/enterprise#contact`); config in `pricing-plans.ts`
+- `MarketingFooter` includes Enterprise on landing, trust, enterprise (docs/community when wired)
+
+## Before merge
+
+```bash
+cd dashboard && npm run lint && npm run build
+cd ../core && pytest tests/test_demo_requests.py tests/test_rate_limiting.py::TestDemoRequestsRateLimiting -q
+rg -i 'SOC 2|HIPAA|SAML|SCIM|PagerDuty|Slack alert|SLA guarantee|detects hallucination' \
+  dashboard/components/marketing/enterprise dashboard/app/enterprise
+```
+
+Update `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` §20.6, `wiki/REST-API.md`, and `backend-dashboard-contract.mdc` if demo-requests contract changes.

--- a/core/api/community.py
+++ b/core/api/community.py
@@ -1,0 +1,286 @@
+"""
+Public community board — posts, replies, image uploads. No login required.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import uuid
+from pathlib import Path
+
+from fastapi import APIRouter, File, Query, Request, UploadFile
+from services.exceptions import bad_request, not_found
+from fastapi.responses import FileResponse
+from pydantic import BaseModel, Field
+
+from api.utils import client_ip
+from db.connection import get_pool
+from services.rate_limiter import RateLimiter, RedisStorage, SlidingWindowStrategy
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+UPLOAD_DIR = Path(os.getenv("COMMUNITY_UPLOAD_DIR", "/data/community_uploads"))
+MAX_UPLOAD_BYTES = 3 * 1024 * 1024
+ALLOWED_EXT = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
+CATEGORIES = {"question", "experience", "showcase"}
+
+
+RATE_WINDOW_SEC = 3600
+RATE_MAX_POSTS = 10
+
+community_limiter = RateLimiter(
+    limit=RATE_MAX_POSTS,
+    window_sec=RATE_WINDOW_SEC,
+    storage=RedisStorage(key_prefix="ratelimit:community"),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many posts. Try again later."
+)
+
+
+class CreatePostBody(BaseModel):
+    author_name: str = Field(min_length=1, max_length=120)
+    author_email: str | None = Field(default=None, max_length=255)
+    category: str = "question"
+    title: str = Field(min_length=3, max_length=300)
+    body: str = Field(min_length=10, max_length=12000)
+    image_urls: list[str] = Field(default_factory=list)
+    website: str | None = None  # honeypot — must be empty
+
+
+class CreateReplyBody(BaseModel):
+    author_name: str = Field(min_length=1, max_length=120)
+    author_email: str | None = Field(default=None, max_length=255)
+    body: str = Field(min_length=2, max_length=8000)
+    website: str | None = None
+
+
+
+def _public_base_url(request: Request) -> str:
+    env = os.getenv("PUBLIC_API_URL", "").rstrip("/")
+    if env:
+        return env
+    scheme = request.headers.get("x-forwarded-proto", request.url.scheme)
+    host = request.headers.get("host", "db.zizka.ai")
+    return f"{scheme}://{host}"
+
+
+@router.get("/posts")
+async def list_posts(
+    request: Request,
+    category: str | None = None,
+    limit: int = Query(default=40, ge=1, le=100),
+):
+    pool = get_pool()
+    params: list[object] = []
+    where = ""
+    if category and category in CATEGORIES:
+        where = "WHERE category = $1"
+        params.append(category)
+
+    rows = await pool.fetch(
+        f"""
+        SELECT post_id, author_name, category, title,
+               LEFT(body, 280) AS excerpt,
+               image_urls, reply_count, created_at
+        FROM community_posts
+        {where}
+        ORDER BY created_at DESC
+        LIMIT {limit}
+        """,
+        *params,
+    )
+    base = _public_base_url(request)
+    return [
+        {
+            "id":           str(r["post_id"]),
+            "author_name":  r["author_name"],
+            "category":     r["category"],
+            "title":        r["title"],
+            "excerpt":      r["excerpt"],
+            "image_urls":   _normalize_image_urls(r["image_urls"], base),
+            "reply_count":  r["reply_count"],
+            "created_at":   r["created_at"].isoformat(),
+        }
+        for r in rows
+    ]
+
+
+@router.get("/posts/{post_id}")
+async def get_post(post_id: str, request: Request):
+    pool = get_pool()
+    try:
+        pid = uuid.UUID(post_id)
+    except ValueError:
+        raise not_found("Post not found")
+
+    post = await pool.fetchrow(
+        """
+        SELECT post_id, author_name, author_email, category, title, body,
+               image_urls, reply_count, created_at
+        FROM community_posts WHERE post_id = $1
+        """,
+        pid,
+    )
+    if not post:
+        raise not_found("Post not found")
+
+    replies = await pool.fetch(
+        """
+        SELECT reply_id, author_name, body, created_at
+        FROM community_replies
+        WHERE post_id = $1
+        ORDER BY created_at ASC
+        """,
+        pid,
+    )
+    base = _public_base_url(request)
+    return {
+        "id":           str(post["post_id"]),
+        "author_name":  post["author_name"],
+        "category":     post["category"],
+        "title":        post["title"],
+        "body":         post["body"],
+        "image_urls":   _normalize_image_urls(post["image_urls"], base),
+        "reply_count":  post["reply_count"],
+        "created_at":   post["created_at"].isoformat(),
+        "replies": [
+            {
+                "id":          str(r["reply_id"]),
+                "author_name": r["author_name"],
+                "body":        r["body"],
+                "created_at":  r["created_at"].isoformat(),
+            }
+            for r in replies
+        ],
+    }
+
+
+@router.post("/posts", status_code=201)
+async def create_post(body: CreatePostBody, request: Request):
+    if body.website:
+        raise bad_request("Invalid submission")
+    if body.category not in CATEGORIES:
+        raise bad_request("Invalid category")
+    await community_limiter.check(client_ip(request))
+    pool = get_pool()
+    urls = [u for u in body.image_urls if isinstance(u, str) and u.startswith("/v1/community/media/")][:6]
+
+    row = await pool.fetchrow(
+        """
+        INSERT INTO community_posts (
+            author_name, author_email, category, title, body, image_urls
+        )
+        VALUES ($1, $2, $3, $4, $5, $6::jsonb)
+        RETURNING post_id, created_at
+        """,
+        body.author_name.strip(),
+        body.author_email.lower().strip() if body.author_email else None,
+        body.category,
+        body.title.strip(),
+        body.body.strip(),
+        json.dumps(urls),
+    )
+    return {"id": str(row["post_id"]), "created_at": row["created_at"].isoformat()}
+
+
+@router.post("/posts/{post_id}/replies", status_code=201)
+async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
+    if body.website:
+        raise bad_request("Invalid submission")
+    await community_limiter.check(client_ip(request))
+    pool = get_pool()
+    try:
+        pid = uuid.UUID(post_id)
+    except ValueError:
+        raise not_found("Post not found")
+
+    exists = await pool.fetchval(
+        "SELECT 1 FROM community_posts WHERE post_id = $1", pid,
+    )
+    if not exists:
+        raise not_found("Post not found")
+
+    row = await pool.fetchrow(
+        """
+        INSERT INTO community_replies (post_id, author_name, author_email, body)
+        VALUES ($1, $2, $3, $4)
+        RETURNING reply_id, created_at
+        """,
+        pid,
+        body.author_name.strip(),
+        body.author_email.lower().strip() if body.author_email else None,
+        body.body.strip(),
+    )
+    await pool.execute(
+        """
+        UPDATE community_posts
+        SET reply_count = reply_count + 1, updated_at = NOW()
+        WHERE post_id = $1
+        """,
+        pid,
+    )
+    return {"id": str(row["reply_id"]), "created_at": row["created_at"].isoformat()}
+
+
+@router.post("/upload")
+async def upload_image(request: Request, file: UploadFile = File(...)):
+    await community_limiter.check(client_ip(request) + ":upload")
+
+    if not file.filename:
+        raise bad_request("No file")
+
+    ext = Path(file.filename).suffix.lower()
+    if ext not in ALLOWED_EXT:
+        raise bad_request("Use PNG, JPG, WEBP, or GIF")
+
+    data = await file.read()
+    if len(data) > MAX_UPLOAD_BYTES:
+        raise bad_request("Image must be under 3MB")
+
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+    name = f"{uuid.uuid4().hex}{ext}"
+    path = UPLOAD_DIR / name
+    path.write_bytes(data)
+
+    return {"url": f"/v1/community/media/{name}"}
+
+
+@router.get("/media/{filename}")
+async def serve_media(filename: str):
+    safe = re.sub(r"[^a-zA-Z0-9._-]", "", filename)
+    if not safe or safe != filename:
+        raise not_found("Not found")
+    path = UPLOAD_DIR / safe
+    if not path.is_file():
+        raise not_found("Not found")
+    media = {
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".webp": "image/webp",
+        ".gif": "image/gif",
+    }
+    return FileResponse(path, media_type=media.get(path.suffix.lower(), "application/octet-stream"))
+
+
+def _normalize_image_urls(raw, base: str) -> list[str]:
+    if isinstance(raw, str):
+        try:
+            raw = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+    if not isinstance(raw, list):
+        return []
+    out = []
+    for u in raw:
+        if not isinstance(u, str):
+            continue
+        if u.startswith("http"):
+            out.append(u)
+        elif u.startswith("/"):
+            out.append(f"{base}{u}")
+    return out

--- a/core/api/demo_requests.py
+++ b/core/api/demo_requests.py
@@ -1,0 +1,79 @@
+"""
+Public demo request form — landing page "Book demo" submissions.
+"""
+
+from __future__ import annotations
+
+import logging
+from fastapi import APIRouter, Request, status
+from services.exceptions import make_exception, bad_request
+from pydantic import BaseModel, EmailStr, Field
+
+from api.utils import client_ip
+from db.connection import get_pool
+from services.rate_limiter import RateLimiter, RedisStorage, SlidingWindowStrategy
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+
+RATE_WINDOW_SEC = 3600
+RATE_MAX = 8
+VALID_SOURCES = frozenset({"enterprise", "landing", "newsletter"})
+
+demo_limiter = RateLimiter(
+    limit=RATE_MAX,
+    window_sec=RATE_WINDOW_SEC,
+    storage=RedisStorage(key_prefix="ratelimit:demo-requests"),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many requests. Try again later."
+)
+
+
+class CreateDemoRequestBody(BaseModel):
+    first_name: str = Field(min_length=1, max_length=80)
+    last_name: str = Field(min_length=1, max_length=80)
+    email: EmailStr
+    company_name: str = Field(min_length=1, max_length=255)
+    website: str = Field(min_length=1, max_length=500)
+    position: str | None = Field(default=None, max_length=120)
+    source: str | None = Field(default=None, max_length=64)
+    botcheck: str | None = None  # honeypot — must be empty
+
+
+
+
+
+@router.post("", status_code=201)
+async def create_demo_request(body: CreateDemoRequestBody, request: Request):
+    if body.botcheck:
+        raise bad_request("Invalid submission")
+
+    ip = client_ip(request)
+    await demo_limiter.check(ip)
+
+    source = (body.source.strip() or None) if body.source else None
+    if source and source not in VALID_SOURCES:
+        raise make_exception(status.HTTP_422_UNPROCESSABLE_ENTITY, "Invalid source")
+
+    pool = get_pool()
+    row = await pool.fetchrow(
+        """
+        INSERT INTO demo_requests (first_name, last_name, email, company_name, website, position, source, ip_address)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+        RETURNING request_id, created_at
+        """,
+        body.first_name.strip(),
+        body.last_name.strip(),
+        str(body.email).strip().lower(),
+        body.company_name.strip(),
+        body.website.strip(),
+        (body.position.strip() or None) if body.position else None,
+        source,
+        ip,
+    )
+    log.info("demo request from %s (%s %s)", ip, body.first_name, body.company_name)
+    return {
+        "id": str(row["request_id"]),
+        "created_at": row["created_at"].isoformat(),
+    }

--- a/core/api/marketing_subscriptions.py
+++ b/core/api/marketing_subscriptions.py
@@ -1,0 +1,79 @@
+"""
+Public marketing subscription endpoint (popup lead capture).
+
+- Must not gate access: banner/popup are UX-only; this endpoint is optional.
+- Stores emails for the admin panel under "Marketing Material Subscriptions".
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, EmailStr, Field
+
+from api.utils import client_ip
+from db.connection import get_pool
+from services.email_suppress import is_suppressed
+from services.rate_limiter import RateLimiter, RedisStorage, SlidingWindowStrategy
+
+router = APIRouter()
+log = logging.getLogger(__name__)
+
+RATE_WINDOW_SEC = 3600
+RATE_MAX = 20
+
+subscribe_limiter = RateLimiter(
+    limit=RATE_MAX,
+    window_sec=RATE_WINDOW_SEC,
+    storage=RedisStorage(key_prefix="ratelimit:marketing-subscribe"),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many requests. Try again later.",
+)
+
+
+class SubscribeBody(BaseModel):
+    email: EmailStr
+    source: str = Field(default="popup", max_length=64)
+    botcheck: str | None = None  # honeypot
+
+
+
+
+@router.post("", status_code=201)
+async def subscribe(body: SubscribeBody, request: Request):
+    if body.botcheck:
+        raise HTTPException(status_code=400, detail="Invalid submission")
+
+    ip = client_ip(request)
+    await subscribe_limiter.check(ip)
+
+    pool = get_pool()
+    email = str(body.email).strip().lower()
+    if await is_suppressed(pool, email):
+        # Soft success — do not re-add unsubscribed addresses
+        return {"ok": True, "suppressed": True}
+
+    source = (body.source.strip() or "popup")[:64]
+    ua = (request.headers.get("user-agent") or "")[:2000]
+
+    # Upsert on lower(email) via unique index; do not error on re-subscribe.
+    await pool.execute(
+        """
+        INSERT INTO marketing_subscriptions (email, source, ip_address, user_agent)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT (LOWER(email)) DO UPDATE
+          SET source = EXCLUDED.source,
+              ip_address = EXCLUDED.ip_address,
+              user_agent = EXCLUDED.user_agent,
+              created_at = NOW()
+        """,
+        email,
+        source,
+        ip,
+        ua,
+    )
+
+    log.info("marketing subscription: %s (%s)", email, source)
+    return {"ok": True}
+

--- a/core/db/connection.py
+++ b/core/db/connection.py
@@ -208,7 +208,37 @@ async def init_db():
         ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS email VARCHAR(255) NOT NULL DEFAULT '';
     """)
 
+    await _pg_pool.execute("""
+        ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS position VARCHAR(120);
+        ALTER TABLE demo_requests ADD COLUMN IF NOT EXISTS source VARCHAR(64);
+    """)
 
+    await _pg_pool.execute("""
+        CREATE TABLE IF NOT EXISTS marketing_subscriptions (
+            subscription_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            email           VARCHAR(255) NOT NULL,
+            source          VARCHAR(64)  NOT NULL DEFAULT 'popup',
+            ip_address      VARCHAR(64),
+            user_agent      TEXT,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_marketing_subscriptions_created
+            ON marketing_subscriptions (created_at DESC);
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_marketing_subscriptions_email
+            ON marketing_subscriptions (LOWER(email));
+    """)
+
+    await _pg_pool.execute("""
+        CREATE TABLE IF NOT EXISTS email_suppressions (
+            suppression_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            email          VARCHAR(255) NOT NULL,
+            reason         VARCHAR(200) NOT NULL DEFAULT 'unsubscribed',
+            source         VARCHAR(64)  NOT NULL DEFAULT 'unsubscribe_link',
+            created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_email_suppressions_email
+            ON email_suppressions (LOWER(email));
+    """)
 
     _redis = redis.from_url(os.getenv("REDIS_URL", "redis://localhost:6379"))
     logger.info("Redis connected")

--- a/core/db/connection.py
+++ b/core/db/connection.py
@@ -121,6 +121,34 @@ async def init_db():
 
     """)
 
+    # Upgrade legacy community board schema (pre-marketing-restore installs used
+    # image_url/author_ip columns; the restored API expects image_urls JSONB).
+    await _pg_pool.execute("""
+        ALTER TABLE community_posts ADD COLUMN IF NOT EXISTS author_email VARCHAR(255);
+        ALTER TABLE community_posts ADD COLUMN IF NOT EXISTS image_urls JSONB NOT NULL DEFAULT '[]'::jsonb;
+        ALTER TABLE community_posts ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+        ALTER TABLE community_replies ADD COLUMN IF NOT EXISTS author_email VARCHAR(255);
+    """)
+    await _pg_pool.execute("""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'community_posts'
+                  AND column_name = 'image_url'
+            ) THEN
+                UPDATE community_posts
+                SET image_urls = CASE
+                    WHEN image_url IS NOT NULL AND image_url <> ''
+                    THEN jsonb_build_array(image_url)
+                    ELSE '[]'::jsonb
+                END
+                WHERE image_urls IS NULL OR image_urls = '[]'::jsonb;
+            END IF;
+        END $$;
+    """)
+
     await _pg_pool.execute("""
         ALTER TABLE tenants
         ADD COLUMN IF NOT EXISTS embedding_provider VARCHAR(32)

--- a/core/main.py
+++ b/core/main.py
@@ -17,6 +17,9 @@ from api.telemetry import router as telemetry_router
 from api.billing_checkout import router as billing_checkout_router
 from api.settings import router as settings_router
 from api.account import router as account_router
+from api.demo_requests import router as demo_requests_router
+from api.community import router as community_router
+from api.marketing_subscriptions import router as marketing_subscriptions_router
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -110,6 +113,9 @@ app.include_router(telemetry_router, prefix="/v1/telemetry", tags=["telemetry"])
 app.include_router(billing_checkout_router, prefix="/v1/billing", tags=["billing"])
 app.include_router(settings_router,  prefix="/v1/settings",  tags=["settings"])
 app.include_router(account_router,   prefix="/v1/account",   tags=["account"])
+app.include_router(demo_requests_router, prefix="/v1/demo-requests", tags=["demo"])
+app.include_router(community_router, prefix="/v1/community", tags=["community"])
+app.include_router(marketing_subscriptions_router, prefix="/v1/marketing-subscriptions", tags=["marketing"])
 
 
 @app.get("/health")

--- a/core/services/email_suppress.py
+++ b/core/services/email_suppress.py
@@ -1,0 +1,252 @@
+"""
+Email mailing-list suppression (unsubscribe / admin remove).
+
+Removes the address from marketing lists, outreach contacts, and developer leads,
+and blocks future outreach/marketing until cleared by an admin.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import logging
+import os
+import uuid
+from typing import Optional
+from urllib.parse import urlencode
+
+log = logging.getLogger(__name__)
+
+
+def _unsub_secret() -> str:
+    return (
+        os.getenv("UNSUBSCRIBE_SECRET")
+        or os.getenv("JWT_SECRET")
+        or "dev-secret"
+    ).strip()
+
+
+def normalize_email(email: str) -> str:
+    return (email or "").strip().lower()
+
+
+def unsubscribe_token(email: str) -> str:
+    email_n = normalize_email(email)
+    digest = hmac.new(
+        _unsub_secret().encode("utf-8"),
+        email_n.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()[:32]
+    return digest
+
+
+def verify_unsubscribe_token(email: str, token: str) -> bool:
+    if not email or not token:
+        return False
+    expected = unsubscribe_token(email)
+    return hmac.compare_digest(expected, (token or "").strip())
+
+
+def build_unsubscribe_url(email: str, *, api_base: Optional[str] = None) -> str:
+    base = (api_base or os.getenv("PUBLIC_API_URL", "http://localhost:8000")).rstrip("/")
+    qs = urlencode({"email": normalize_email(email), "token": unsubscribe_token(email)})
+    return f"{base}/v1/outreach/unsubscribe?{qs}"
+
+
+async def is_suppressed(pool, email: str) -> bool:
+    email_n = normalize_email(email)
+    if not email_n:
+        return False
+    row = await pool.fetchval(
+        "SELECT 1 FROM email_suppressions WHERE LOWER(email) = $1 LIMIT 1",
+        email_n,
+    )
+    return bool(row)
+
+
+async def lookup_mailing_presence(pool, email: str) -> dict:
+    """Where this email appears across mailing-related tables."""
+    email_n = normalize_email(email)
+    marketing = await pool.fetch(
+        """
+        SELECT subscription_id, email, source, created_at
+        FROM marketing_subscriptions WHERE LOWER(email) = $1
+        """,
+        email_n,
+    )
+    contacts = await pool.fetch(
+        """
+        SELECT contact_id, email, name, status, imported_at
+        FROM outreach_contacts WHERE LOWER(email) = $1
+        """,
+        email_n,
+    )
+    leads = await pool.fetch(
+        """
+        SELECT lead_id, email, name, status, created_at
+        FROM developer_leads WHERE LOWER(email) = $1
+        """,
+        email_n,
+    )
+    sends = await pool.fetch(
+        """
+        SELECT send_id, to_email, subject, status, sent_at, created_at
+        FROM email_outreach_sends
+        WHERE LOWER(to_email) = $1
+        ORDER BY created_at DESC
+        LIMIT 20
+        """,
+        email_n,
+    )
+    suppressed = await pool.fetchrow(
+        """
+        SELECT email, reason, source, created_at
+        FROM email_suppressions WHERE LOWER(email) = $1
+        """,
+        email_n,
+    )
+    users = await pool.fetch(
+        """
+        SELECT user_id, email, marketing_consent, marketing_consent_at
+        FROM users WHERE LOWER(email) = $1
+        """,
+        email_n,
+    )
+    return {
+        "email": email_n,
+        "suppressed": bool(suppressed),
+        "suppression": (
+            {
+                "email": suppressed["email"],
+                "reason": suppressed["reason"],
+                "source": suppressed["source"],
+                "created_at": suppressed["created_at"].isoformat()
+                if suppressed["created_at"]
+                else None,
+            }
+            if suppressed
+            else None
+        ),
+        "marketing_subscriptions": [
+            {
+                "subscription_id": str(r["subscription_id"]),
+                "email": r["email"],
+                "source": r["source"],
+                "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+            }
+            for r in marketing
+        ],
+        "outreach_contacts": [
+            {
+                "contact_id": str(r["contact_id"]),
+                "email": r["email"],
+                "name": r["name"],
+                "status": r["status"],
+                "imported_at": r["imported_at"].isoformat() if r["imported_at"] else None,
+            }
+            for r in contacts
+        ],
+        "developer_leads": [
+            {
+                "lead_id": str(r["lead_id"]),
+                "email": r["email"],
+                "name": r["name"],
+                "status": r["status"],
+                "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+            }
+            for r in leads
+        ],
+        "outreach_sends": [
+            {
+                "send_id": str(r["send_id"]),
+                "to_email": r["to_email"],
+                "subject": r["subject"],
+                "status": r["status"],
+                "sent_at": r["sent_at"].isoformat() if r["sent_at"] else None,
+                "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+            }
+            for r in sends
+        ],
+        "users": [
+            {
+                "user_id": str(r["user_id"]),
+                "email": r["email"],
+                "marketing_consent": bool(r["marketing_consent"]),
+                "marketing_consent_at": r["marketing_consent_at"].isoformat()
+                if r["marketing_consent_at"]
+                else None,
+            }
+            for r in users
+        ],
+    }
+
+
+async def remove_from_all_mailing_lists(
+    pool,
+    email: str,
+    *,
+    reason: str = "unsubscribed",
+    source: str = "unsubscribe_link",
+) -> dict:
+    """
+    Suppress email and remove from marketing / outreach contacts / developer leads.
+    Does not delete paid user accounts; clears marketing_consent when present.
+    Outreach send history is kept for audit but future sends are blocked.
+    """
+    email_n = normalize_email(email)
+    if not email_n or "@" not in email_n:
+        raise ValueError("Invalid email")
+
+    deleted = {
+        "marketing_subscriptions": 0,
+        "outreach_contacts": 0,
+        "developer_leads": 0,
+        "users_marketing_cleared": 0,
+    }
+
+    r = await pool.execute(
+        "DELETE FROM marketing_subscriptions WHERE LOWER(email) = $1",
+        email_n,
+    )
+    deleted["marketing_subscriptions"] = int(str(r).split()[-1]) if r else 0
+
+    r = await pool.execute(
+        "DELETE FROM outreach_contacts WHERE LOWER(email) = $1",
+        email_n,
+    )
+    deleted["outreach_contacts"] = int(str(r).split()[-1]) if r else 0
+
+    r = await pool.execute(
+        "DELETE FROM developer_leads WHERE LOWER(email) = $1",
+        email_n,
+    )
+    deleted["developer_leads"] = int(str(r).split()[-1]) if r else 0
+
+    r = await pool.execute(
+        """
+        UPDATE users
+        SET marketing_consent = FALSE,
+            marketing_consent_at = NULL
+        WHERE LOWER(email) = $1 AND COALESCE(marketing_consent, FALSE) = TRUE
+        """,
+        email_n,
+    )
+    deleted["users_marketing_cleared"] = int(str(r).split()[-1]) if r else 0
+
+    await pool.execute(
+        """
+        INSERT INTO email_suppressions (suppression_id, email, reason, source)
+        VALUES ($1, $2, $3, $4)
+        ON CONFLICT ((LOWER(email))) DO UPDATE
+        SET reason = EXCLUDED.reason,
+            source = EXCLUDED.source,
+            created_at = NOW()
+        """,
+        uuid.uuid4(),
+        email_n,
+        (reason or "unsubscribed")[:200],
+        (source or "unsubscribe_link")[:64],
+    )
+
+    log.info("email suppressed email=%s source=%s deleted=%s", email_n, source, deleted)
+    return {"email": email_n, "suppressed": True, "removed": deleted}

--- a/core/tests/test_demo_requests.py
+++ b/core/tests/test_demo_requests.py
@@ -1,0 +1,156 @@
+"""
+Unit tests for POST /v1/demo-requests — source validation, position, honeypot.
+Rate limiting is covered in test_rate_limiting.py.
+"""
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from api.demo_requests import demo_limiter
+from main import app
+from services.rate_limiter import InMemoryStorage
+
+client = TestClient(app)
+
+VALID_PAYLOAD = {
+    "first_name": "Ada",
+    "last_name": "Lovelace",
+    "email": "ada@example.com",
+    "company_name": "Analytical Engines Ltd",
+    "website": "https://example.com",
+    "botcheck": "",
+}
+
+
+def _mock_pool_row():
+    mock_pool = MagicMock()
+    mock_row = {
+        "request_id": "11111111-1111-1111-1111-111111111111",
+        "created_at": datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc),
+    }
+    mock_pool.fetchrow = AsyncMock(return_value=mock_row)
+    return mock_pool
+
+
+class TestDemoRequests:
+    def setup_method(self):
+        demo_limiter.storage = InMemoryStorage()
+        asyncio.run(demo_limiter.storage.clear())
+
+    @patch("api.demo_requests.get_pool")
+    def test_create_minimal_fields(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        response = client.post("/v1/demo-requests", json=VALID_PAYLOAD)
+        assert response.status_code == 201
+        body = response.json()
+        assert "id" in body
+        assert "created_at" in body
+
+    @patch("api.demo_requests.get_pool")
+    def test_create_with_enterprise_source_and_position(self, mock_get_pool):
+        mock_pool = _mock_pool_row()
+        mock_get_pool.return_value = mock_pool
+        response = client.post(
+            "/v1/demo-requests",
+            json={
+                **VALID_PAYLOAD,
+                "source": "enterprise",
+                "position": "Head of Platform",
+            },
+        )
+        assert response.status_code == 201
+        call_args = mock_pool.fetchrow.call_args[0]
+        # position is 6th positional arg ($6), source is 7th ($7)
+        assert call_args[6] == "Head of Platform"
+        assert call_args[7] == "enterprise"
+
+    @patch("api.demo_requests.get_pool")
+    def test_valid_sources_accepted(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        for source in ("enterprise", "landing", "newsletter"):
+            asyncio.run(demo_limiter.storage.clear())
+            response = client.post(
+                "/v1/demo-requests",
+                json={**VALID_PAYLOAD, "source": source},
+            )
+            assert response.status_code == 201, source
+
+    @patch("api.demo_requests.get_pool")
+    def test_invalid_source_rejected(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        response = client.post(
+            "/v1/demo-requests",
+            json={**VALID_PAYLOAD, "source": "spam"},
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"] == "Invalid source"
+
+    @patch("api.demo_requests.get_pool")
+    def test_empty_source_treated_as_null(self, mock_get_pool):
+        mock_pool = _mock_pool_row()
+        mock_get_pool.return_value = mock_pool
+        response = client.post(
+            "/v1/demo-requests",
+            json={**VALID_PAYLOAD, "source": "   "},
+        )
+        assert response.status_code == 201
+        call_args = mock_pool.fetchrow.call_args[0]
+        assert call_args[7] is None
+
+    @patch("api.demo_requests.get_pool")
+    def test_honeypot_rejected(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        response = client.post(
+            "/v1/demo-requests",
+            json={**VALID_PAYLOAD, "botcheck": "bot"},
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"] == "Invalid submission"
+
+    @patch("api.demo_requests.get_pool")
+    def test_whitespace_trimmed(self, mock_get_pool):
+        mock_pool = _mock_pool_row()
+        mock_get_pool.return_value = mock_pool
+        response = client.post(
+            "/v1/demo-requests",
+            json={
+                **VALID_PAYLOAD,
+                "first_name": "  Ada  ",
+                "last_name": "  Lovelace  ",
+                "email": "  Ada@Example.COM  ",
+                "company_name": "  Analytical Engines  ",
+                "website": "  https://example.com  ",
+                "position": "  CTO  ",
+                "source": "enterprise",
+            },
+        )
+        assert response.status_code == 201
+        args = mock_pool.fetchrow.call_args[0]
+        assert args[1] == "Ada"
+        assert args[2] == "Lovelace"
+        assert args[3] == "ada@example.com"
+        assert args[4] == "Analytical Engines"
+        assert args[5] == "https://example.com"
+        assert args[6] == "CTO"
+        assert args[7] == "enterprise"
+
+    @patch("api.demo_requests.get_pool")
+    def test_optional_position_omitted(self, mock_get_pool):
+        mock_pool = _mock_pool_row()
+        mock_get_pool.return_value = mock_pool
+        response = client.post("/v1/demo-requests", json=VALID_PAYLOAD)
+        assert response.status_code == 201
+        args = mock_pool.fetchrow.call_args[0]
+        assert args[6] is None
+        assert args[7] is None
+
+    @patch("api.demo_requests.get_pool")
+    def test_missing_required_field_rejected(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        payload = {**VALID_PAYLOAD}
+        del payload["company_name"]
+        response = client.post("/v1/demo-requests", json=payload)
+        assert response.status_code == 422

--- a/dashboard/.dockerignore
+++ b/dashboard/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+.git
+*.md
+.env*
+coverage
+.turbo

--- a/dashboard/app/community/[id]/page.tsx
+++ b/dashboard/app/community/[id]/page.tsx
@@ -1,0 +1,150 @@
+'use client'
+
+import Link from 'next/link'
+import { SiteNav } from '@/components/SiteNav'
+import { useParams } from 'next/navigation'
+import { useCallback, useEffect, useState } from 'react'
+import { formatDistanceToNow } from 'date-fns'
+import {
+  getCommunityPost,
+  createCommunityReply,
+  mediaUrl,
+  type CommunityPostDetail,
+} from '@/lib/community'
+
+export default function CommunityPostPage() {
+  const params = useParams()
+  const id = params.id as string
+  const [post, setPost] = useState<CommunityPostDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState('')
+  const [authorName, setAuthorName] = useState('')
+  const [replyBody, setReplyBody] = useState('')
+  const [website, setWebsite] = useState('')
+  const [submitting, setSubmitting] = useState(false)
+
+  const load = useCallback(() => {
+    setLoading(true)
+    getCommunityPost(id)
+      .then(setPost)
+      .catch((e) => setErr(e instanceof Error ? e.message : 'Not found'))
+      .finally(() => setLoading(false))
+  }, [id])
+
+  useEffect(() => { load() }, [load])
+
+  async function submitReply(e: React.FormEvent) {
+    e.preventDefault()
+    if (website || !post) return
+    setSubmitting(true)
+    setErr('')
+    try {
+      await createCommunityReply(id, { author_name: authorName, body: replyBody })
+      setReplyBody('')
+      load()
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to reply')
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div style={{ fontFamily: 'Inter, system-ui, sans-serif', color: '#111', background: '#fafafa', minHeight: '100vh' }}>
+      <SiteNav active="community" />
+
+      <main style={{ maxWidth: 720, margin: '0 auto', padding: '28px 20px 80px' }}>
+        <Link href="/community" style={{ fontSize: 13, color: '#888', textDecoration: 'none' }}>← Back to community</Link>
+
+        {loading && <p style={{ marginTop: 24, color: '#888' }}>Loading…</p>}
+        {err && !loading && <p style={{ marginTop: 24, color: '#ef4444' }}>{err}</p>}
+
+        {post && (
+          <>
+            <article style={{ background: '#fff', border: '1px solid #e5e5e5', borderRadius: 12, padding: 24, marginTop: 20 }}>
+              <div style={{ fontSize: 12, color: '#888', marginBottom: 10 }}>
+                <span style={{ fontWeight: 600, textTransform: 'uppercase', color: '#f97316' }}>{post.category}</span>
+                {' · '}{post.author_name}
+                {' · '}{formatDistanceToNow(new Date(post.created_at), { addSuffix: true })}
+              </div>
+              <h1 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 16px', lineHeight: 1.3 }}>{post.title}</h1>
+              <p style={{ fontSize: 15, lineHeight: 1.7, color: '#333', margin: 0, whiteSpace: 'pre-wrap' }}>{post.body}</p>
+              {post.image_urls.length > 0 && (
+                <div style={{ display: 'flex', flexDirection: 'column', gap: 12, marginTop: 20 }}>
+                  {post.image_urls.map((url) => (
+                    // eslint-disable-next-line @next/next/no-img-element
+                    <img
+                      key={url}
+                      src={mediaUrl(url)}
+                      alt=""
+                      style={{ maxWidth: '100%', borderRadius: 10, border: '1px solid #eee' }}
+                    />
+                  ))}
+                </div>
+              )}
+            </article>
+
+            <section style={{ marginTop: 28 }}>
+              <h2 style={{ fontSize: 16, fontWeight: 600, marginBottom: 16 }}>
+                {post.replies.length} {post.replies.length === 1 ? 'Reply' : 'Replies'}
+              </h2>
+
+              {post.replies.map((r) => (
+                <div
+                  key={r.id}
+                  style={{
+                    background: '#fff', border: '1px solid #e5e5e5', borderRadius: 10,
+                    padding: '14px 16px', marginBottom: 10,
+                  }}
+                >
+                  <div style={{ fontSize: 12, color: '#888', marginBottom: 6 }}>
+                    <strong style={{ color: '#111' }}>{r.author_name}</strong>
+                    {' · '}{formatDistanceToNow(new Date(r.created_at), { addSuffix: true })}
+                  </div>
+                  <p style={{ fontSize: 14, lineHeight: 1.6, margin: 0, whiteSpace: 'pre-wrap' }}>{r.body}</p>
+                </div>
+              ))}
+
+              <form onSubmit={submitReply} style={{ background: '#fff', border: '1px solid #e5e5e5', borderRadius: 12, padding: 18, marginTop: 16 }}>
+                <input type="text" name="website" value={website} onChange={(e) => setWebsite(e.target.value)} style={{ display: 'none' }} tabIndex={-1} autoComplete="off" />
+                <h3 style={{ fontSize: 14, fontWeight: 600, margin: '0 0 12px' }}>Add a reply</h3>
+                <input
+                  required
+                  value={authorName}
+                  onChange={(e) => setAuthorName(e.target.value)}
+                  placeholder="Your name"
+                  style={{
+                    width: '100%', boxSizing: 'border-box', padding: '10px 12px', marginBottom: 10,
+                    border: '1px solid #ddd', borderRadius: 8, fontSize: 14,
+                  }}
+                />
+                <textarea
+                  required
+                  value={replyBody}
+                  onChange={(e) => setReplyBody(e.target.value)}
+                  placeholder="Write your answer or comment…"
+                  rows={4}
+                  style={{
+                    width: '100%', boxSizing: 'border-box', padding: '10px 12px', marginBottom: 12,
+                    border: '1px solid #ddd', borderRadius: 8, fontSize: 14, resize: 'vertical',
+                  }}
+                />
+                <button
+                  type="submit"
+                  disabled={submitting || !authorName.trim() || replyBody.length < 2}
+                  style={{
+                    padding: '10px 18px', background: '#111', color: '#fff', border: 'none',
+                    borderRadius: 8, fontSize: 14, fontWeight: 500, cursor: 'pointer',
+                    opacity: submitting ? 0.6 : 1,
+                  }}
+                >
+                  {submitting ? 'Sending…' : 'Reply'}
+                </button>
+              </form>
+            </section>
+          </>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/dashboard/app/community/page.tsx
+++ b/dashboard/app/community/page.tsx
@@ -1,0 +1,537 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { SiteNav } from "@/components/SiteNav";
+import { MarketingFooter } from "@/components/marketing/MarketingFooter";
+import { BRAND } from "@/components/brand";
+import { formatDistanceToNow } from "date-fns";
+import {
+  listCommunityPosts,
+  createCommunityPost,
+  uploadCommunityImage,
+  mediaUrl,
+  type CommunityCategory,
+  type CommunityPostListItem,
+} from "@/lib/community";
+
+const CATEGORIES: { key: CommunityCategory | "all"; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "question", label: "Questions" },
+  { key: "experience", label: "Experiences" },
+  { key: "showcase", label: "Screenshots" },
+];
+
+const CAT_COLOR: Record<CommunityCategory, string> = {
+  question: "#3b82f6",
+  experience: "#22c55e",
+  showcase: BRAND,
+};
+
+export default function CommunityPage() {
+  const [filter, setFilter] = useState<CommunityCategory | "all">("all");
+  const [posts, setPosts] = useState<CommunityPostListItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [err, setErr] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setErr("");
+    try {
+      const data = await listCommunityPosts(
+        filter === "all" ? undefined : filter,
+      );
+      setPosts(data);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Failed to load");
+    } finally {
+      setLoading(false);
+    }
+  }, [filter]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div
+      style={{
+        fontFamily: "Inter, system-ui, sans-serif",
+        color: "#111",
+        background: "#fafafa",
+        minHeight: "100vh",
+      }}
+    >
+      <style>{`
+        @media (max-width: 640px) {
+          .zdb-comm-pad { padding-left: 16px !important; padding-right: 16px !important; }
+        }
+      `}</style>
+
+      <SiteNav active="community" />
+
+      <main
+        className="zdb-comm-pad"
+        style={{ maxWidth: 760, margin: "0 auto", padding: "32px 20px 80px" }}
+      >
+        <h1
+          style={{
+            fontSize: 28,
+            fontWeight: 700,
+            margin: "0 0 8px",
+            letterSpacing: -0.5,
+          }}
+        >
+          Community
+        </h1>
+        <p
+          style={{
+            fontSize: 15,
+            color: "#555",
+            lineHeight: 1.6,
+            margin: "0 0 24px",
+          }}
+        >
+          Share experiences, post screenshots, ask questions, and help other
+          builders. No account required — just your name.
+        </p>
+
+        <button
+          type="button"
+          onClick={() => setShowForm((v) => !v)}
+          style={{
+            width: "100%",
+            padding: "12px 16px",
+            marginBottom: 20,
+            background: showForm ? "#fff" : "#111",
+            color: showForm ? "#111" : "#fff",
+            border: showForm ? "1px solid #ddd" : "none",
+            borderRadius: 10,
+            fontSize: 14,
+            fontWeight: 600,
+            cursor: "pointer",
+          }}
+        >
+          {showForm ? "Cancel" : "+ New post"}
+        </button>
+
+        {showForm && (
+          <NewPostForm
+            onPosted={(id) => {
+              setShowForm(false);
+              load();
+              window.location.href = `/community/${id}`;
+            }}
+            onError={setErr}
+          />
+        )}
+
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            flexWrap: "wrap",
+            marginBottom: 20,
+          }}
+        >
+          {CATEGORIES.map((c) => (
+            <button
+              key={c.key}
+              type="button"
+              onClick={() => setFilter(c.key)}
+              style={{
+                padding: "6px 14px",
+                borderRadius: 100,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: "pointer",
+                border: filter === c.key ? "1px solid #111" : "1px solid #ddd",
+                background: filter === c.key ? "#111" : "#fff",
+                color: filter === c.key ? "#fff" : "#555",
+              }}
+            >
+              {c.label}
+            </button>
+          ))}
+        </div>
+
+        {err && (
+          <p style={{ color: "#ef4444", fontSize: 13, marginBottom: 16 }}>
+            {err}
+          </p>
+        )}
+
+        {loading ? (
+          <p style={{ color: "#888", fontSize: 14 }}>Loading…</p>
+        ) : posts.length === 0 ? (
+          <div
+            style={{
+              background: "#fff",
+              border: "1px solid #e5e5e5",
+              borderRadius: 12,
+              padding: 32,
+              textAlign: "center",
+            }}
+          >
+            <p style={{ color: "#888", margin: 0 }}>
+              No posts yet. Be the first to share something.
+            </p>
+          </div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+            {posts.map((p) => (
+              <Link
+                key={p.id}
+                href={`/community/${p.id}`}
+                style={{
+                  display: "block",
+                  textDecoration: "none",
+                  color: "inherit",
+                  background: "#fff",
+                  border: "1px solid #e5e5e5",
+                  borderRadius: 12,
+                  padding: "18px 20px",
+                  transition: "border-color 0.15s",
+                }}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    marginBottom: 8,
+                  }}
+                >
+                  <span
+                    style={{
+                      fontSize: 11,
+                      fontWeight: 600,
+                      textTransform: "uppercase",
+                      letterSpacing: 0.5,
+                      color:
+                        CAT_COLOR[p.category as CommunityCategory] ?? "#888",
+                    }}
+                  >
+                    {p.category}
+                  </span>
+                  <span style={{ fontSize: 12, color: "#aaa" }}>
+                    {p.author_name} ·{" "}
+                    {formatDistanceToNow(new Date(p.created_at), {
+                      addSuffix: true,
+                    })}
+                  </span>
+                  {p.reply_count > 0 && (
+                    <span
+                      style={{
+                        fontSize: 12,
+                        color: "#888",
+                        marginLeft: "auto",
+                      }}
+                    >
+                      {p.reply_count}{" "}
+                      {p.reply_count === 1 ? "reply" : "replies"}
+                    </span>
+                  )}
+                </div>
+                <h2
+                  style={{ fontSize: 16, fontWeight: 600, margin: "0 0 6px" }}
+                >
+                  {p.title}
+                </h2>
+                <p
+                  style={{
+                    fontSize: 14,
+                    color: "#555",
+                    margin: 0,
+                    lineHeight: 1.5,
+                  }}
+                >
+                  {p.excerpt}
+                  {p.excerpt.length >= 280 ? "…" : ""}
+                </p>
+                {p.image_urls.length > 0 && (
+                  <div
+                    style={{
+                      display: "flex",
+                      gap: 8,
+                      marginTop: 12,
+                      flexWrap: "wrap",
+                    }}
+                  >
+                    {p.image_urls.slice(0, 3).map((url) => (
+                      // eslint-disable-next-line @next/next/no-img-element
+                      <img
+                        key={url}
+                        src={mediaUrl(url)}
+                        alt=""
+                        style={{
+                          width: 72,
+                          height: 72,
+                          objectFit: "cover",
+                          borderRadius: 8,
+                          border: "1px solid #eee",
+                        }}
+                      />
+                    ))}
+                  </div>
+                )}
+              </Link>
+            ))}
+          </div>
+        )}
+      </main>
+      <MarketingFooter />
+    </div>
+  );
+}
+
+function NewPostForm({
+  onPosted,
+  onError,
+}: {
+  onPosted: (id: string) => void;
+  onError: (msg: string) => void;
+}) {
+  const [authorName, setAuthorName] = useState("");
+  const [authorEmail, setAuthorEmail] = useState("");
+  const [category, setCategory] = useState<CommunityCategory>("question");
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [images, setImages] = useState<string[]>([]);
+  const [uploading, setUploading] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [website, setWebsite] = useState("");
+
+  async function onFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const files = e.target.files;
+    if (!files?.length) return;
+    setUploading(true);
+    onError("");
+    try {
+      const urls: string[] = [];
+      for (const file of Array.from(files).slice(0, 4)) {
+        urls.push(await uploadCommunityImage(file));
+      }
+      setImages((prev) => [...prev, ...urls].slice(0, 6));
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "Upload failed");
+    } finally {
+      setUploading(false);
+      e.target.value = "";
+    }
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    if (website) return;
+    setSubmitting(true);
+    onError("");
+    try {
+      const res = await createCommunityPost({
+        author_name: authorName,
+        author_email: authorEmail || undefined,
+        category,
+        title,
+        body,
+        image_urls: images,
+      });
+      onPosted(res.id);
+    } catch (err) {
+      onError(err instanceof Error ? err.message : "Failed to post");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const inputStyle: React.CSSProperties = {
+    width: "100%",
+    boxSizing: "border-box",
+    padding: "10px 12px",
+    border: "1px solid #ddd",
+    borderRadius: 8,
+    fontSize: 14,
+    marginBottom: 12,
+  };
+
+  return (
+    <form
+      onSubmit={submit}
+      style={{
+        background: "#fff",
+        border: "1px solid #e5e5e5",
+        borderRadius: 12,
+        padding: 20,
+        marginBottom: 24,
+      }}
+    >
+      <input
+        type="text"
+        name="website"
+        value={website}
+        onChange={(e) => setWebsite(e.target.value)}
+        style={{ display: "none" }}
+        tabIndex={-1}
+        autoComplete="off"
+      />
+
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+        <div>
+          <label style={{ fontSize: 12, fontWeight: 600, color: "#555" }}>
+            Your name *
+          </label>
+          <input
+            required
+            value={authorName}
+            onChange={(e) => setAuthorName(e.target.value)}
+            style={inputStyle}
+            placeholder="Alex"
+          />
+        </div>
+        <div>
+          <label style={{ fontSize: 12, fontWeight: 600, color: "#555" }}>
+            Email (optional)
+          </label>
+          <input
+            type="email"
+            value={authorEmail}
+            onChange={(e) => setAuthorEmail(e.target.value)}
+            style={inputStyle}
+            placeholder="you@company.com"
+          />
+        </div>
+      </div>
+
+      <label style={{ fontSize: 12, fontWeight: 600, color: "#555" }}>
+        Type
+      </label>
+      <div style={{ display: "flex", gap: 8, marginBottom: 12 }}>
+        {(["question", "experience", "showcase"] as CommunityCategory[]).map(
+          (c) => (
+            <button
+              key={c}
+              type="button"
+              onClick={() => setCategory(c)}
+              style={{
+                padding: "6px 12px",
+                borderRadius: 8,
+                fontSize: 12,
+                cursor: "pointer",
+                border: category === c ? "1px solid #111" : "1px solid #ddd",
+                background: category === c ? "#f5f5f5" : "#fff",
+              }}
+            >
+              {c}
+            </button>
+          ),
+        )}
+      </div>
+
+      <label style={{ fontSize: 12, fontWeight: 600, color: "#555" }}>
+        Title *
+      </label>
+      <input
+        required
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+        style={inputStyle}
+        placeholder="What's on your mind?"
+      />
+
+      <label style={{ fontSize: 12, fontWeight: 600, color: "#555" }}>
+        Details *
+      </label>
+      <textarea
+        required
+        value={body}
+        onChange={(e) => setBody(e.target.value)}
+        rows={5}
+        style={{ ...inputStyle, resize: "vertical", minHeight: 100 }}
+        placeholder="Share your experience, question, or context…"
+      />
+
+      <label style={{ fontSize: 12, fontWeight: 600, color: "#555" }}>
+        Screenshots (optional)
+      </label>
+      <input
+        type="file"
+        accept="image/png,image/jpeg,image/webp,image/gif"
+        multiple
+        onChange={onFile}
+        style={{ fontSize: 13, marginBottom: 12 }}
+      />
+      {uploading && <p style={{ fontSize: 12, color: "#888" }}>Uploading…</p>}
+      {images.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            gap: 8,
+            flexWrap: "wrap",
+            marginBottom: 12,
+          }}
+        >
+          {images.map((url) => (
+            <div key={url} style={{ position: "relative" }}>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={mediaUrl(url)}
+                alt=""
+                style={{
+                  width: 80,
+                  height: 80,
+                  objectFit: "cover",
+                  borderRadius: 8,
+                }}
+              />
+              <button
+                type="button"
+                onClick={() =>
+                  setImages((prev) => prev.filter((u) => u !== url))
+                }
+                style={{
+                  position: "absolute",
+                  top: 4,
+                  right: 4,
+                  width: 20,
+                  height: 20,
+                  borderRadius: "50%",
+                  border: "none",
+                  background: "#111",
+                  color: "#fff",
+                  fontSize: 12,
+                  cursor: "pointer",
+                  lineHeight: 1,
+                }}
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <button
+        type="submit"
+        disabled={
+          submitting ||
+          !authorName.trim() ||
+          title.length < 3 ||
+          body.length < 10
+        }
+        style={{
+          padding: "11px 20px",
+          background: "#111",
+          color: "#fff",
+          border: "none",
+          borderRadius: 8,
+          fontSize: 14,
+          fontWeight: 500,
+          cursor: "pointer",
+          opacity: submitting ? 0.6 : 1,
+        }}
+      >
+        {submitting ? "Posting…" : "Publish"}
+      </button>
+    </form>
+  );
+}

--- a/dashboard/app/docs/page.tsx
+++ b/dashboard/app/docs/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import Link from 'next/link'
+import { useEffect, useState } from 'react'
+import { SiteNav } from '@/components/SiteNav'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
+import { M } from '@/components/marketing/marketing-theme'
+import {
+  OverviewSection,
+  PythonSection,
+  TypeScriptSection,
+  RestSection,
+  McpSection,
+  SelfHostSection,
+  ConceptsSection,
+  FrameworksSection,
+} from "./sections";
+
+const API_EXPLORER_URL = "/swagger";
+
+type Section =
+  | "overview"
+  | "frameworks"
+  | "python"
+  | "typescript"
+  | "rest"
+  | "mcp"
+  | "selfhost"
+  | "concepts";
+
+const NAV: { id: Section; label: string; group: 'start' | 'integrate' | 'ref' }[] = [
+  { id: 'overview',   label: 'Overview',       group: 'start' },
+  { id: 'frameworks', label: 'Frameworks',     group: 'integrate' },
+  { id: 'python',     label: 'Python SDK',     group: 'integrate' },
+  { id: 'typescript', label: 'TypeScript SDK', group: 'integrate' },
+  { id: 'rest',       label: 'REST API',       group: 'integrate' },
+  { id: 'mcp',        label: 'MCP',            group: 'integrate' },
+  { id: 'selfhost',   label: 'Self-host (OSS)', group: 'integrate' },
+  { id: 'concepts',   label: 'Core concepts',  group: 'ref' },
+]
+
+const MOBILE_LABELS: Record<Section, string> = {
+  overview: "Overview",
+  frameworks: "Frameworks",
+  python: "Python",
+  typescript: "TypeScript",
+  rest: "REST",
+  mcp: "MCP",
+  selfhost: "Self-host",
+  concepts: "Concepts",
+};
+
+const S = {
+  page: {
+    fontFamily: "Inter, system-ui, sans-serif",
+    color: M.inkSoft,
+    background: M.bg,
+    minHeight: "100vh",
+  } as const,
+  layout: { display: "flex", maxWidth: 1100, margin: "0 auto" } as const,
+  main: {
+    flex: 1,
+    padding: "32px 20px 80px",
+    maxWidth: 820,
+    minWidth: 0,
+  } as const,
+  label: {
+    fontSize: 11,
+    fontWeight: 700,
+    color: M.faint,
+    letterSpacing: 1,
+    textTransform: "uppercase" as const,
+    margin: "0 0 6px",
+  },
+};
+
+function NavItem({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      style={{
+        display: "block",
+        width: "100%",
+        textAlign: "left",
+        background: active ? "rgba(249,115,22,0.12)" : "none",
+        border: "none",
+        borderRadius: 7,
+        padding: "7px 12px",
+        fontSize: 13.5,
+        color: active ? M.ink : M.muted,
+        fontWeight: active ? 600 : 400,
+        cursor: "pointer",
+        marginBottom: 2,
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+const VALID_SECTIONS: Section[] = ['overview', 'frameworks', 'python', 'typescript', 'rest', 'mcp', 'selfhost', 'concepts']
+
+function sectionFromUrl(): Section | null {
+  if (typeof window === 'undefined') return null
+  const hash = window.location.hash.replace('#', '')
+  if (VALID_SECTIONS.includes(hash as Section)) return hash as Section
+  const param = new URLSearchParams(window.location.search).get('section')
+  if (param && VALID_SECTIONS.includes(param as Section)) return param as Section
+  return null
+}
+
+export default function DocsPage() {
+  const [section, setSection] = useState<Section>("overview");
+
+  useEffect(() => {
+    const fromUrl = sectionFromUrl()
+    if (fromUrl) setSection(fromUrl)
+  }, [])
+
+  useEffect(() => {
+    const onHashChange = () => {
+      const fromUrl = sectionFromUrl()
+      if (fromUrl) setSection(fromUrl)
+    }
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
+  const navigate = (id: string) => {
+    if (VALID_SECTIONS.includes(id as Section)) {
+      setSection(id as Section)
+      window.history.replaceState(null, '', `/docs#${id}`)
+    }
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  return (
+    <div style={S.page}>
+      <style>{`
+        @media (max-width: 640px) {
+          .docs-sidebar { display: none !important; }
+          .docs-mobile-nav { display: flex !important; }
+          .docs-main { padding: 20px 16px 60px !important; }
+        }
+      `}</style>
+
+      <SiteNav active="docs" suffix="Docs" />
+
+      <div
+        className="docs-mobile-nav"
+        style={{
+          display: "none",
+          overflowX: "auto",
+          borderBottom: `1px solid ${M.line}`,
+          padding: "0 16px",
+          gap: 0,
+          position: "sticky",
+          top: 56,
+          background: M.bgElevated,
+          zIndex: 99,
+        }}
+      >
+        {NAV.map(({ id, label }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => navigate(id)}
+            style={{
+              padding: "10px 14px",
+              fontSize: 13,
+              fontWeight: 500,
+              border: "none",
+              background: "none",
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+              flexShrink: 0,
+              borderBottom:
+                section === id ? `2px solid ${M.brand}` : "2px solid transparent",
+              color: section === id ? M.ink : M.muted,
+            }}
+          >
+            {MOBILE_LABELS[id]}
+          </button>
+        ))}
+      </div>
+
+      <div style={S.layout}>
+        <aside
+          className="docs-sidebar"
+          style={{
+            width: 210,
+            flexShrink: 0,
+            padding: "32px 16px",
+            position: "sticky",
+            top: 56,
+            height: "calc(100vh - 56px)",
+            overflowY: "auto",
+            borderRight: `1px solid ${M.line}`,
+          }}
+        >
+          <div style={{ marginBottom: 20 }}>
+            <div style={S.label}>Start here</div>
+            {NAV.filter((n) => n.group === "start").map((n) => (
+              <NavItem
+                key={n.id}
+                active={section === n.id}
+                onClick={() => navigate(n.id)}
+              >
+                {n.label}
+              </NavItem>
+            ))}
+          </div>
+          <div style={{ marginBottom: 20 }}>
+            <div style={S.label}>Integrations</div>
+            {NAV.filter((n) => n.group === "integrate").map((n) => (
+              <NavItem
+                key={n.id}
+                active={section === n.id}
+                onClick={() => navigate(n.id)}
+              >
+                {n.label}
+              </NavItem>
+            ))}
+          </div>
+          <div>
+            <div style={S.label}>Reference</div>
+            {NAV.filter((n) => n.group === "ref").map((n) => (
+              <NavItem
+                key={n.id}
+                active={section === n.id}
+                onClick={() => navigate(n.id)}
+              >
+                {n.label}
+              </NavItem>
+            ))}
+            <a
+              href={API_EXPLORER_URL}
+              style={{
+                display: "block",
+                fontSize: 13.5,
+                color: M.muted,
+                textDecoration: "none",
+                padding: "7px 12px",
+                marginBottom: 2,
+              }}
+            >
+              API Explorer ↗
+            </a>
+            <Link
+              href="/trust"
+              style={{
+                display: "block",
+                fontSize: 13.5,
+                color: M.muted,
+                textDecoration: "none",
+                padding: "7px 12px",
+              }}
+            >
+              Technical reference
+            </Link>
+          </div>
+        </aside>
+
+        <main className="docs-main" style={S.main}>
+          {section === "overview" && <OverviewSection onNavigate={navigate} />}
+          {section === "frameworks" && <FrameworksSection />}
+          {section === "python" && <PythonSection />}
+          {section === "typescript" && <TypeScriptSection />}
+          {section === "rest" && <RestSection />}
+          {section === "mcp" && <McpSection />}
+          {section === "selfhost" && <SelfHostSection />}
+          {section === "concepts" && <ConceptsSection onNavigate={navigate} />}
+        </main>
+      </div>
+      <MarketingFooter />
+    </div>
+  );
+}

--- a/dashboard/app/docs/sections.tsx
+++ b/dashboard/app/docs/sections.tsx
@@ -1,0 +1,1804 @@
+"use client";
+
+import Link from "next/link";
+import { type ReactNode } from "react";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import { codeInlineLight, codeMonoDark } from "@/lib/content-styles";
+
+// ── Shared UI (matches docs page) ───────────────────────────────────────────
+
+export const S = {
+  h1: {
+    fontSize: 32,
+    fontWeight: 700,
+    margin: "0 0 8px",
+    letterSpacing: -0.5,
+    color: "#fff",
+  } as const,
+  h2: {
+    fontSize: 22,
+    fontWeight: 700,
+    margin: "48px 0 6px",
+    letterSpacing: -0.3,
+    color: "#fff",
+  } as const,
+  h3: {
+    fontSize: 15,
+    fontWeight: 600,
+    margin: "28px 0 8px",
+    color: "#ffffff",
+  } as const,
+  lead: {
+    fontSize: 16,
+    color: "#ffffff",
+    lineHeight: 1.7,
+    margin: "0 0 32px",
+  } as const,
+  p: {
+    fontSize: 14.5,
+    color: "#ffffff",
+    lineHeight: 1.7,
+    margin: "0 0 14px",
+  } as const,
+};
+
+export function Code({
+  children,
+  lang = "",
+}: {
+  children: string;
+  lang?: string;
+}) {
+  const { copied, copy } = useCopyToClipboard();
+  return (
+    <div style={{ position: "relative", margin: "10px 0 20px" }}>
+      <pre
+        style={{
+          background: "#111827",
+          border: "1px solid rgba(255,255,255,0.12)",
+          borderRadius: 10,
+          padding: "18px 20px",
+          fontSize: 13,
+          lineHeight: 1.75,
+          overflowX: "auto",
+          fontFamily: "JetBrains Mono, Fira Code, Menlo, monospace",
+          color: "#ffffff",
+          margin: 0,
+        }}
+      >
+        {lang && (
+          <span
+            style={{
+              position: "absolute",
+              top: 10,
+              left: 16,
+              fontSize: 10,
+              color: "#ffffff",
+              fontFamily: "sans-serif",
+              textTransform: "uppercase",
+              letterSpacing: 1,
+            }}
+          >
+            {lang}
+          </span>
+        )}
+        <span
+          style={{
+            display: lang ? "block" : undefined,
+            marginTop: lang ? 12 : 0,
+          }}
+        >
+          {children}
+        </span>
+      </pre>
+      <button
+        type="button"
+        onClick={() => copy(children)}
+        style={{
+          position: "absolute",
+          top: 10,
+          right: 12,
+          background: copied ? "#22c55e" : "rgba(255,255,255,0.1)",
+          border: "none",
+          borderRadius: 6,
+          padding: "3px 10px",
+          fontSize: 11,
+          cursor: "pointer",
+          color: copied ? "#fff" : "#ffffff",
+        }}
+      >
+        {copied ? "✓ Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
+export function Step({
+  n,
+  title,
+  children,
+}: {
+  n: number;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div style={{ display: "flex", gap: 16, marginBottom: 32 }}>
+      <div
+        style={{
+          flexShrink: 0,
+          width: 28,
+          height: 28,
+          borderRadius: "50%",
+          background: "#f97316",
+          color: "#fff",
+          fontSize: 13,
+          fontWeight: 700,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          marginTop: 2,
+        }}
+      >
+        {n}
+      </div>
+      <div style={{ flex: 1 }}>
+        <div style={{ fontWeight: 600, fontSize: 15, marginBottom: 8, color: "#fff" }}>
+          {title}
+        </div>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export function Callout({
+  type,
+  children,
+}: {
+  type: "tip" | "warning" | "info";
+  children: ReactNode;
+}) {
+  const styles = {
+    tip: { bg: "rgba(34,197,94,0.12)", border: "rgba(34,197,94,0.35)", text: "#86efac" },
+    warning: { bg: "rgba(251,191,36,0.12)", border: "rgba(251,191,36,0.35)", text: "#fde68a" },
+    info: { bg: "rgba(249,115,22,0.12)", border: "rgba(249,115,22,0.35)", text: "#fdba74" },
+  };
+  const s = styles[type];
+  return (
+    <div
+      style={{
+        background: s.bg,
+        border: `1px solid ${s.border}`,
+        borderRadius: 10,
+        padding: "12px 16px",
+        fontSize: 13.5,
+        color: s.text,
+        margin: "0 0 20px",
+        lineHeight: 1.6,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function MethodRow({ method, desc }: { method: string; desc: string }) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 16,
+        padding: "12px 16px",
+        background: "#111827",
+        borderRadius: 10,
+        border: "1px solid rgba(255,255,255,0.1)",
+      }}
+    >
+      <code
+        style={{
+          fontFamily: "monospace",
+          fontSize: 13,
+          fontWeight: 600,
+          color: "#fb923c",
+          minWidth: 200,
+          flexShrink: 0,
+        }}
+      >
+        {method}
+      </code>
+      <span style={{ fontSize: 13.5, color: "#ffffff", lineHeight: 1.5 }}>
+        {desc}
+      </span>
+    </div>
+  );
+}
+
+const SDK_METHODS = [
+  {
+    method: "log()",
+    desc: "Log any event. Use parent_id / parentId for causal links.",
+  },
+  {
+    method: "why(event_id)",
+    desc: "Walk the causal chain from an event to its root.",
+  },
+  {
+    method: "search(query)",
+    desc: "Semantic search over agent history in plain English.",
+  },
+  {
+    method: "at(agent, timestamp)",
+    desc: "Reconstruct logged state at a past timestamp.",
+  },
+  {
+    method: "query(agent)",
+    desc: "List recent events, optionally filtered by event type.",
+  },
+  {
+    method: "context_for(agent, task)",
+    desc: "Memory block formatted for system prompt injection.",
+  },
+  {
+    method: "baseline(agent)",
+    desc: "Behavioral baseline and drift score vs historical sessions.",
+  },
+  {
+    method: "memory_diff(session_id)",
+    desc: "Summary of what happened in one session.",
+  },
+  { method: "forget(key, value)", desc: "GDPR erasure by metadata filter." },
+  { method: "agents()", desc: "List all agents for your tenant." },
+];
+
+// ── Overview ────────────────────────────────────────────────────────────────
+
+export function OverviewSection({
+  onNavigate,
+}: {
+  onNavigate: (s: string) => void;
+}) {
+  return (
+    <div>
+      <h1 style={S.h1}>Documentation</h1>
+      <div
+        style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 20 }}
+      >
+        {[
+          { label: "Python SDK", pkg: "zizkadb-sdk" },
+          { label: "MCP", pkg: "zizkadb-mcp" },
+          { label: "LangChain", pkg: "zizkadb-langchain" },
+          { label: "CrewAI", pkg: "zizkadb-crewai" },
+        ].map(({ label, pkg }) => (
+          // eslint-disable-next-line @next/next/no-img-element
+          <a
+            key={pkg}
+            href={`https://pypi.org/project/${pkg}/`}
+            target="_blank"
+            rel="noreferrer"
+          >
+            <img
+              src={`https://img.shields.io/pypi/v/${pkg}?label=${encodeURIComponent(label)}`}
+              alt={`${label} on PyPI`}
+              style={{ display: "block", height: 20 }}
+            />
+          </a>
+        ))}
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <a
+          href="https://www.npmjs.com/package/zizkadb-sdk"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <img
+            src="https://img.shields.io/npm/v/zizkadb-sdk?label=TypeScript%20SDK"
+            alt="TypeScript SDK on npm"
+            style={{ display: "block", height: 20 }}
+          />
+        </a>
+      </div>
+      <p style={S.lead}>
+        Open-source guides for self-hosting ZizkaDB with Docker. Start with the quickstart,
+        then connect your stack. Managed cloud docs are at the bottom if you prefer hosted.
+      </p>
+
+      <Callout type="tip">
+        <strong>OSS quickstart (recommended):</strong>
+        <Code lang="bash">{`git clone https://github.com/Zizka-ai/ZizkaDB
+cd ZizkaDB
+bash scripts/quickstart.sh`}</Code>
+        Pulls pre-built GHCR images when available — no local compile. Runs the <code style={codeMonoDark}>why()</code> demo
+        and opens the dashboard at <code style={codeMonoDark}>http://localhost:3001/login</code> (no signup).
+        Full connect guide:{' '}
+        <a href="https://github.com/Zizka-ai/ZizkaDB/blob/main/CONNECT.md" target="_blank" rel="noreferrer" style={{ color: '#166534', fontWeight: 500 }}>
+          CONNECT.md
+        </a>
+      </Callout>
+
+      <Callout type="tip">
+        <strong>Environment variables</strong> (self-host + cloud):
+        <Code lang="bash">{`export ZIZKADB_HOST=http://localhost:8000   # self-host only
+export ZIZKADB_API_KEY=zizkadb_live_...   # managed cloud only
+export ZIZKADB_AGENT=my-bot
+export ZIZKADB_TELEMETRY=false            # optional`}</Code>
+      </Callout>
+
+      <Callout type="tip">
+        SDKs are <strong>stateless</strong> — pass{" "}
+        <code style={codeMonoDark}>agent</code>,{" "}
+        <code style={codeMonoDark}>session_id</code>, and{" "}
+        <code style={codeMonoDark}>event_id</code> explicitly.
+        See{" "}
+        <Link href="/trust#performance" style={{ color: "#166534" }}>
+          performance
+        </Link>{" "}
+        and{" "}
+        <Link href="/trust#security" style={{ color: "#166534" }}>
+          security
+        </Link>{" "}
+        on the technical reference.
+      </Callout>
+
+      <h2 style={{ ...S.h2, marginTop: 24 }}>Choose your integration</h2>
+      <div style={{ display: "grid", gap: 12, marginBottom: 40 }}>
+        {[
+          { id: 'selfhost', title: 'Self-host (OSS)', desc: 'bash scripts/quickstart.sh — Docker, pre-built images, db.why() demo', time: '~2 min' },
+          { id: 'frameworks', title: 'Framework starters', desc: 'zizkadb init — LangChain, CrewAI, OpenAI, MCP templates', time: '~2 min' },
+          { id: 'python', title: 'Python SDK', desc: 'FastAPI, LangChain, notebooks. pip install zizkadb-sdk', time: '~5 min' },
+          { id: 'typescript', title: 'TypeScript SDK', desc: 'Node, Bun, Deno. npm install zizkadb-sdk', time: '~5 min' },
+          { id: 'mcp', title: 'MCP server', desc: 'Claude Desktop, Cursor, Windsurf — no app code changes', time: '~2 min' },
+          { id: 'rest', title: 'REST API', desc: 'Any language via HTTP. curl, Go, Rust, Java', time: '~3 min' },
+        ].map(item => (
+          <button key={item.id} type="button" onClick={() => onNavigate(item.id)} style={{
+            textAlign: 'left', padding: '18px 20px', borderRadius: 12, border: '1px solid #e5e5e5',
+            background: '#fff', cursor: 'pointer', display: 'flex', justifyContent: 'space-between', alignItems: 'center', gap: 16,
+          }}>
+            <div>
+              <div style={{ fontWeight: 600, fontSize: 15, marginBottom: 4 }}>
+                {item.title}
+              </div>
+              <div style={{ fontSize: 13.5, color: "#000000" }}>{item.desc}</div>
+            </div>
+            <span style={{ fontSize: 12, color: "#000000", flexShrink: 0 }}>
+              {item.time}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <h2 style={{ ...S.h2, marginTop: 0 }}>OSS path — self-host with Docker</h2>
+      <p style={S.p}>
+        Full guide in{' '}
+        <button type="button" onClick={() => onNavigate('selfhost')} style={{ background: 'none', border: 'none', color: '#1e40af', fontWeight: 500, cursor: 'pointer', padding: 0, fontSize: 'inherit' }}>Self-host →</button>
+        {' '}· connect snippets in{' '}
+        <a href="https://github.com/Zizka-ai/ZizkaDB/blob/main/CONNECT.md" target="_blank" rel="noreferrer" style={{ color: '#1e40af', fontWeight: 500 }}>CONNECT.md</a>
+      </p>
+      <Step n={1} title="Quickstart (one command)">
+        <Code lang="bash">{`git clone https://github.com/Zizka-ai/ZizkaDB
+cd ZizkaDB
+bash scripts/quickstart.sh`}</Code>
+        <p style={S.p}>
+          Starts API + dashboard. Uses pre-built <code style={codeMonoDark}>ghcr.io/zizka-ai/*</code> images when published;
+          otherwise builds locally. Runs <code style={codeMonoDark}>zizkadb demo</code> (causal lineage).
+        </p>
+      </Step>
+      <Step n={2} title="Open dashboard (no email)">
+        <p style={S.p}>
+          Go to <code style={codeMonoDark}>http://localhost:3001/login</code> → click{' '}
+          <strong>Open my dashboard →</strong>. This is your local workspace.
+        </p>
+      </Step>
+      <Step n={3} title="Connect your agent">
+        <Code lang="python">{`pip install zizkadb-sdk
+# zizkadb demo          # repeat the worked example
+# zizkadb init my-agent --template basic
+
+from zizkadb import ZizkaDB
+db = ZizkaDB(host="http://localhost:8000")  # auto-uses local dev key
+await db.log(agent="my-bot", event="started", data={})`}</Code>
+        <Callout type="warning">
+          <strong>Important:</strong> SDK and dashboard must use the <strong>same tenant</strong>.
+          Local dev: green dashboard button + <code style={codeMonoDark}>host=</code> SDK.
+          Production VPS: email OTP + API key from Settings.
+        </Callout>
+      </Step>
+      <Step n={4} title="See your data in the dashboard">
+        <p style={S.p}>Agents appear as soon as you log events. Click an agent for events, sessions, and drift.</p>
+      </Step>
+
+      <h2 style={{ ...S.h2, marginTop: 48 }}>Managed cloud (optional)</h2>
+      <p style={S.p}>Prefer not to run Docker? Use hosted ZizkaDB at <strong>db.zizka.ai</strong>.</p>
+      <Step n={1} title="Sign up & create an agent">
+        <p style={S.p}>
+          <Link href="/signup" style={{ color: "#111", fontWeight: 500 }}>
+            Sign up
+          </Link>{" "}
+          with email OTP →{" "}
+          <Link href="/dashboard" style={{ color: "#111", fontWeight: 500 }}>
+            Dashboard → Create agent
+          </Link>{" "}
+          → copy the API key (
+          <code
+            style={codeInlineLight}
+          >
+            zizkadb_live_…
+          </code>
+          ).
+        </p>
+      </Step>
+      <Step n={2} title="Connect SDK, MCP, or REST">
+        <p style={S.p}>
+          Use your API key and the <strong>same agent name</strong> in every <code style={codeMonoDark}>db.log(agent=…)</code> call.
+        </p>
+      </Step>
+      <Step n={3} title="Open your dashboard">
+        <p style={S.p}>
+          <Link href="/dashboard" style={{ color: '#111', fontWeight: 500 }}>db.zizka.ai/dashboard</Link> shows the same agents and events your code logs.
+        </p>
+      </Step>
+
+      <h2 style={{ ...S.h2, marginTop: 48 }}>After connecting</h2>
+      <Step n={1} title="Log events with session_id">
+        <p style={S.p}>
+          Log{" "}
+          <code
+            style={codeInlineLight}
+          >
+            user_message
+          </code>
+          , each{" "}
+          <code
+            style={codeInlineLight}
+          >
+            tool_call
+          </code>
+          , and{" "}
+          <code
+            style={codeInlineLight}
+          >
+            assistant_response
+          </code>{" "}
+          with{" "}
+          <code
+            style={codeInlineLight}
+          >
+            parent_id
+          </code>{" "}
+          links. Use the same{" "}
+          <code
+            style={codeInlineLight}
+          >
+            session_id
+          </code>{" "}
+          for one conversation so baselines and diffs work.
+        </p>
+      </Step>
+      <Step n={2} title="Configure embeddings (managed)">
+        <p style={S.p}>
+          In Settings → <strong>Embeddings</strong>, pick your OpenAI model
+          (platform-hosted or your own key). Required for semantic search and{" "}
+          <code style={codeMonoDark}>context_for()</code>.
+          Logging and <code style={codeMonoDark}>why()</code>{" "}
+          work without embeddings.
+        </p>
+      </Step>
+      <Step n={3} title="Use drift & search">
+        <p style={S.p}>
+          Once you have enough sessions, use{" "}
+          <code style={codeMonoDark}>baseline()</code> and
+          semantic search in the dashboard or SDK.
+        </p>
+      </Step>
+    </div>
+  );
+}
+
+// ── Python SDK ────────────────────────────────────────────────────────────────
+
+export function PythonSection() {
+  return (
+    <div>
+      <h1 style={S.h1}>Python SDK</h1>
+      <p style={S.lead}>
+        Full guide for integrating ZizkaDB in Python agents — FastAPI services,
+        LangChain, CrewAI, notebooks, or scripts.
+      </p>
+
+      <Step n={1} title="Prerequisites">
+        <p style={S.p}>
+          Python <strong>3.10+</strong>. Works in venv, conda, or system Python.
+        </p>
+        <Code lang="bash">python3 --version # 3.10 or higher</Code>
+      </Step>
+
+      <Step n={2} title="Choose your environment">
+        <p style={S.p}>
+          <strong>Managed cloud:</strong>{" "}
+          <Link href="/signup" style={{ color: "#111", fontWeight: 500 }}>
+            Sign up
+          </Link>{" "}
+          → Settings → Create API key (
+          <code style={codeMonoDark}>zizkadb_live_…</code>).
+        </p>
+        <p style={S.p}>
+          <strong>Self-host:</strong> use{" "}
+          <code style={codeMonoDark}>
+            host=&quot;http://localhost:8000&quot;
+          </code>{" "}
+          (dev key auto-sent). See{" "}
+          <Link href="/docs" style={{ color: "#1e40af" }}>
+            Self-host docs
+          </Link>{" "}
+          → click <strong>Open my dashboard →</strong> on the login page.
+        </p>
+      </Step>
+
+      <Step n={3} title="Install">
+        <Code lang="bash">pip install zizkadb-sdk</Code>
+        <Callout type="warning">
+          Install <strong>zizkadb-sdk</strong> on PyPI — not the unrelated{" "}
+          <code style={codeMonoDark}>agentdb</code> package.
+        </Callout>
+      </Step>
+
+      <Step n={4} title="Initialize the client">
+        <Code lang="python">{`from zizkadb import ZizkaDB
+
+# Managed cloud (db.zizka.ai)
+db = ZizkaDB("zizkadb_live_xxxx")
+
+# Self-hosted
+# db = ZizkaDB(host="http://localhost:8000")`}</Code>
+      </Step>
+
+      <Step n={5} title="Log your first event">
+        <p style={S.p}>
+          The SDK is async-first. Wrap calls in{" "}
+          <code style={codeMonoDark}>async def main()</code> and
+          run with{" "}
+          <code style={codeMonoDark}>asyncio.run(main())</code>.
+        </p>
+        <Code lang="python">{`import asyncio
+from zizkadb import ZizkaDB
+
+db = ZizkaDB("zizkadb_live_xxxx")
+
+async def main():
+    result = await db.log(
+        agent="support-bot",
+        event="tool_call",
+        data={"tool": "search", "query": "pricing"},
+        session_id="sess_abc123",   # group one conversation
+    )
+    print("Saved:", result.event_id)
+
+asyncio.run(main())`}</Code>
+      </Step>
+
+      <Step n={6} title="Link events causally">
+        <p style={S.p}>
+          Pass <code style={codeMonoDark}>parent_id</code> so you
+          can call <code style={codeMonoDark}>why()</code> later.
+        </p>
+        <Code lang="python">{`async def main():
+    msg = await db.log(
+        agent="support-bot", event="user_message",
+        data={"text": "why is my bill $200?"},
+        session_id="sess_abc123",
+    )
+    tool = await db.log(
+        agent="support-bot", event="tool_call",
+        data={"tool": "get_billing"},
+        parent_id=msg.event_id,
+        session_id="sess_abc123",
+    )
+    resp = await db.log(
+        agent="support-bot", event="assistant_response",
+        data={"text": "I found a duplicate charge."},
+        parent_id=tool.event_id,
+        session_id="sess_abc123",
+    )
+    chain = await db.why(resp.event_id)
+    chain.print()
+
+asyncio.run(main())`}</Code>
+      </Step>
+
+      <Step n={7} title="Use search, replay, and memory">
+        <Code lang="python">{`async def main():
+    # Semantic search
+    hits = await db.search("billing complaint", agent="support-bot", limit=5)
+
+    # Reconstruct logged state at a time
+    from datetime import datetime, timezone
+    state = await db.at("support-bot", datetime(2026, 5, 1, 15, 0, tzinfo=timezone.utc))
+
+    # Prompt-ready memory block
+    ctx = await db.context_for(
+        agent="support-bot",
+        task="user asking about refund policy",
+        max_tokens=2000,
+    )
+
+    # Drift vs baseline (needs enough sessions with session_id)
+    baseline = await db.baseline("support-bot", recent_window=50)
+    print(baseline)
+
+asyncio.run(main())`}</Code>
+      </Step>
+
+      <h2 style={{ ...S.h2, marginTop: 16 }}>
+        Framework example: OpenAI tool loop
+      </h2>
+      <Code lang="python">{`import asyncio
+from openai import AsyncOpenAI
+from zizkadb import ZizkaDB
+
+db = ZizkaDB("zizkadb_live_xxxx")
+openai = AsyncOpenAI()
+
+async def run_turn(user_text: str, session_id: str):
+    msg = await db.log(
+        agent="my-agent", event="user_message",
+        data={"text": user_text}, session_id=session_id,
+    )
+    parent_id = msg.event_id
+
+    response = await openai.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": user_text}],
+    )
+    text = response.choices[0].message.content or ""
+    await db.log(
+        agent="my-agent", event="assistant_response",
+        data={"text": text}, parent_id=parent_id, session_id=session_id,
+    )
+    return text
+
+asyncio.run(run_turn("Hello", "sess_001"))`}</Code>
+
+      <h2 style={S.h2}>All Python methods</h2>
+      <div style={{ display: "grid", gap: 10 }}>
+        {SDK_METHODS.map((m) => (
+          <MethodRow key={m.method} method={`db.${m.method}`} desc={m.desc} />
+        ))}
+      </div>
+
+      <h2 style={S.h2}>Troubleshooting</h2>
+      <div style={{ display: "grid", gap: 12 }}>
+        {[
+          {
+            q: "SyntaxError: await outside async function",
+            a: "Wrap code in async def main() and asyncio.run(main()).",
+          },
+          {
+            q: "401 Invalid API key",
+            a: "Copy the full key from Dashboard → Agents (no spaces). Use ZIZKADB_API_KEY or AGENTDB_API_KEY in your env.",
+          },
+          {
+            q: "403 Agent mismatch",
+            a: "Your key is scoped to one agent (e.g. my-bot) but code logged to a different agent name. Use the same name in db.log(), or create a tenant-wide key in Settings.",
+          },
+          {
+            q: "Dashboard empty but SDK works",
+            a: "Check you are viewing the same agent name your code logs to. Click Test agent on the agent page. Settings test event goes to dashboard-connection-test, not your app agent.",
+          },
+          {
+            q: "Search returns nothing",
+            a: "Configure embeddings in Settings. Log a few events first so there is history to search.",
+          },
+          {
+            q: "baseline shows warming_up",
+            a: "Log more sessions with session_id on each event. Drift needs volume.",
+          },
+        ].map((item) => (
+          <div
+            key={item.q}
+            style={{
+              padding: "14px 18px",
+              background: "#fafafa",
+              borderRadius: 10,
+              border: "1px solid #ebebeb",
+            }}
+          >
+            <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 4, color: "#1a1a1a" }}>
+              {item.q}
+            </div>
+            <div style={{ fontSize: 13.5, color: "#555" }}>{item.a}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── TypeScript SDK ────────────────────────────────────────────────────────────
+
+export function TypeScriptSection() {
+  return (
+    <div>
+      <h1 style={S.h1}>TypeScript SDK</h1>
+      <p style={S.lead}>
+        Integrate ZizkaDB in Node.js, Bun, Deno, or edge runtimes. Core HTTP client matches Python for{' '}
+        <code style={codeMonoDark}>log</code>, <code style={codeMonoDark}>why</code>,{' '}
+        <code style={codeMonoDark}>search</code>, and related APIs. LangChain and CrewAI adapters are Python-only — use MCP or REST from Node for those stacks.
+      </p>
+
+      <Step n={1} title="Prerequisites">
+        <p style={S.p}>
+          Node.js <strong>18+</strong> (or Bun / Deno). TypeScript optional but
+          recommended.
+        </p>
+        <Code lang="bash">node --version # v18+</Code>
+      </Step>
+
+      <Step n={2} title="Choose your environment">
+        <p style={S.p}>
+          <strong>Managed cloud:</strong>{" "}
+          <Link href="/signup" style={{ color: "#111", fontWeight: 500 }}>
+            Sign up
+          </Link>{" "}
+          → Settings → Create API key.
+        </p>
+        <p style={S.p}>
+          <strong>Self-host:</strong>{" "}
+          <code
+            style={codeMonoDark}
+          >{`new ZizkaDB({ host: 'http://localhost:8000' })`}</code>{" "}
+          — see{" "}
+          <Link href="/docs" style={{ color: "#1e40af" }}>
+            Self-host docs
+          </Link>{" "}
+          for dashboard setup.
+        </p>
+      </Step>
+
+      <Step n={3} title="Install">
+        <Code lang="bash">
+          npm install zizkadb-sdk # or: pnpm add zizkadb-sdk / yarn add
+          zizkadb-sdk / bun add zizkadb-sdk
+        </Code>
+      </Step>
+
+      <Step n={4} title="Initialize the client">
+        <Code lang="typescript">{`import { ZizkaDB } from 'zizkadb-sdk'
+
+// Managed cloud
+const db = new ZizkaDB({ apiKey: 'zizkadb_live_xxxx' })
+
+// Self-hosted
+// const db = new ZizkaDB({ host: 'http://localhost:8000' })`}</Code>
+      </Step>
+
+      <Step n={5} title="Log your first event">
+        <Code lang="typescript">{`const result = await db.log({
+  agent: 'support-bot',
+  event: 'tool_call',
+  data: { tool: 'search', query: 'pricing' },
+  sessionId: 'sess_abc123',
+})
+console.log(result.eventId)`}</Code>
+      </Step>
+
+      <Step n={6} title="Link events causally">
+        <Code lang="typescript">{`const msg = await db.log({
+  agent: 'support-bot',
+  event: 'user_message',
+  data: { text: 'why is my bill $200?' },
+  sessionId: 'sess_abc123',
+})
+
+const tool = await db.log({
+  agent: 'support-bot',
+  event: 'tool_call',
+  data: { tool: 'get_billing' },
+  parentId: msg.eventId,
+  sessionId: 'sess_abc123',
+})
+
+const chain = await db.why(tool.eventId)
+chain.print()`}</Code>
+      </Step>
+
+      <Step n={7} title="Search, replay, context, baseline">
+        <Code lang="typescript">{`// Semantic search
+const hits = await db.search({
+  query: 'billing complaint',
+  agent: 'support-bot',
+  limit: 5,
+})
+
+// Logged state at timestamp (ISO string)
+const state = await db.at({
+  agent: 'support-bot',
+  timestamp: '2026-05-01T15:00:00Z',
+})
+
+// Memory for system prompt
+const context = await db.contextFor({
+  agent: 'support-bot',
+  task: 'user asking about refund',
+  maxTokens: 2000,
+})
+
+// Behavioral drift
+const baseline = await db.baseline({ agent: 'support-bot', recentWindow: 50 })`}</Code>
+      </Step>
+
+      <h2 style={{ ...S.h2, marginTop: 16 }}>
+        Framework example: Express + OpenAI
+      </h2>
+      <Code lang="typescript">{`import express from 'express'
+import OpenAI from 'openai'
+import { ZizkaDB } from 'zizkadb-sdk'
+
+const app = express()
+app.use(express.json())
+const db = new ZizkaDB({ apiKey: process.env.ZIZKADB_API_KEY! })
+const openai = new OpenAI()
+
+app.post('/chat', async (req, res) => {
+  const { message, sessionId } = req.body
+  const msg = await db.log({
+    agent: 'api-bot', event: 'user_message',
+    data: { text: message }, sessionId,
+  })
+  const completion = await openai.chat.completions.create({
+    model: 'gpt-4o-mini',
+    messages: [{ role: 'user', content: message }],
+  })
+  const text = completion.choices[0]?.message?.content ?? ''
+  await db.log({
+    agent: 'api-bot', event: 'assistant_response',
+    data: { text }, parentId: msg.eventId, sessionId,
+  })
+  res.json({ reply: text })
+})
+
+app.listen(3000)`}</Code>
+
+      <Callout type="tip">
+        Opt out of anonymous SDK telemetry:{" "}
+        <code style={codeMonoDark}>ZIZKADB_TELEMETRY=false</code>
+      </Callout>
+
+      <h2 style={S.h2}>All TypeScript methods</h2>
+      <div style={{ display: "grid", gap: 10 }}>
+        {SDK_METHODS.map((m) => (
+          <MethodRow
+            key={m.method}
+            method={`db.${m.method.replace("_", "")}`}
+            desc={m.desc}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── REST API ────────────────────────────────────────────────────────────────
+
+export function RestSection() {
+  return (
+    <div>
+      <h1 style={S.h1}>REST API</h1>
+      <p style={S.lead}>
+        Call ZizkaDB from any language with HTTP. Use this for Go, Rust, Java,
+        Ruby, mobile, or custom integrations.
+      </p>
+
+      <Step n={1} title="Base URL & auth">
+        <p style={S.p}>
+          <strong>Managed:</strong>{" "}
+          <code
+            style={codeInlineLight}
+          >
+            https://db.zizka.ai
+          </code>
+          <br />
+          <strong>Self-host:</strong>{" "}
+          <code
+            style={codeInlineLight}
+          >
+            http://localhost:8000
+          </code>
+        </p>
+        <p style={S.p}>
+          Every request (except{" "}
+          <code style={codeMonoDark}>/health</code>) needs:
+        </p>
+        <Code lang="http">
+          Authorization: Bearer zizkadb_live_xxxx Content-Type: application/json
+        </Code>
+        <Callout type="warning">
+          API routes are under <strong>/v1/</strong> — not{" "}
+          <code style={codeMonoDark}>/api/v1/</code> when calling
+          directly. Interactive reference:{" "}
+          <a href="/swagger" style={{ color: "#92400e", fontWeight: 500 }}>
+            /swagger
+          </a>
+        </Callout>
+      </Step>
+
+      <Step n={2} title="Health check (no auth)">
+        <Code lang="bash">{`curl https://db.zizka.ai/health
+# {"status":"ok","version":"0.1.0"}`}</Code>
+      </Step>
+
+      <Step n={3} title="Log an event">
+        <Code lang="bash">{`curl -X POST https://db.zizka.ai/v1/events \\
+  -H "Authorization: Bearer zizkadb_live_xxxx" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "agent": "support-bot",
+    "event": "tool_call",
+    "data": { "tool": "get_billing" },
+    "session_id": "sess_abc123",
+    "parent_id": null
+  }'
+# → { "event_id": "...", "timestamp": "...", "sequence_no": 1 }`}</Code>
+      </Step>
+
+      <Step n={4} title="Query events">
+        <Code lang="bash">{`curl "https://db.zizka.ai/v1/events?agent=support-bot&limit=20" \\
+  -H "Authorization: Bearer zizkadb_live_xxxx"`}</Code>
+      </Step>
+
+      <Step n={5} title="Causal chain (why)">
+        <Code lang="bash">{`curl "https://db.zizka.ai/v1/events/EVENT_UUID_HERE/why" \\
+  -H "Authorization: Bearer zizkadb_live_xxxx"`}</Code>
+      </Step>
+
+      <Step n={6} title="Time travel (state at timestamp)">
+        <Code lang="bash">{`curl "https://db.zizka.ai/v1/events/at?agent=support-bot&timestamp=2026-05-01T15:00:00Z" \\
+  -H "Authorization: Bearer zizkadb_live_xxxx"`}</Code>
+      </Step>
+
+      <Step n={7} title="Semantic search">
+        <Code lang="bash">{`curl -X POST https://db.zizka.ai/v1/search \\
+  -H "Authorization: Bearer zizkadb_live_xxxx" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "query": "customer frustrated about billing",
+    "agent": "support-bot",
+    "limit": 10
+  }'`}</Code>
+      </Step>
+
+      <Step n={8} title="Context for prompts">
+        <Code lang="bash">{`curl -X POST https://db.zizka.ai/v1/memory/context \\
+  -H "Authorization: Bearer zizkadb_live_xxxx" \\
+  -H "Content-Type: application/json" \\
+  -d '{
+    "agent": "support-bot",
+    "task": "user asking about refund policy",
+    "max_tokens": 2000
+  }'`}</Code>
+      </Step>
+
+      <Step n={9} title="Agents, baseline, session diff, forget">
+        <Code lang="bash">{`# List agents
+curl https://db.zizka.ai/v1/agents -H "Authorization: Bearer zizkadb_live_xxxx"
+
+# Behavioral baseline / drift
+curl "https://db.zizka.ai/v1/agents/support-bot/baseline?recent_window=50" \\
+  -H "Authorization: Bearer zizkadb_live_xxxx"
+
+# Session summary
+curl https://db.zizka.ai/v1/memory/diff/sess_abc123 \\
+  -H "Authorization: Bearer zizkadb_live_xxxx"
+
+# GDPR erasure by metadata
+curl -X DELETE https://db.zizka.ai/v1/memory/forget \\
+  -H "Authorization: Bearer zizkadb_live_xxxx" \\
+  -H "Content-Type: application/json" \\
+  -d '{"filter_key": "user_id", "filter_value": "user_123"}'`}</Code>
+      </Step>
+
+      <h2 style={S.h2}>Endpoint reference</h2>
+      <div
+        style={{
+          overflowX: "auto",
+          border: "1px solid #e5e5e5",
+          borderRadius: 10,
+        }}
+      >
+        <table
+          style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}
+        >
+          <thead>
+            <tr style={{ background: "#f7f7f7" }}>
+              <th style={{ padding: "10px 14px", textAlign: "left" }}>
+                Method
+              </th>
+              <th style={{ padding: "10px 14px", textAlign: "left" }}>Path</th>
+              <th style={{ padding: "10px 14px", textAlign: "left" }}>
+                Purpose
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {[
+              ["POST", "/v1/events", "Log event"],
+              ["GET", "/v1/events", "Query events"],
+              ["GET", "/v1/events/{id}/why", "Causal chain"],
+              ["GET", "/v1/events/at", "State at timestamp"],
+              ["POST", "/v1/search", "Semantic search"],
+              ["POST", "/v1/memory/context", "Prompt context"],
+              ["GET", "/v1/memory/diff/{session_id}", "Session diff"],
+              ["DELETE", "/v1/memory/forget", "GDPR erasure"],
+              ["GET", "/v1/agents", "List agents"],
+              ["GET", "/v1/agents/{id}/baseline", "Drift baseline"],
+              ["GET", "/v1/agents/{id}/sessions", "List sessions"],
+              ["GET", "/v1/settings/embeddings", "Embedding config"],
+              ["PUT", "/v1/settings/embeddings", "Update embeddings (JWT)"],
+            ].map(([m, p, d]) => (
+              <tr key={p} style={{ borderTop: "1px solid #f0f0f0" }}>
+                <td
+                  style={{
+                    padding: "10px 14px",
+                    fontFamily: "monospace",
+                    fontSize: 12,
+                  }}
+                >
+                  {m}
+                </td>
+                <td
+                  style={{
+                    padding: "10px 14px",
+                    fontFamily: "monospace",
+                    fontSize: 12,
+                  }}
+                >
+                  {p}
+                </td>
+                <td style={{ padding: "10px 14px", color: "#555" }}>{d}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h2 style={S.h2}>Common errors</h2>
+      <div style={{ display: "grid", gap: 12 }}>
+        {[
+          {
+            q: "401 Unauthorized",
+            a: "Missing or invalid Bearer token. Use zizkadb_live_ key from Settings.",
+          },
+          {
+            q: "404 on /api/v1/...",
+            a: "Use /v1/ directly: https://db.zizka.ai/v1/events",
+          },
+          {
+            q: "400 on /v1/search",
+            a: "Embeddings not configured. Set up in Dashboard → Settings → Embeddings.",
+          },
+        ].map((item) => (
+          <div
+            key={item.q}
+            style={{
+              padding: "14px 18px",
+              background: "#fafafa",
+              borderRadius: 10,
+              border: "1px solid #ebebeb",
+            }}
+          >
+            <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 4, color: "#1a1a1a" }}>
+              {item.q}
+            </div>
+            <div style={{ fontSize: 13.5, color: "#555" }}>{item.a}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── MCP ─────────────────────────────────────────────────────────────────────
+
+export function McpSection() {
+  return (
+    <div>
+      <h1 style={S.h1}>MCP Server</h1>
+      <p style={S.lead}>
+        Connect ZizkaDB to Claude Desktop, Cursor, or Windsurf in minutes — no
+        SDK and no changes to your app code. The AI calls ZizkaDB tools directly
+        during conversations.
+      </p>
+
+      <Callout type="info">
+        <strong>Fastest start — Cursor:</strong> paste this into{" "}
+        <code style={codeMonoDark}>~/.cursor/mcp.json</code>,
+        reload MCP, done.
+      </Callout>
+      <Code lang="json">{`{
+  "mcpServers": {
+    "zizkadb": {
+      "command": "uvx",
+      "args": ["zizkadb-mcp"],
+      "env": { "ZIZKADB_API_KEY": "zizkadb_live_xxxx" }
+    }
+  }
+}`}</Code>
+      <p style={{ ...S.p, marginTop: -8, marginBottom: 24 }}>
+        Self-host: use the full block in <strong>Self-hosted API</strong> below
+        (only <code style={codeMonoDark}>ZIZKADB_HOST</code> —
+        dev key auto-injected). Requires{" "}
+        <code style={codeMonoDark}>uvx</code> — install{" "}
+        <a
+          href="https://docs.astral.sh/uv/"
+          target="_blank"
+          rel="noreferrer"
+          style={{ color: "#111" }}
+        >
+          uv
+        </a>{" "}
+        first.
+      </p>
+
+      <Callout type="info">
+        <strong>MCP</strong> (Model Context Protocol) lets AI apps use external
+        tools. ZizkaDB exposes log, search, why, time travel, and more as native
+        MCP tools.
+      </Callout>
+
+      <Step n={1} title="Prerequisites">
+        <p style={S.p}>
+          <strong>uvx</strong> (recommended) — comes with{" "}
+          <a
+            href="https://docs.astral.sh/uv/"
+            target="_blank"
+            rel="noreferrer"
+            style={{ color: "#111" }}
+          >
+            uv
+          </a>{" "}
+          install. Or:{" "}
+          <code style={codeMonoDark}>
+            pip install zizkadb-mcp
+          </code>
+        </p>
+        <Code lang="bash">
+          # macOS / Linux curl -LsSf https://astral.sh/uv/install.sh | sh uvx
+          --version
+        </Code>
+      </Step>
+
+      <Step n={2} title="Create an agent & copy key">
+        <p style={S.p}>
+          <Link href="/signup" style={{ color: "#111", fontWeight: 500 }}>
+            Sign up
+          </Link>{" "}
+          → Dashboard → Create agent → copy key. Use the same agent name when
+          calling <code style={codeMonoDark}>log_event</code>.
+        </p>
+      </Step>
+
+      <h2 style={{ ...S.h2, marginTop: 32 }}>Claude Desktop</h2>
+      <Step n={3} title="Edit Claude config">
+        <p style={S.p}>Mac:</p>
+        <Code>
+          ~/Library/Application Support/Claude/claude_desktop_config.json
+        </Code>
+        <p style={S.p}>Windows:</p>
+        <Code>%APPDATA%\\Claude\\claude_desktop_config.json</Code>
+        <p style={S.p}>
+          Add ZizkaDB (merge into existing{" "}
+          <code style={codeMonoDark}>mcpServers</code> if you
+          have other servers):
+        </p>
+        <Code lang="json">{`{
+  "mcpServers": {
+    "zizkadb": {
+      "command": "uvx",
+      "args": ["zizkadb-mcp"],
+      "env": {
+        "ZIZKADB_API_KEY": "zizkadb_live_xxxx"
+      }
+    }
+  }
+}`}</Code>
+      </Step>
+      <Step n={4} title="Restart Claude Desktop">
+        <p style={S.p}>
+          Quit completely and reopen. ZizkaDB tools appear in the tool list
+          (hammer icon). Claude can call them during any chat.
+        </p>
+      </Step>
+
+      <h2 style={S.h2}>Cursor</h2>
+      <Step n={5} title="Edit Cursor MCP config">
+        <p style={S.p}>
+          Create or edit{" "}
+          <code
+            style={codeInlineLight}
+          >
+            ~/.cursor/mcp.json
+          </code>{" "}
+          (global) or{" "}
+          <code
+            style={codeInlineLight}
+          >
+            .cursor/mcp.json
+          </code>{" "}
+          in your project:
+        </p>
+        <Code lang="json">{`{
+  "mcpServers": {
+    "zizkadb": {
+      "command": "uvx",
+      "args": ["zizkadb-mcp"],
+      "env": {
+        "ZIZKADB_API_KEY": "zizkadb_live_xxxx"
+      }
+    }
+  }
+}`}</Code>
+      </Step>
+      <Step n={6} title="Reload MCP in Cursor">
+        <p style={S.p}>
+          Quit Cursor completely (
+          <code style={codeMonoDark}>Cmd+Q</code>) and reopen, or
+          use Command Palette → <strong>MCP: Reload servers</strong>. Open{" "}
+          <code style={codeMonoDark}>Cmd+Shift+J</code> →{" "}
+          <strong>Tools &amp; MCP</strong> to confirm{" "}
+          <code style={codeMonoDark}>zizkadb</code> is connected.
+        </p>
+      </Step>
+
+      <h2 style={S.h2}>Windsurf & other MCP clients</h2>
+      <p style={S.p}>
+        Same JSON block — point your client&apos;s MCP config at{" "}
+        <code style={codeMonoDark}>uvx zizkadb-mcp</code> with{" "}
+        <code style={codeMonoDark}>ZIZKADB_API_KEY</code> in env.
+      </p>
+
+      <h2 style={S.h2}>Self-hosted API</h2>
+      <p style={S.p}>
+        After{" "}
+        <code style={codeMonoDark}>
+          bash scripts/setup-local.sh
+        </code>
+        , paste this (no API key needed on localhost):
+      </p>
+      <Code lang="json">{`{
+  "mcpServers": {
+    "zizkadb": {
+      "command": "uvx",
+      "args": ["zizkadb-mcp"],
+      "env": {
+        "ZIZKADB_HOST": "http://localhost:8000"
+      }
+    }
+  }
+}`}</Code>
+
+      <h2 style={S.h2}>Using MCP in practice</h2>
+      <p style={S.p}>
+        Once connected, ask the AI naturally — it will call tools when needed:
+      </p>
+      <div style={{ display: "grid", gap: 10, marginBottom: 24 }}>
+        {[
+          {
+            say: '"Log that we decided to use Postgres for the billing service"',
+            tool: "log_event",
+          },
+          {
+            say: '"What did we log about billing last week?"',
+            tool: "search_memory",
+          },
+          {
+            say: '"Why did the agent call get_billing in event X?"',
+            tool: "why",
+          },
+          {
+            say: '"What was the agent state on May 1 at 3pm?"',
+            tool: "time_travel",
+          },
+        ].map((item) => (
+          <div
+            key={item.tool}
+            style={{
+              padding: "12px 16px",
+              background: "#fafafa",
+              borderRadius: 8,
+              border: "1px solid #ebebeb",
+            }}
+          >
+            <div style={{ fontSize: 13.5, color: "#333", marginBottom: 4 }}>
+              {item.say}
+            </div>
+            <code style={{ fontSize: 12, color: "#000000" }}>→ {item.tool}</code>
+          </div>
+        ))}
+      </div>
+
+      <h2 style={S.h2}>All MCP tools</h2>
+      <div style={{ display: "grid", gap: 8 }}>
+        {[
+          {
+            tool: "log_event",
+            desc: "Log action with optional causal parent_id",
+          },
+          { tool: "search_memory", desc: "Semantic search over agent history" },
+          {
+            tool: "get_context",
+            desc: "Formatted memory block for system prompts",
+          },
+          { tool: "why", desc: "Causal chain for an event_id" },
+          { tool: "query_events", desc: "List/filter recent events" },
+          { tool: "time_travel", desc: "Logged state at a past timestamp" },
+          { tool: "memory_diff", desc: "Session summary" },
+          { tool: "forget", desc: "GDPR delete by metadata filter" },
+        ].map((item) => (
+          <div
+            key={item.tool}
+            style={{
+              display: "flex",
+              gap: 16,
+              padding: "11px 16px",
+              background: "#fafafa",
+              borderRadius: 8,
+              border: "1px solid #ebebeb",
+            }}
+          >
+            <code
+              style={{
+                fontFamily: "monospace",
+                fontSize: 12.5,
+                fontWeight: 600,
+                color: "#fb923c",
+                minWidth: 140,
+                flexShrink: 0,
+              }}
+            >
+              {item.tool}
+            </code>
+            <span style={{ fontSize: 13.5, color: "#444" }}>{item.desc}</span>
+          </div>
+        ))}
+      </div>
+
+      <h2 style={S.h2}>Troubleshooting</h2>
+      <div style={{ display: "grid", gap: 12 }}>
+        {[
+          {
+            q: "Tools not showing",
+            a: "Restart the app after editing config. Check JSON is valid (no trailing commas).",
+          },
+          {
+            q: "uvx not found",
+            a: "Install uv: curl -LsSf https://astral.sh/uv/install.sh | sh",
+          },
+          {
+            q: "Auth errors",
+            a: "Cloud: verify ZIZKADB_API_KEY. Self-host: set ZIZKADB_HOST to http://localhost:8000 and ensure local API is running (curl http://localhost:8000/health). Dev key is zizkadb_dev_local by default.",
+          },
+        ].map((item) => (
+          <div
+            key={item.q}
+            style={{
+              padding: "14px 18px",
+              background: "#fafafa",
+              borderRadius: 10,
+              border: "1px solid #ebebeb",
+            }}
+          >
+            <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 4, color: "#1a1a1a" }}>
+              {item.q}
+            </div>
+            <div style={{ fontSize: 13.5, color: "#555" }}>{item.a}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Self-host (expanded) ────────────────────────────────────────────────────
+
+export function SelfHostSection() {
+  return (
+    <div>
+      <h1 style={S.h1}>Self-Host</h1>
+      <p style={S.lead}>
+        Run the full ZizkaDB stack on your server. Free forever (AGPL), no cloud
+        account required. SDK, MCP, and dashboard all connect to the same local
+        tenant.
+      </p>
+
+      <Callout type="warning">
+        <strong>One rule:</strong> SDK/MCP and dashboard must use the{" "}
+        <strong>same tenant</strong>.
+        <ul style={{ margin: "8px 0 0", paddingLeft: 20 }}>
+          <li>
+            <strong>Local dev (just you):</strong> login →{" "}
+            <em>Open my dashboard →</em> + SDK with{" "}
+            <code style={codeMonoDark}>host=</code>
+          </li>
+          <li>
+            <strong>Production / team on your server:</strong> email OTP login →
+            create API key in Settings → use that key in SDK/MCP
+          </li>
+        </ul>
+        Mixing email login with the auto dev key shows an empty dashboard.
+      </Callout>
+
+      <Callout type="info">
+        Stack: Postgres + pgvector, Qdrant, Redis, FastAPI. Starts in under 60
+        seconds with Docker Compose.
+      </Callout>
+
+      <Step n={1} title="Quickstart (recommended)">
+        <Code lang="bash">{`git clone https://github.com/Zizka-ai/ZizkaDB
+cd ZizkaDB
+bash scripts/quickstart.sh`}</Code>
+        <p style={S.p}>
+          One command: Docker stack + <code style={codeMonoDark}>db.why()</code> demo + dashboard link.
+          Pre-built images from <code style={codeMonoDark}>ghcr.io/zizka-ai/</code> when available.
+        </p>
+        <p style={S.p}>
+          Stack only: <code style={codeMonoDark}>bash scripts/setup-local.sh</code> ·
+          Connect guide:{' '}
+          <a href="https://github.com/Zizka-ai/ZizkaDB/blob/main/CONNECT.md" target="_blank" rel="noreferrer" style={{ color: '#1e40af' }}>CONNECT.md</a>
+        </p>
+      </Step>
+
+      <Step n={2} title="Run the lineage demo again">
+        <Code lang="bash">{`pip install zizkadb-sdk
+zizkadb demo`}</Code>
+        <p style={S.p}>
+          Worked example:{' '}
+          <a href="https://github.com/Zizka-ai/ZizkaDB/tree/main/worked/01-support-order-delay" target="_blank" rel="noreferrer" style={{ color: '#1e40af' }}>
+            worked/01-support-order-delay
+          </a>
+        </p>
+      </Step>
+
+      <Step n={3} title="Manual setup (optional)">
+        <Code lang="bash">{`git clone https://github.com/Zizka-ai/ZizkaDB
+cd ZizkaDB
+cp .env.example infra/.env`}</Code>
+        <p style={S.p}>
+          Edit <code style={codeMonoDark}>infra/.env</code>:
+        </p>
+        <Code lang="bash">{`OPENAI_API_KEY=sk-...          # for semantic search
+JWT_SECRET=your-random-32-char-secret
+DEV_API_KEY=zizkadb_dev_local       # default local dev key (SDK auto-sends this)
+
+# Optional: email OTP for production dashboard login
+EMAIL_HOST=smtp.gmail.com
+EMAIL_PORT=465
+EMAIL_USER=you@gmail.com
+EMAIL_PASS=your-app-password`}</Code>
+      </Step>
+
+      <Step n={4} title="Start the API stack">
+        <Code lang="bash">docker compose -f infra/docker-compose.yml up -d --build</Code>
+        <Code lang="bash">{`curl http://localhost:8000/health
+# {"status":"ok","version":"0.1.0"}`}</Code>
+      </Step>
+
+      <Step n={5} title="Connect SDK or MCP">
+        <p style={S.p}>
+          Self-hosted SDK calls auto-send the local dev key (
+          <code style={codeMonoDark}>zizkadb_dev_local</code> by
+          default). Create a named API key in the dashboard Settings when you
+          move to production.
+        </p>
+        <Code lang="python">{`from zizkadb import ZizkaDB
+db = ZizkaDB(host="http://localhost:8000")`}</Code>
+        <p style={S.p}>
+          MCP:{" "}
+          <code style={codeMonoDark}>
+            ZIZKADB_HOST=http://localhost:8000
+          </code>{" "}
+          (dev key auto-injected on localhost)
+        </p>
+        <p style={S.p}>
+          REST:{" "}
+          <code style={codeMonoDark}>
+            Authorization: Bearer zizkadb_dev_local
+          </code>
+        </p>
+      </Step>
+
+      <Step n={6} title="Open the dashboard">
+        <p style={S.p}>
+          With{" "}
+          <code style={codeMonoDark}>
+            bash scripts/setup-local.sh
+          </code>
+          , dashboard is at{" "}
+          <code style={codeMonoDark}>
+            http://localhost:3001/login
+          </code>
+          . Click <strong>Open my dashboard →</strong> — no email required.
+        </p>
+        <p style={S.p}>
+          Or run manually:{" "}
+          <code style={codeMonoDark}>
+            docker compose -f infra/docker-compose.yml -f
+            infra/docker-compose.dashboard.yml up -d
+          </code>
+        </p>
+      </Step>
+
+      <Step n={7} title="Production on your VPS">
+        <p style={S.p}>For production on a VPS:</p>
+        <Code lang="bash">{`docker compose -f infra/docker-compose.yml up -d
+bash infra/deploy-selfhost.sh
+# Set EMAIL_* in infra/.env for team login; set NEXT_PUBLIC_DEV_MODE=false`}</Code>
+        <p style={S.p}>
+          Point nginx to :3001 (dashboard) and :8000 (API) — see{" "}
+          <code style={codeMonoDark}>infra/nginx.conf</code>.
+        </p>
+      </Step>
+
+      <h2 style={S.h2}>Troubleshooting</h2>
+      <div style={{ display: "grid", gap: 12 }}>
+        {[
+          {
+            q: "API not starting",
+            a: "docker compose -f infra/docker-compose.yml logs api --tail=50",
+          },
+          {
+            q: "Dashboard empty but SDK logs work",
+            a: 'Use "Open my dashboard →" (dev login) with host= SDK — or create an API key in Settings and use it in your agent.',
+          },
+          {
+            q: "Search not working",
+            a: "Set OPENAI_API_KEY in infra/.env and restart api container.",
+          },
+          {
+            q: "Port 8000 in use",
+            a: "Change port mapping in infra/docker-compose.yml.",
+          },
+        ].map((item) => (
+          <div
+            key={item.q}
+            style={{
+              padding: "14px 18px",
+              background: "#fafafa",
+              borderRadius: 10,
+              border: "1px solid #ebebeb",
+            }}
+          >
+            <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 4, color: "#1a1a1a" }}>
+              {item.q}
+            </div>
+            <div style={{ fontSize: 13.5, color: "#555" }}>{item.a}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Frameworks (LangChain, CrewAI, OpenAI) ───────────────────────────────────
+
+export function FrameworksSection() {
+  return (
+    <div>
+      <h1 style={S.h1}>Framework integrations</h1>
+      <p style={S.lead}>
+        Official adapters and starters — same causal{" "}
+        <code style={codeMonoDark}>log()</code> +{" "}
+        <code style={codeMonoDark}>parent_id</code> pattern for
+        every stack.
+      </p>
+
+      <Callout type="tip">
+        <strong>Fastest start (Python):</strong>{' '}
+        <code style={codeMonoDark}>pip install zizkadb-sdk</code> then{' '}
+        <code style={codeMonoDark}>zizkadb init my-agent --template langchain</code>.
+        The <code style={codeMonoDark}>zizkadb init</code> CLI ships with the Python SDK only.
+        Templates: <code style={codeMonoDark}>basic</code>,{' '}
+        <code style={codeMonoDark}>openai</code>,{' '}
+        <code style={codeMonoDark}>langchain</code>,{' '}
+        <code style={codeMonoDark}>crewai</code>,{' '}
+        <code style={codeMonoDark}>mcp-cursor</code>.
+      </Callout>
+
+      <h2 style={S.h2}>Package overview</h2>
+      <div style={{ display: 'grid', gap: 10, marginBottom: 24 }}>
+        {[
+          ['Python SDK (zizkadb-sdk)', 'log, why, search, context_for, zizkadb init CLI'],
+          ['TypeScript SDK (npm)', 'log, why, search, context_for — HTTP client only'],
+          ['zizkadb-langchain', 'Auto-log LangChain LLM + tool steps (Python)'],
+          ['zizkadb-crewai', 'Log crew kickoff + output (Python)'],
+          ['zizkadb-mcp', 'Cursor / Claude Desktop tools — any language via MCP'],
+        ].map(([pkg, desc]) => (
+          <div key={pkg} style={{ padding: '12px 16px', background: '#fafafa', borderRadius: 10, border: '1px solid #ebebeb', fontSize: 13.5, color: '#1a1a1a' }}>
+            <strong>{pkg}</strong> — {desc}
+          </div>
+        ))}
+      </div>
+
+      <h2 style={{ ...S.h2, marginTop: 24 }}>Scaffold a project</h2>
+      <Code lang="bash">{`pip install zizkadb-sdk
+zizkadb init my-agent --template basic
+cd my-agent && cp .env.example .env
+pip install -r requirements.txt
+python agent.py`}</Code>
+
+      <h2 style={S.h2}>OpenAI / Anthropic (SDK)</h2>
+      <p style={S.p}>
+        Use <code style={codeMonoDark}>AsyncOpenAI</code> or{" "}
+        <code style={codeMonoDark}>AsyncAnthropic</code> inside{" "}
+        <code style={codeMonoDark}>async with ZizkaDB(...)</code>
+        . Log the user turn, call the model, log the reply with{" "}
+        <code style={codeMonoDark}>parent_id=turn.event_id</code>
+        .
+      </p>
+      <Code lang="python">{`# pip install zizkadb-sdk anthropic
+import anthropic
+from zizkadb import ZizkaDB
+
+async def run(user_input: str):
+    async with ZizkaDB("zizkadb_live_...") as db:
+        client = anthropic.AsyncAnthropic()
+        turn = await db.log(agent="my-bot", event="user_message", data={"text": user_input})
+        response = await client.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=1024,
+            messages=[{"role": "user", "content": user_input}],
+        )
+        await db.log(
+            agent="my-bot",
+            event="assistant_response",
+            data={"text": response.content[0].text},
+            parent_id=turn.event_id,
+        )`}</Code>
+
+      <h2 style={S.h2}>LangChain</h2>
+      <p style={S.p}>
+        Install{" "}
+        <code style={codeMonoDark}>zizkadb-langchain</code> from
+        PyPI. Pass{" "}
+        <code style={codeMonoDark}>ZizkaDBCallbackHandler</code>{" "}
+        in{" "}
+        <code style={codeMonoDark}>
+          config={"{"}&quot;callbacks&quot;: [handler]{"}"}
+        </code>
+        .
+      </p>
+      <Code lang="python">{`pip install zizkadb-sdk zizkadb-langchain langchain-openai
+
+from langchain_openai import ChatOpenAI
+from langchain_core.messages import HumanMessage
+from zizkadb import ZizkaDB
+from zizkadb_langchain import ZizkaDBCallbackHandler
+
+async with ZizkaDB("zizkadb_live_...") as db:
+    handler = ZizkaDBCallbackHandler(db, agent="my-bot")
+    llm = ChatOpenAI(model="gpt-4o-mini")
+    await llm.ainvoke([HumanMessage(content="Hello")], config={"callbacks": [handler]})
+    (await db.why(handler.last_event_id)).print()`}</Code>
+
+      <h2 style={S.h2}>CrewAI</h2>
+      <p style={S.p}>
+        Install <code style={codeMonoDark}>zizkadb-crewai</code>{" "}
+        from PyPI.
+        <code style={codeMonoDark}>ZizkaDBCrewLogger</code> logs
+        kickoff, tasks, and final output with lineage.
+      </p>
+      <Code lang="python">{`pip install zizkadb-sdk zizkadb-crewai crewai
+
+from zizkadb import ZizkaDB
+from zizkadb_crewai import ZizkaDBCrewLogger
+
+async with ZizkaDB("zizkadb_live_...") as db:
+    logger = ZizkaDBCrewLogger(db, agent="research-crew")
+    kickoff = await logger.log_kickoff(goal="Research topic X")
+    output = await crew.kickoff_async()
+    await logger.log_output(str(output), parent_id=kickoff.event_id)`}</Code>
+
+      <h2 style={S.h2}>Examples in the repo</h2>
+      <p style={S.p}>
+        Runnable trees under{" "}
+        <code style={codeMonoDark}>examples/</code> on{" "}
+        <a
+          href="https://github.com/Zizka-ai/ZizkaDB"
+          style={{ color: "#1e40af" }}
+        >
+          GitHub
+        </a>
+        : minimal-python, openai-agent, langchain-agent, crewai-agent,
+        mcp-cursor.
+      </p>
+    </div>
+  );
+}
+
+// ── Concepts ──────────────────────────────────────────────────────────────────
+
+export function ConceptsSection({
+  onNavigate,
+}: {
+  onNavigate: (s: string) => void;
+}) {
+  return (
+    <div>
+      <h1 style={S.h1}>Core Concepts</h1>
+      <p style={S.lead}>
+        How ZizkaDB thinks about agent memory — events, causality, search,
+        replay, and drift.
+      </p>
+      <Callout type="info">
+        Runnable examples:{" "}
+        <code style={codeMonoDark}>zizkadb init my-agent</code>{" "}
+        or the <code style={codeMonoDark}>examples/</code> folder
+        on GitHub. Framework guides in{" "}
+        <button
+          type="button"
+          onClick={() => onNavigate("frameworks")}
+          style={{
+            background: "none",
+            border: "none",
+            color: "#1e40af",
+            fontWeight: 500,
+            cursor: "pointer",
+            padding: 0,
+            fontSize: "inherit",
+          }}
+        >
+          Framework integrations
+        </button>
+        .
+      </Callout>
+
+      {[
+        {
+          title: "Events",
+          body: "Everything is an event: agent name, event type string, JSON data, timestamp. Log what matters — user messages, tool calls, decisions, errors.",
+          code: `await db.log(agent="support-bot", event="tool_call",
+    data={"tool": "get_billing", "user_id": 123})`,
+        },
+        {
+          title: "Causal lineage",
+          body: 'parent_id links child → parent. db.why() walks from any event back to the root. This is how you debug "why did the agent do that?"',
+          code: `msg  = await db.log(..., event="user_message", data={...})
+tool = await db.log(..., event="tool_call", parent_id=msg.event_id)
+await db.why(tool.event_id)  # user_message → tool_call`,
+        },
+        {
+          title: "Sessions & baselines",
+          body: "Use session_id on every event in one run. After enough sessions, baseline() compares recent behavior to historical patterns and returns a drift score.",
+          code: `baseline = await db.baseline("support-bot", recent_window=50)
+# drift.score: 0 = identical, 1 = totally different`,
+        },
+        {
+          title: "Semantic search",
+          body: "Events are embedded automatically (OpenAI). Search in plain English — no SQL, no keywords.",
+          code: `results = await db.search("angry customer billing", agent="support-bot")`,
+        },
+        {
+          title: "Time travel",
+          body: "at() reconstructs logged state from events up to a timestamp. Replays what was recorded, not a re-run of the LLM.",
+          code: `from datetime import datetime, timezone
+state = await db.at("support-bot", datetime(2026, 5, 1, 15, 0, tzinfo=timezone.utc))`,
+        },
+        {
+          title: "Context injection",
+          body: "context_for() returns recent + semantically relevant events within a token budget — paste into your system prompt.",
+          code: `ctx = await db.context_for(agent="support-bot", task="refund question", max_tokens=2000)`,
+        },
+      ].map((concept) => (
+        <div
+          key={concept.title}
+          style={{
+            marginBottom: 48,
+            paddingBottom: 48,
+            borderBottom: "1px solid #f0f0f0",
+          }}
+        >
+          <h2 style={{ ...S.h2, marginTop: 0 }}>{concept.title}</h2>
+          <p style={S.p}>{concept.body}</p>
+          <Code lang="python">{concept.code}</Code>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/app/enterprise/page.tsx
+++ b/dashboard/app/enterprise/page.tsx
@@ -1,0 +1,1155 @@
+"use client";
+
+import { BRAND, BRAND_SHADOW_TINT } from '@/components/brand'
+import { CalendlyBookModal } from '@/components/marketing/CalendlyBookModal'
+import { EnterpriseConnectForm } from '@/components/marketing/enterprise/EnterpriseConnectForm'
+import {
+  M,
+  container,
+  h2,
+  lead,
+  outlineBtn,
+  primaryBtn,
+  sectionTitle,
+} from '@/components/marketing/marketing-theme'
+import { MarketingPageStyles } from '@/components/marketing/MarketingPageStyles'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
+import { SiteNav } from '@/components/SiteNav'
+import Link from 'next/link'
+import { useState } from 'react'
+
+const GITHUB_URL = 'https://github.com/Zizka-ai/ZizkaDB'
+
+// This page alternates section backgrounds between white (#fff) and M.wash
+// (dark navy), but `h2`/`lead`/`outlineBtn` from marketing-theme.ts are
+// styled for the dark theme (light text) by default. Sections on a white
+// background must use these local overrides instead of the raw tokens —
+// using the raw tokens on a white section renders invisible white-on-white
+// text/buttons. (This bit twice already; centralizing it here so it can't
+// happen a third time.)
+const lightH2 = { ...h2, color: '#000' }
+const lightLead = { ...lead, color: '#333' }
+const lightOutlineBtn = { ...outlineBtn, color: '#000', border: `1px solid ${M.line}` }
+
+const CAPABILITY_ROWS = [
+  { cap: "Event logging", api: "POST /v1/events", oss: true, ent: true },
+  {
+    cap: "Causal chain (why)",
+    api: "GET /v1/events/{id}/why",
+    oss: true,
+    ent: true,
+  },
+  { cap: "State at time T", api: "GET /v1/events/at", oss: true, ent: true },
+  { cap: "Semantic search", api: "POST /v1/search", oss: true, ent: true },
+  {
+    cap: "Behavioral baseline",
+    api: "GET /v1/agents/{id}/baseline",
+    oss: true,
+    ent: true,
+  },
+  {
+    cap: "GDPR erasure",
+    api: "DELETE /v1/memory/forget",
+    oss: true,
+    ent: true,
+  },
+  { cap: "Fleet dashboard", api: "Enterprise UI", oss: false, ent: true },
+  { cap: "Fleet ranking", api: "Enterprise UI", oss: false, ent: true },
+  { cap: "Audit export", api: "CSV / JSON + checksums", oss: false, ent: true },
+  {
+    cap: "Commercial license",
+    api: "Named org + expiry",
+    oss: false,
+    ent: true,
+  },
+  { cap: "Supported install", api: "Zizka + your team", oss: false, ent: true },
+];
+
+const WHY_ROWS = [
+  { item: "Deployment", detail: "Your VPC, your region, your infrastructure" },
+  {
+    item: "Data residency",
+    detail: "All agent data stays inside your private network",
+  },
+  {
+    item: "Behavioral drift",
+    detail: "Per-agent baseline with fleet-wide ranking",
+  },
+  { item: "Audit trail", detail: "On-demand export with per-event checksums" },
+  {
+    item: "Commercial license",
+    detail: "Named org, defined expiry, no AGPL obligations",
+  },
+  {
+    item: "Integration support",
+    detail: "Install workshop with your dev team",
+  },
+  {
+    item: "Framework agnostic",
+    detail: "Python, TypeScript, MCP, REST. No framework lock-in.",
+  },
+  {
+    item: "Open core engine",
+    detail: "Same engine on GitHub, cloud, and Enterprise VPC",
+  },
+];
+
+const SECURITY_ROWS = [
+  {
+    feature: "Network isolation",
+    detail: "Agents reach ZizkaDB via same VPC, VPC peering, or PrivateLink",
+  },
+  {
+    feature: "TLS in transit",
+    detail: "All API and dashboard traffic over HTTPS",
+  },
+  {
+    feature: "Tenant isolation",
+    detail: "Single-tenant stack, no shared database with other customers",
+  },
+  {
+    feature: "GDPR erasure",
+    detail: "forget() deletes events by metadata filter on request",
+  },
+  {
+    feature: "Event checksums",
+    detail: "Per-event SHA-256 for audit integrity",
+  },
+  {
+    feature: "Access revocation",
+    detail: "Zizka access removed at handoff on Day 28",
+  },
+  {
+    feature: "Secrets management",
+    detail: "License key and API keys stored in your secrets manager",
+  },
+  {
+    feature: "Backup and restore",
+    detail: "Postgres dump scripts included in integration kit",
+  },
+];
+
+const PRICING_TIERS = [
+  {
+    name: "Starter VPC",
+    period: "",
+    highlight: false,
+    features: [
+      "Single-tenant VPC deployment",
+      "Up to 5 agents",
+      "Fleet dashboard",
+      "Audit export",
+      "Commercial license (1 year)",
+      "Install included",
+    ],
+    cta: "Lets connect",
+    href: "#contact",
+  },
+  {
+    name: "Growth VPC",
+    period: "",
+    highlight: true,
+    features: [
+      "Single-tenant VPC deployment",
+      "Up to 50 agents",
+      "Fleet dashboard and ranking",
+      "Audit export with checksums",
+      "Commercial license (1 year)",
+      "Install + integration workshop",
+    ],
+    cta: "Lets connect",
+    href: "#contact",
+  },
+  {
+    name: "Scale VPC",
+    period: "",
+    highlight: false,
+    features: [
+      "Single-tenant VPC deployment",
+      "Unlimited agents",
+      "Fleet dashboard and ranking",
+      "Audit export with checksums",
+      "Commercial license (1 year)",
+      "Dedicated Install sprint",
+    ],
+    cta: "Lets connect",
+    href: "#contact",
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    q: "Can you deploy inside our Kubernetes cluster?",
+    a: "Version 1 is a VM running Docker Compose. Helm is available when a deal requires it.",
+  },
+  {
+    q: "Do you modify our agent code?",
+    a: "An optional Launch Sprint can open pull requests on one or two services. The default path is your developers working with our integration kit.",
+  },
+  {
+    q: "How is this different from self-hosting from GitHub?",
+    a: "AGPL open core versus commercial license, fleet dashboard, audit export, and a supported install in your VPC.",
+  },
+  {
+    q: "How is Enterprise different from Pro or Team cloud?",
+    a: "We host multi-tenant SaaS on db.zizka.ai. Enterprise is single-tenant in your VPC with a commercial license.",
+  },
+  {
+    q: "Can we run a POC without a VPC?",
+    a: "Cloud trial works for developer evaluation. Enterprise pilot is expected in your VPC.",
+  },
+  {
+    q: "How does GDPR and data residency work?",
+    a: "You control all data. forget() deletes by metadata filter. VPC deployments keep everything in your infrastructure.",
+  },
+];
+
+export default function EnterprisePage() {
+  const [demoOpen, setDemoOpen] = useState(false);
+  const [openFaq, setOpenFaq] = useState<number | null>(null);
+
+  return (
+    <div
+      style={{
+        fontFamily: "Inter, system-ui, sans-serif",
+        color: M.ink,
+        background: "#fff",
+      }}
+    >
+      <MarketingPageStyles />
+      <style>{`
+        @media (max-width: 768px) {
+          .ent-section { padding-left: 20px !important; padding-right: 20px !important; padding-top: 52px !important; padding-bottom: 52px !important; }
+          .ent-price-grid { grid-template-columns: 1fr !important; }
+          .ent-hero-btns { flex-direction: column !important; align-items: stretch !important; }
+          .ent-hero-btns a, .ent-hero-btns button { justify-content: center !important; }
+          .ent-split { grid-template-columns: 1fr !important; }
+          .ent-resource-grid { grid-template-columns: 1fr !important; }
+        }
+        @media (min-width: 769px) and (max-width: 1024px) {
+          .ent-resource-grid { grid-template-columns: repeat(2, 1fr) !important; }
+        }
+        .ent-table { width: 100%; border-collapse: collapse; }
+        .ent-table th, .ent-table td { padding: 12px 16px; text-align: left; border-bottom: 1px solid #e5e7eb; font-size: 14px; }
+        .ent-table th { font-weight: 700; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; background: #f9fafb; color: #374151; }
+        .ent-table tr:last-child td { border-bottom: none; }
+        .ent-table tr:hover td { background: #f3f4f6; }
+        .ent-table-dark th, .ent-table-dark td {
+          border-bottom: 1px solid rgba(255,255,255,0.1);
+          color: rgba(255,255,255,0.85);
+        }
+        .ent-table-dark th {
+          background: #111827;
+          color: rgba(255,255,255,0.55);
+        }
+        .ent-table-dark tr:hover td { background: rgba(249,115,22,0.14); }
+        .ent-table-dark tr:hover td[style] { background: rgba(249,115,22,0.14) !important; }
+        .faq-item { border-bottom: 1px solid #e5e7eb; }
+        .faq-item:last-child { border-bottom: none; }
+      `}</style>
+
+      <SiteNav active="enterprise" suffix="Enterprise" />
+
+      {/* Hero */}
+      <section
+        className="ent-section"
+        style={{
+          padding: "72px 40px 60px",
+          background: "#fff",
+          borderBottom: `1px solid ${M.line}`,
+        }}
+      >
+        <div style={{ ...container(760), textAlign: "center" }}>
+          <div
+            style={{
+              display: "inline-block",
+              fontSize: 11,
+              fontWeight: 800,
+              letterSpacing: 1.2,
+              textTransform: "uppercase" as const,
+              color: BRAND,
+              marginBottom: 20,
+              padding: "5px 14px",
+              background: `${BRAND}12`,
+              borderRadius: 6,
+            }}
+          >
+            Enterprise
+          </div>
+          <h1
+            style={{
+              fontSize: 44,
+              fontWeight: 800,
+              lineHeight: 1.12,
+              margin: "0 0 32px",
+              letterSpacing: -0.8,
+              color: "#000",
+            }}
+          >
+            Operational control for multi-agent fleets in your cloud
+          </h1>
+
+          <div
+            className="ent-hero-btns"
+            style={{
+              display: "flex",
+              gap: 12,
+              flexWrap: "wrap",
+              justifyContent: "center",
+            }}
+          >
+            <a href="#contact" style={primaryBtn}>
+              Lets connect
+            </a>
+            <button
+              type="button"
+              onClick={() => setDemoOpen(true)}
+              style={{ ...lightOutlineBtn, cursor: "pointer" }}
+            >
+              Book demo
+            </button>
+          </div>
+
+          <CalendlyBookModal
+            open={demoOpen}
+            onClose={() => setDemoOpen(false)}
+          />
+        </div>
+      </section>
+
+      {/* What ZizkaDB is */}
+      <section
+        className="ent-section"
+        style={{ padding: "80px 40px", background: M.wash }}
+      >
+        <div style={container(860)}>
+          <p style={sectionTitle}>What ZizkaDB is</p>
+          <h2 style={h2}>Operational database for AI agents</h2>
+          <p style={{ ...lead, marginBottom: 32 }}>
+            ZizkaDB stores agent decisions, tool calls, and outcomes with causal
+            links. It is not a vector index for RAG documents and not
+            distributed traces. Most teams use all three alongside each other.
+          </p>
+
+          <div style={{ overflowX: "auto" as const }}>
+            <table
+              className="ent-table ent-table-dark"
+              style={{
+                borderRadius: 12,
+                overflow: "hidden",
+                border: `1px solid ${M.line}`,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>Layer</th>
+                  <th>Role</th>
+                  <th>Examples</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Vector DB</td>
+                  <td>RAG / knowledge retrieval</td>
+                  <td>Pinecone, Qdrant</td>
+                </tr>
+                <tr>
+                  <td>App DB</td>
+                  <td>Transactional app state</td>
+                  <td>Postgres, Redis</td>
+                </tr>
+                <tr>
+                  <td style={{ fontWeight: 700, color: BRAND }}>Agent ops</td>
+                  <td>Decision history, lineage, drift</td>
+                  <td style={{ fontWeight: 700, color: BRAND }}>ZizkaDB</td>
+                </tr>
+                <tr>
+                  <td>Traces</td>
+                  <td>Spans, framework hooks</td>
+                  <td>LangSmith, OTel</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p
+            style={{
+              marginTop: 20,
+              fontSize: 14,
+              color: M.muted,
+              fontWeight: 500,
+            }}
+          >
+            Works with any LLM framework. No framework lock-in. Instrument with
+            Python, TypeScript, MCP, or REST. Open core engine on GitHub (AGPL)
+            runs the same code on self-host, managed cloud, and Enterprise VPC.
+          </p>
+        </div>
+      </section>
+
+      {/* Multi-agent fleets */}
+      <section
+        className="ent-section"
+        style={{ padding: "80px 40px", background: "#fff" }}
+      >
+        <div style={container(960)}>
+          <p style={sectionTitle}>Multi-agent fleets</p>
+          <h2 style={lightH2}>
+            One ZizkaDB instance. Many agents. Full visibility.
+          </h2>
+          <p style={{ ...lightLead, marginBottom: 40 }}>
+            Each agent logs under a distinct name. Tenant-wide API keys support
+            SaaS patterns with thousands of logical agents.
+          </p>
+
+          <div
+            className="ent-split"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 20,
+            }}
+          >
+            {[
+              {
+                icon: "🗺",
+                title: "Fleet observability",
+                body: "See all agents, last seen, and session volume in one place. Included in your Enterprise VPC deployment.",
+              },
+              {
+                icon: "📈",
+                title: "Behavioral drift",
+                body: "Compare recent sessions to each agent's baseline. Verdicts from Stable to Significant. Operational behavior change, not hallucination detection.",
+              },
+              {
+                icon: "🔗",
+                title: "Causal tracing",
+                body: "Walk decision chains with why() and replay sessions when something breaks in production.",
+              },
+            ].map((card) => (
+              <div
+                key={card.title}
+                style={{
+                  padding: "28px 24px",
+                  borderRadius: 16,
+                  background: M.wash,
+                  border: `1px solid ${M.line}`,
+                }}
+              >
+                <div style={{ fontSize: 28, marginBottom: 14 }}>
+                  {card.icon}
+                </div>
+                <h3
+                  style={{
+                    fontSize: 17,
+                    fontWeight: 700,
+                    margin: "0 0 10px",
+                    color: "#000",
+                  }}
+                >
+                  {card.title}
+                </h3>
+                <p
+                  style={{
+                    fontSize: 14,
+                    color: "#333",
+                    lineHeight: 1.65,
+                    margin: 0,
+                    fontWeight: 500,
+                  }}
+                >
+                  {card.body}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{
+              marginTop: 24,
+              padding: "16px 20px",
+              borderRadius: 10,
+              background: "#fffbeb",
+              border: "1px solid #fde68a",
+              fontSize: 13,
+              color: "#92400e",
+              fontWeight: 500,
+            }}
+          >
+            Drift means operational behavior change, for example tool errors up
+            12 percentage points. It is not hallucination detection or truth
+            verification.
+          </div>
+        </div>
+      </section>
+
+      {/* Capabilities */}
+      <section
+        className="ent-section"
+        style={{ padding: "80px 40px", background: M.wash }}
+      >
+        <div style={container(900)}>
+          <p style={sectionTitle}>Capabilities</p>
+          <h2 style={h2}>
+            Open core today. Enterprise VPC adds fleet operations.
+          </h2>
+          <p style={{ ...lead, marginBottom: 36 }}>
+            The same ZizkaDB engine runs on GitHub (AGPL), managed cloud, and
+            Enterprise VPC. Enterprise adds commercial license, fleet UI, audit
+            export, and supported install.
+          </p>
+
+          <div style={{ overflowX: "auto" as const }}>
+            <table
+              className="ent-table ent-table-dark"
+              style={{
+                borderRadius: 12,
+                overflow: "hidden",
+                border: `1px solid ${M.line}`,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>Capability</th>
+                  <th>API / detail</th>
+                  <th style={{ textAlign: "center" as const }}>Open core</th>
+                  <th style={{ textAlign: "center" as const }}>
+                    Enterprise VPC
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {CAPABILITY_ROWS.map((row) => (
+                  <tr key={row.cap}>
+                    <td style={{ fontWeight: 600, color: M.inkSoft }}>
+                      {row.cap}
+                    </td>
+                    <td
+                      style={{
+                        color: M.muted,
+                        fontFamily: "monospace",
+                        fontSize: 13,
+                      }}
+                    >
+                      {row.api}
+                    </td>
+                    <td
+                      style={{
+                        textAlign: "center" as const,
+                        fontWeight: 700,
+                        color: row.oss ? "#16a34a" : "#d1d5db",
+                      }}
+                    >
+                      {row.oss ? "✓" : "-"}
+                    </td>
+                    <td
+                      style={{
+                        textAlign: "center" as const,
+                        fontWeight: 700,
+                        color: "#16a34a",
+                      }}
+                    >
+                      ✓
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* Why enterprises choose */}
+      <section
+        className="ent-section"
+        style={{ padding: "80px 40px", background: "#fff" }}
+      >
+        <div style={container(900)}>
+          <p style={sectionTitle}>Why enterprises choose ZizkaDB</p>
+          <h2 style={lightH2}>Private deployment. Operational control.</h2>
+          <p style={{ ...lightLead, marginBottom: 36 }}>
+            Built for teams that cannot send agent logs to a shared cloud and
+            need a complete operational record for every agent decision.
+          </p>
+
+          <div style={{ overflowX: "auto" as const }}>
+            <table
+              className="ent-table"
+              style={{
+                borderRadius: 12,
+                overflow: "hidden",
+                border: `1px solid ${M.line}`,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>What you get</th>
+                  <th>Why it matters</th>
+                </tr>
+              </thead>
+              <tbody>
+                {WHY_ROWS.map((row) => (
+                  <tr key={row.item}>
+                    <td
+                      style={{
+                        fontWeight: 700,
+                        color: "#000",
+                        whiteSpace: "nowrap" as const,
+                      }}
+                    >
+                      {row.item}
+                    </td>
+                    <td style={{ color: "#333" }}>{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      {/* Security and trust */}
+      <section
+        className="ent-section"
+        style={{ padding: "80px 40px", background: M.wash }}
+      >
+        <div style={container(900)}>
+          <p style={sectionTitle}>Security and trust</p>
+          <h2 style={h2}>Built for production environments.</h2>
+          <p style={{ ...lead, marginBottom: 36 }}>
+            Single-tenant deployment with no shared infrastructure. Your data
+            never leaves your network.
+          </p>
+
+          <div style={{ overflowX: "auto" as const }}>
+            <table
+              className="ent-table ent-table-dark"
+              style={{
+                borderRadius: 12,
+                overflow: "hidden",
+                border: `1px solid ${M.line}`,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th>Security feature</th>
+                  <th>Detail</th>
+                </tr>
+              </thead>
+              <tbody>
+                {SECURITY_ROWS.map((row) => (
+                  <tr key={row.feature}>
+                    <td
+                      style={{
+                        fontWeight: 700,
+                        color: M.inkSoft,
+                        whiteSpace: "nowrap" as const,
+                      }}
+                    >
+                      {row.feature}
+                    </td>
+                    <td style={{ color: M.muted }}>{row.detail}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          <div
+            style={{
+              marginTop: 20,
+              padding: "14px 18px",
+              borderRadius: 10,
+              background: "#f0fdf4",
+              border: "1px solid #bbf7d0",
+              fontSize: 13,
+              color: "#166534",
+              fontWeight: 500,
+            }}
+          >
+            SSO, SAML, and automated alerting are on the roadmap. Pilots use
+            dashboard OTP plus VPN access.
+          </div>
+        </div>
+      </section>
+
+      {/* Deployment timeline */}
+      <section
+        className="ent-section"
+        style={{ padding: "80px 40px", background: "#fff" }}
+      >
+        <div style={container(960)}>
+          <p style={sectionTitle}>Deployment</p>
+          <h2 style={lightH2}>Production-ready in your cloud within 28 days</h2>
+          <p style={{ ...lightLead, marginBottom: 40 }}>
+            Same install package every customer. Only variables: region, sizing,
+            DNS, secrets, and license tier.
+          </p>
+
+          <div
+            className="ent-split"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 20,
+              marginBottom: 32,
+            }}
+          >
+            {[
+              {
+                icon: "🔌",
+                title: "No platform rewrite",
+                body: "Add ZIZKADB_HOST and ZIZKADB_API_KEY to your services. Instrument five log points per conversation.",
+              },
+              {
+                icon: "🔄",
+                title: "Your CI/CD",
+                body: "You merge and redeploy through your pipeline. Optional Launch Sprint can help instrument one or two services via pull requests.",
+              },
+              {
+                icon: "🔒",
+                title: "Private network",
+                body: "Agent subnets reach ZizkaDB via same VPC, VPC peering, or PrivateLink.",
+              },
+            ].map((card) => (
+              <div
+                key={card.title}
+                style={{
+                  padding: "28px 24px",
+                  borderRadius: 16,
+                  background: M.wash,
+                  border: `1px solid ${M.line}`,
+                }}
+              >
+                <div style={{ fontSize: 28, marginBottom: 14 }}>
+                  {card.icon}
+                </div>
+                <h3
+                  style={{
+                    fontSize: 17,
+                    fontWeight: 700,
+                    margin: "0 0 10px",
+                    color: "#000",
+                  }}
+                >
+                  {card.title}
+                </h3>
+                <p
+                  style={{
+                    fontSize: 14,
+                    color: "#333",
+                    lineHeight: 1.65,
+                    margin: 0,
+                    fontWeight: 500,
+                  }}
+                >
+                  {card.body}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(4, 1fr)",
+              gap: 12,
+            }}
+          >
+            {[
+              { day: "Day 0", label: "Discovery and checklist" },
+              { day: "Day 7", label: "Stack live in staging" },
+              { day: "Day 14", label: "Integration workshop" },
+              { day: "Day 28", label: "Handoff and access revoked" },
+            ].map((step) => (
+              <div
+                key={step.day}
+                style={{
+                  padding: "20px",
+                  borderRadius: 12,
+                  background: M.wash,
+                  border: `1px solid ${M.line}`,
+                  textAlign: "center" as const,
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 13,
+                    fontWeight: 800,
+                    color: BRAND,
+                    marginBottom: 6,
+                  }}
+                >
+                  {step.day}
+                </div>
+                <div style={{ fontSize: 13, color: "#000", fontWeight: 600 }}>
+                  {step.label}
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section
+        id="pricing"
+        className="ent-section"
+        style={{ padding: "80px 40px", background: M.wash }}
+      >
+        <div style={container(960)}>
+          <p style={sectionTitle}>Pricing</p>
+          <h2 style={h2}>Annual VPC license. All tiers include the install.</h2>
+          <p style={{ ...lead, marginBottom: 40 }}>
+            Contact us for exact pricing. All tiers are annual licenses with
+            commercial rights included.
+          </p>
+
+          <div
+            className="ent-price-grid zdb-price-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 20,
+              alignItems: "stretch",
+            }}
+          >
+            {PRICING_TIERS.map((tier) => (
+              <div
+                key={tier.name}
+                className="zdb-pricing-card"
+                style={{
+                  background: "#fff",
+                  borderRadius: 16,
+                  padding: "28px 24px",
+                  border: tier.highlight
+                    ? `2px solid ${BRAND}`
+                    : `1px solid ${M.line}`,
+                  position: "relative",
+                  boxShadow: tier.highlight
+                    ? `0 12px 40px ${BRAND_SHADOW_TINT}`
+                    : "none",
+                  height: "100%",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                {tier.highlight && (
+                  <div
+                    style={{
+                      position: "absolute",
+                      top: -11,
+                      left: "50%",
+                      transform: "translateX(-50%)",
+                      background: BRAND,
+                      color: "#fff",
+                      fontSize: 10,
+                      fontWeight: 700,
+                      padding: "3px 12px",
+                      borderRadius: 100,
+                    }}
+                  >
+                    MOST COMMON
+                  </div>
+                )}
+                <div className="zdb-pricing-card-header">
+                  <div
+                    style={{
+                      fontSize: 13,
+                      fontWeight: 800,
+                      color: "#000",
+                      marginBottom: 8,
+                    }}
+                  >
+                    {tier.name}
+                  </div>
+                  <div
+                    style={{
+                      fontSize: 12,
+                      color: "#555",
+                      marginBottom: 20,
+                      fontWeight: 500,
+                    }}
+                  >
+                    Annual license
+                  </div>
+                </div>
+                <ul
+                  className="zdb-pricing-card-body"
+                  style={{
+                    listStyle: "none",
+                    padding: 0,
+                    margin: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 10,
+                    flex: 1,
+                  }}
+                >
+                  {tier.features.map((f) => (
+                    <li
+                      key={f}
+                      style={{
+                        fontSize: 13.5,
+                        color: "#000",
+                        display: "flex",
+                        gap: 8,
+                        fontWeight: 500,
+                      }}
+                    >
+                      <span
+                        style={{
+                          color: "#16a34a",
+                          fontWeight: 800,
+                          flexShrink: 0,
+                        }}
+                      >
+                        ✓
+                      </span>{" "}
+                      {f}
+                    </li>
+                  ))}
+                </ul>
+                <div
+                  className="zdb-pricing-card-footer"
+                  style={{ marginTop: "auto", paddingTop: 20 }}
+                >
+                  <a
+                    href={tier.href}
+                    style={{
+                      display: "block",
+                      textAlign: "center" as const,
+                      padding: "11px",
+                      borderRadius: 10,
+                      textDecoration: "none",
+                      fontWeight: 600,
+                      fontSize: 14,
+                      background: tier.highlight ? BRAND : "#fff",
+                      color: tier.highlight ? "#fff" : "#000",
+                      border: tier.highlight ? "none" : `1px solid ${M.line}`,
+                    }}
+                  >
+                    {tier.cta}
+                  </a>
+                  <div
+                    style={{ minHeight: 40, marginTop: 8 }}
+                    aria-hidden="true"
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* FAQ */}
+      <section
+        className="ent-section"
+        style={{ padding: "80px 40px", background: "#fff" }}
+      >
+        <div style={container(760)}>
+          <p style={sectionTitle}>FAQ</p>
+          <h2 style={{ ...lightH2, marginBottom: 32 }}>
+            Common enterprise questions
+          </h2>
+
+          <div
+            style={{
+              border: `1px solid ${M.line}`,
+              borderRadius: 12,
+              overflow: "hidden",
+            }}
+          >
+            {FAQ_ITEMS.map((item, i) => (
+              <div key={i} className="faq-item">
+                <button
+                  type="button"
+                  onClick={() => setOpenFaq(openFaq === i ? null : i)}
+                  style={{
+                    width: "100%",
+                    textAlign: "left" as const,
+                    padding: "18px 20px",
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                    display: "flex",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    fontSize: 15,
+                    fontWeight: 600,
+                    color: "#000",
+                  }}
+                >
+                  {item.q}
+                  <span style={{ fontSize: 18, color: "#555", flexShrink: 0 }}>
+                    {openFaq === i ? "-" : "+"}
+                  </span>
+                </button>
+                {openFaq === i && (
+                  <div
+                    style={{
+                      padding: "0 20px 18px",
+                      fontSize: 14,
+                      color: "#444",
+                      lineHeight: 1.7,
+                      fontWeight: 500,
+                    }}
+                  >
+                    {item.a}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* Contact form */}
+      <section
+        id="contact"
+        className="ent-section"
+        style={{
+          padding: "80px 40px",
+          background: M.wash,
+          scrollMarginTop: 72,
+        }}
+      >
+        <div style={container(600)}>
+          <p style={sectionTitle}>Get started</p>
+          <h2 style={h2}>Ready to deploy in your VPC?</h2>
+          <p style={{ ...lead, marginBottom: 36 }}>
+            Tell us about your agent fleet. We will map a 4 week install path or
+            point you to managed cloud.
+          </p>
+
+          <EnterpriseConnectForm />
+
+          <div
+            className="ent-hero-btns"
+            style={{
+              display: "flex",
+              gap: 12,
+              marginTop: 20,
+              justifyContent: "center",
+              flexWrap: "wrap",
+            }}
+          >
+            <button
+              type="button"
+              onClick={() => setDemoOpen(true)}
+              style={{ ...outlineBtn, cursor: "pointer" }}
+            >
+              Book demo
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* Technical resources */}
+      <section
+        className="ent-section"
+        style={{
+          padding: "72px 40px",
+          background: "#fff",
+          borderTop: `1px solid ${M.line}`,
+        }}
+      >
+        <div style={container(860)}>
+          <p style={sectionTitle}>Technical resources</p>
+          <h2 style={{ ...lightH2, marginBottom: 32 }}>
+            For engineering and security review
+          </h2>
+
+          <div
+            className="ent-resource-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 12,
+            }}
+          >
+            {[
+              {
+                label: "Overview",
+                sub: "What ZizkaDB is and how it fits",
+                href: "/docs",
+              },
+              {
+                label: "Technical reference",
+                sub: "Architecture, APIs, data model",
+                href: "/docs",
+              },
+              {
+                label: "Security",
+                sub: "TLS, tenant isolation, GDPR",
+                href: "/trust",
+              },
+              {
+                label: "EU AI Act",
+                sub: "Article mapping and controls",
+                href: "/eu-ai-act",
+              },
+              {
+                label: "Integrity",
+                sub: "Checksums and retention",
+                href: "/trust",
+              },
+              {
+                label: "Deployment modes",
+                sub: "Self-host, managed, Enterprise VPC",
+                href: "/docs",
+              },
+              { label: "Licensing", sub: "AGPL vs commercial", href: "/docs" },
+              {
+                label: "API reference",
+                sub: "REST explorer",
+                href: "/api-explorer",
+              },
+              {
+                label: "Documentation",
+                sub: "SDK, MCP, integration guides",
+                href: "/docs",
+              },
+              {
+                label: "Open source",
+                sub: "AGPL core on GitHub",
+                href: GITHUB_URL,
+              },
+            ].map((res) => (
+              <a
+                key={res.label}
+                href={res.href}
+                target={res.href.startsWith("http") ? "_blank" : undefined}
+                rel={res.href.startsWith("http") ? "noreferrer" : undefined}
+                style={{
+                  padding: "16px 18px",
+                  borderRadius: 10,
+                  background: M.wash,
+                  border: `1px solid ${M.line}`,
+                  textDecoration: "none",
+                  display: "block",
+                }}
+              >
+                <div
+                  style={{
+                    fontSize: 14,
+                    fontWeight: 700,
+                    color: "#000",
+                    marginBottom: 4,
+                  }}
+                >
+                  {res.label}
+                </div>
+                <div style={{ fontSize: 12, color: "#555", fontWeight: 500 }}>
+                  {res.sub}
+                </div>
+              </a>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <MarketingFooter />
+    </div>
+  );
+}

--- a/dashboard/app/eu-ai-act/page.tsx
+++ b/dashboard/app/eu-ai-act/page.tsx
@@ -1,0 +1,647 @@
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+import { SiteNav } from "@/components/SiteNav";
+import { MarketingFooter } from "@/components/marketing/MarketingFooter";
+import { BRAND, BRAND_DARK, BRAND_PALE } from "@/components/brand";
+import { FOUNDER_EMAIL } from "@/lib/constants";
+
+export const metadata = {
+  title: "EU AI Act Compliance",
+  description:
+    "How ZizkaDB's causal logging, traceability, and human-oversight tooling support EU AI Act (Regulation (EU) 2024/1689) conformity for providers and deployers of AI agent systems.",
+};
+
+const p: CSSProperties = {
+  fontSize: 15,
+  color: "#444",
+  lineHeight: 1.75,
+  margin: "0 0 14px",
+};
+const ul: CSSProperties = {
+  margin: "0 0 14px",
+  paddingLeft: 22,
+  fontSize: 15,
+  color: "#444",
+  lineHeight: 1.8,
+};
+const h3: CSSProperties = {
+  fontSize: 15,
+  fontWeight: 600,
+  margin: "24px 0 10px",
+  color: "#222",
+};
+const codeInline: CSSProperties = {
+  fontFamily: "monospace",
+  fontSize: 12.5,
+  background: "#f5f5f5",
+  padding: "2px 6px",
+  borderRadius: 4,
+};
+const link: CSSProperties = { color: "#111", fontWeight: 500 };
+const table: CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontSize: 14,
+  margin: "12px 0",
+};
+const th: CSSProperties = {
+  textAlign: "left",
+  padding: "10px 12px",
+  borderBottom: "2px solid #eee",
+  color: "#333",
+  fontWeight: 600,
+  fontSize: 13,
+};
+const td: CSSProperties = {
+  padding: "10px 12px",
+  borderBottom: "1px solid #f0f0f0",
+  color: "#444",
+  verticalAlign: "top",
+};
+const infoCard: CSSProperties = {
+  padding: "20px 22px",
+  borderRadius: 12,
+  background: "#fafafa",
+  border: "1px solid #ebebeb",
+};
+const techTag: CSSProperties = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: "#333",
+  background: "#fff",
+  border: "1px solid #e5e5e5",
+  borderRadius: 100,
+  padding: "4px 10px",
+};
+const articleBadge: CSSProperties = {
+  display: "inline-block",
+  fontSize: 12,
+  fontWeight: 700,
+  color: BRAND_DARK,
+  background: BRAND_PALE + "40",
+  border: `1px solid ${BRAND_PALE}`,
+  borderRadius: 6,
+  padding: "2px 8px",
+  width: "fit-content",
+};
+const disclaimerBox: CSSProperties = {
+  padding: "16px 18px",
+  borderRadius: 10,
+  background: "#fffbeb",
+  border: "1px solid #fde68a",
+  fontSize: 13.5,
+  color: "#92400e",
+  lineHeight: 1.7,
+  fontWeight: 500,
+};
+const primaryLinkBtn: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "12px 22px",
+  background: `linear-gradient(135deg, ${BRAND} 0%, ${BRAND_DARK} 100%)`,
+  color: "#fff",
+  borderRadius: 10,
+  textDecoration: "none",
+  fontWeight: 600,
+  fontSize: 14,
+  boxShadow: "0 4px 18px rgba(249,115,22,0.3)",
+};
+const outlineLinkBtn: CSSProperties = {
+  display: "inline-flex",
+  alignItems: "center",
+  justifyContent: "center",
+  padding: "12px 22px",
+  background: "#fff",
+  color: "#111",
+  borderRadius: 10,
+  textDecoration: "none",
+  fontWeight: 600,
+  fontSize: 14,
+  border: "1px solid #e5e5e5",
+};
+
+const SECTIONS = [
+  { id: "overview", label: "Overview" },
+  { id: "compliance-mapping", label: "Article mapping" },
+  { id: "architecture", label: "Architecture & distribution" },
+  { id: "data-protection", label: "Data protection & GDPR" },
+  { id: "disclaimer", label: "Important disclaimer" },
+  { id: "faq", label: "FAQ" },
+  { id: "contact", label: "Contact" },
+] as const;
+
+type ComplianceRow = {
+  requirement: string;
+  articles: string[];
+  detail: ReactNode;
+};
+
+const COMPLIANCE_ROWS: ComplianceRow[] = [
+  {
+    requirement: "Automatic logging & traceability",
+    articles: ["Art. 12", "Art. 26(5)–(6)"],
+    detail: (
+      <>
+        Agents log every event continuously, and sessions reconstruct
+        complete timelines. Configurable, per-tenant log retention supports
+        ongoing deployer monitoring on self-hosted or managed deployments.
+      </>
+    ),
+  },
+  {
+    requirement: "Evidence for risk assessment & post-market monitoring",
+    articles: ["Art. 12(2)", "Art. 72", "Art. 79"],
+    detail: (
+      <>
+        Causal lineage (<code style={codeInline}>why()</code>), behavioral
+        baselines, and drift signals help detect operational anomalies,
+        investigate incidents, and support post-market monitoring and risk
+        management processes.
+      </>
+    ),
+  },
+  {
+    requirement: "Transparency for deployers",
+    articles: ["Art. 13"],
+    detail: (
+      <>
+        Dashboards, APIs, SDKs, semantic search, and point-in-time retrieval
+        (<code style={codeInline}>at()</code>) make agent behavior fully
+        inspectable — avoiding opaque, vendor-managed memory stores.
+      </>
+    ),
+  },
+  {
+    requirement: "Human oversight",
+    articles: ["Art. 14", "Art. 26"],
+    detail: (
+      <>
+        Operators can inspect full action chains, reconstruct system state at
+        any point in time, identify behavioral drift, and intervene using
+        evidence rather than screenshots or manual records.
+      </>
+    ),
+  },
+  {
+    requirement: "Technical documentation & conformity evidence",
+    articles: ["Art. 11", "Arts. 8–9, 17"],
+    detail: (
+      <>
+        Logged histories provide auditable evidence that supports technical
+        documentation and compliance reporting. ZizkaDB complements — it does
+        not replace — formal risk management or notified-body assessments.
+      </>
+    ),
+  },
+  {
+    requirement: "Accuracy, robustness & cybersecurity",
+    articles: ["Art. 15"],
+    detail: (
+      <>
+        Tenant isolation, scoped API keys, tamper-evident event checksums,
+        and self-hosted / VPC deployment options strengthen the security and
+        operational integrity of your AI system.
+      </>
+    ),
+  },
+  {
+    requirement: "Personal data management alongside the AI Act",
+    articles: ["GDPR"],
+    detail: (
+      <>
+        Operated by an EU entity with a published privacy policy,{" "}
+        <code style={codeInline}>forget()</code> erasure across events and
+        vectors, marketing opt-out controls, and self-hosting options to
+        support data-residency requirements.
+      </>
+    ),
+  },
+];
+
+const FAQ_ITEMS = [
+  {
+    q: "Does using ZizkaDB make our AI system “AI Act compliant”?",
+    a: "No single tool grants full compliance. ZizkaDB provides record-keeping, traceability, and human-oversight evidence that support your broader compliance program — it doesn't replace risk classification, a quality management system, or a conformity assessment.",
+  },
+  {
+    q: "Is ZizkaDB a substitute for a formal risk assessment?",
+    a: "No. ZizkaDB supplies the operational evidence (logs, causal chains, drift signals) that a risk assessment or post-market monitoring process can draw on. The assessment itself still requires your own governance process, and for high-risk systems, qualified legal and technical review.",
+  },
+  {
+    q: "Which AI Act obligations does ZizkaDB primarily help with?",
+    a: "Mainly record-keeping (Article 12), transparency for deployers (Article 13), human oversight (Article 14), and deployer monitoring duties (Article 26). See the article mapping above for the full picture.",
+  },
+  {
+    q: "Where is our data stored?",
+    a: "It depends on your deployment: self-hosted keeps everything in your own infrastructure, managed cloud runs on infrastructure operated by ZIZKA AI S.L. (an EU entity), and Enterprise VPC deploys single-tenant inside your own cloud account.",
+  },
+  {
+    q: "How do we exercise erasure rights under GDPR?",
+    a: "Call forget() with a metadata filter, or use the dashboard. It deletes matching events and their vector embeddings together, not just the primary record.",
+  },
+];
+
+export default function EuAiActPage() {
+  return (
+    <div
+      style={{
+        fontFamily: "Inter, system-ui, sans-serif",
+        color: "#111",
+        background: "#fff",
+        minHeight: "100vh",
+      }}
+    >
+      <SiteNav suffix="EU AI Act" />
+
+      <div style={{ display: "flex", maxWidth: 1100, margin: "0 auto" }}>
+        <aside
+          style={{
+            width: 220,
+            flexShrink: 0,
+            padding: "32px 16px",
+            position: "sticky",
+            top: 56,
+            height: "calc(100vh - 56px)",
+            overflowY: "auto",
+            borderRight: "1px solid #f0f0f0",
+            display: "none",
+          }}
+          className="ai-act-sidebar"
+        >
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: "#aaa",
+              letterSpacing: 1,
+              textTransform: "uppercase",
+              marginBottom: 10,
+            }}
+          >
+            On this page
+          </div>
+          {SECTIONS.map((s) => (
+            <a
+              key={s.id}
+              href={`#${s.id}`}
+              style={{
+                display: "block",
+                fontSize: 13,
+                color: "#555",
+                textDecoration: "none",
+                padding: "6px 10px",
+                borderRadius: 6,
+                marginBottom: 2,
+              }}
+            >
+              {s.label}
+            </a>
+          ))}
+        </aside>
+
+        <main
+          style={{
+            flex: 1,
+            maxWidth: 820,
+            padding: "48px 28px 96px",
+            minWidth: 0,
+          }}
+        >
+          <div
+            style={{
+              display: "inline-block",
+              fontSize: 11,
+              fontWeight: 800,
+              letterSpacing: 1.2,
+              textTransform: "uppercase",
+              color: BRAND_DARK,
+              marginBottom: 16,
+              padding: "5px 14px",
+              background: `${BRAND}14`,
+              borderRadius: 6,
+            }}
+          >
+            Regulation (EU) 2024/1689
+          </div>
+          <h1
+            style={{
+              fontSize: 34,
+              fontWeight: 700,
+              letterSpacing: -0.6,
+              margin: "0 0 12px",
+              lineHeight: 1.2,
+            }}
+          >
+            ZizkaDB supports EU AI Act compliance
+          </h1>
+          <p
+            style={{
+              fontSize: 17,
+              color: "#444",
+              lineHeight: 1.75,
+              marginBottom: 28,
+            }}
+          >
+            ZizkaDB is built and operated by an EU entity, ZIZKA AI S.L.
+            (Málaga, Spain). Its causal event log, human-oversight tooling,
+            and data-erasure controls are designed to give providers and
+            deployers of AI agent systems the operational evidence the EU AI
+            Act expects — without becoming a compliance program in itself.
+          </p>
+
+          <div
+            style={{
+              display: "flex",
+              gap: 12,
+              flexWrap: "wrap",
+              marginBottom: 48,
+            }}
+          >
+            <a href="#compliance-mapping" style={primaryLinkBtn}>
+              View article mapping
+            </a>
+            <Link href="/enterprise#contact" style={outlineLinkBtn}>
+              Talk to us
+            </Link>
+          </div>
+
+          <Section id="overview" title="Overview" first>
+            <p style={p}>
+              The EU AI Act (Regulation (EU) 2024/1689) entered into force in
+              August 2024, with obligations phasing in through 2026–2027
+              depending on a system&apos;s risk classification. It places
+              record-keeping, transparency, and human-oversight duties on
+              providers and deployers of AI systems — obligations that are
+              hardest to meet when an agent&apos;s decision history lives only in
+              scattered application logs.
+            </p>
+            <p style={p}>
+              ZizkaDB stores every agent decision, tool call, and outcome as
+              a causally-linked event. Because that history is queryable,
+              inspectable, and erasable by design, it maps directly onto
+              several of the Act&apos;s technical requirements — summarized
+              below.
+            </p>
+          </Section>
+
+          <Section id="compliance-mapping" title="Article mapping">
+            <p style={p}>
+              How ZizkaDB&apos;s existing capabilities relate to specific AI Act
+              provisions. Citations are the relevant articles to review with
+              your legal team, not an exhaustive compliance checklist.
+            </p>
+            <div style={{ overflowX: "auto" }}>
+              <table style={table}>
+                <thead>
+                  <tr>
+                    <th style={{ ...th, width: "26%" }}>Requirement</th>
+                    <th style={{ ...th, width: "18%" }}>Articles</th>
+                    <th style={th}>How ZizkaDB supports it</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {COMPLIANCE_ROWS.map((row) => (
+                    <tr key={row.requirement}>
+                      <td style={{ ...td, fontWeight: 600 }}>
+                        {row.requirement}
+                      </td>
+                      <td style={td}>
+                        <div
+                          style={{
+                            display: "flex",
+                            flexDirection: "column",
+                            gap: 4,
+                          }}
+                        >
+                          {row.articles.map((a) => (
+                            <span key={a} style={articleBadge}>
+                              {a}
+                            </span>
+                          ))}
+                        </div>
+                      </td>
+                      <td style={td}>{row.detail}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Section>
+
+          <Section id="architecture" title="Architecture & distribution">
+            <p style={p}>
+              The same open-core engine runs across every deployment mode, so
+              the compliance posture above holds whether you self-host or use
+              managed cloud.
+            </p>
+            <div
+              className="ai-act-arch-grid"
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr 1fr",
+                gap: 16,
+                margin: "20px 0 8px",
+              }}
+            >
+              <div style={infoCard}>
+                <h3 style={{ ...h3, marginTop: 0 }}>Operational database</h3>
+                <ul style={ul}>
+                  <li>Model agnostic — works with any LLM provider</li>
+                  <li>Pre-built embeddings pipeline for semantic search</li>
+                </ul>
+                <div
+                  style={{
+                    fontSize: 12,
+                    fontWeight: 600,
+                    color: "#888",
+                    textTransform: "uppercase",
+                    letterSpacing: 0.5,
+                    margin: "16px 0 8px",
+                  }}
+                >
+                  Built with time-tested engines
+                </div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+                  {["PostgreSQL", "pgvector", "Qdrant", "Ollama (self-hosted)"].map(
+                    (tag) => (
+                      <span key={tag} style={techTag}>
+                        {tag}
+                      </span>
+                    )
+                  )}
+                </div>
+              </div>
+
+              <div style={infoCard}>
+                <h3 style={{ ...h3, marginTop: 0 }}>Distribution</h3>
+                <ul style={ul}>
+                  <li>Self-hosted SDKs — Python, npm, MCP, LangChain, CrewAI</li>
+                  <li>Managed cloud — Pro and Team plans</li>
+                  <li>Design partnerships for SMEs</li>
+                  <li>
+                    AGPL-3.0 license, with a commercial{" "}
+                    <Link href="/enterprise" style={link}>
+                      Enterprise
+                    </Link>{" "}
+                    license (VPC deployment + SLA) for organizations that
+                    need it
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </Section>
+
+          <Section id="data-protection" title="Data protection & GDPR">
+            <p style={p}>
+              The AI Act&apos;s record-keeping duties sit alongside your existing
+              GDPR obligations, not in place of them. ZizkaDB is built to
+              satisfy both together:
+            </p>
+            <ul style={ul}>
+              <li>
+                Operated by an EU entity, ZIZKA AI S.L. (Málaga, Spain), under
+                a published{" "}
+                <Link href="/privacy" style={link}>
+                  privacy policy
+                </Link>
+              </li>
+              <li>
+                <code style={codeInline}>forget()</code> deletes matching
+                events and their vector embeddings together, by metadata
+                filter
+              </li>
+              <li>Marketing opt-out controls for contacts stored in ZizkaDB</li>
+              <li>
+                Self-hosting and Enterprise VPC options for organizations with
+                data-residency requirements
+              </li>
+            </ul>
+          </Section>
+
+          <Section id="disclaimer" title="Important disclaimer">
+            <div style={disclaimerBox}>
+              This page explains how ZizkaDB&apos;s existing features can support
+              your organization&apos;s EU AI Act conformity work. It is general
+              product information, not legal advice, and does not by itself
+              constitute a conformity assessment, a Quality Management
+              System, or CE marking. Your actual obligations depend on your
+              AI system&apos;s risk classification and your role as provider or
+              deployer (Art. 6, Annex III) — consult qualified legal counsel
+              to confirm what applies to your organization.
+            </div>
+          </Section>
+
+          <Section id="faq" title="FAQ">
+            <div
+              style={{
+                border: "1px solid #eee",
+                borderRadius: 12,
+                overflow: "hidden",
+              }}
+            >
+              {FAQ_ITEMS.map((item, i) => (
+                <details
+                  key={item.q}
+                  className="ai-act-faq-item"
+                  style={{
+                    borderBottom:
+                      i === FAQ_ITEMS.length - 1 ? "none" : "1px solid #eee",
+                  }}
+                >
+                  <summary
+                    style={{
+                      padding: "16px 18px",
+                      fontSize: 14.5,
+                      fontWeight: 600,
+                      cursor: "pointer",
+                      listStyle: "none",
+                    }}
+                  >
+                    {item.q}
+                  </summary>
+                  <div style={{ padding: "0 18px 16px" }}>
+                    <p style={{ ...p, margin: 0 }}>{item.a}</p>
+                  </div>
+                </details>
+              ))}
+            </div>
+          </Section>
+
+          <Section id="contact" title="Contact">
+            <p style={p}>
+              Questions about how ZizkaDB fits your compliance program, or
+              need a signed DPA for procurement?
+            </p>
+            <table style={table}>
+              <tbody>
+                {[
+                  ["Enterprise & compliance", "/enterprise#contact"],
+                  ["Privacy policy", "/privacy"],
+                  ["Email", `mailto:${FOUNDER_EMAIL}`],
+                ].map(([k, v]) => (
+                  <tr key={k}>
+                    <td style={{ ...td, width: "34%", fontWeight: 500 }}>
+                      {k}
+                    </td>
+                    <td style={td}>
+                      <a href={v} style={link}>
+                        {k === "Email" ? FOUNDER_EMAIL : v}
+                      </a>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Section>
+        </main>
+      </div>
+
+      <MarketingFooter />
+
+      <style>{`
+        @media (min-width: 900px) {
+          .ai-act-sidebar { display: block !important; }
+        }
+        @media (max-width: 640px) {
+          .ai-act-arch-grid { grid-template-columns: 1fr !important; }
+        }
+        .ai-act-faq-item summary::-webkit-details-marker { display: none; }
+        .ai-act-faq-item summary:focus-visible {
+          outline: 2px solid ${BRAND};
+          outline-offset: -2px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function Section({
+  id,
+  title,
+  first,
+  children,
+}: {
+  id: string;
+  title: string;
+  first?: boolean;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} style={{ marginBottom: 56, scrollMarginTop: 72 }}>
+      <h2
+        style={{
+          fontSize: 22,
+          fontWeight: 700,
+          marginBottom: 16,
+          letterSpacing: -0.3,
+          paddingTop: first ? 0 : 8,
+          borderTop: first ? "none" : "1px solid #f0f0f0",
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}

--- a/dashboard/app/layout.tsx
+++ b/dashboard/app/layout.tsx
@@ -1,9 +1,17 @@
 import type { Metadata } from 'next'
 import './globals.css'
+import { CookiePrivacyConsent } from '@/components/CookiePrivacyConsent'
+import { MarketingSubscribePopup } from '@/components/MarketingSubscribePopup'
 
 const TAGLINE =
-  "Operational database for AI agents. Open source — self-host free.";
-const SITE_URL = process.env.DASHBOARD_URL || "http://localhost:3001";
+  "Operational Database For AI Agents. Open source. Self-host free or managed cloud.";
+const SITE_URL = process.env.DASHBOARD_URL || "https://db.zizka.ai";
+
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+};
 
 export const metadata: Metadata = {
   title: {
@@ -45,7 +53,11 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        {children}
+        <CookiePrivacyConsent />
+        <MarketingSubscribePopup />
+      </body>
     </html>
   );
 }

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -1,154 +1,476 @@
+"use client";
+
 import Link from "next/link";
+import { IntegrationStrip } from "@/components/marketing/IntegrationStrip";
+import { CompetitorCompare } from "@/components/marketing/CompetitorCompare";
+import { ConversationCompare } from "@/components/marketing/ConversationCompare";
+import { TrustBar } from "@/components/marketing/TrustBar";
+import { MarketingShell } from "@/components/marketing/MarketingShell";
+import { HeroOperationalField } from "@/components/marketing/HeroOperationalField";
+import { LiveDashboardDemo } from "@/components/marketing/LiveDashboardDemo";
+import { PricingCard } from "@/components/marketing/PricingCard";
+import { LANDING_PRICING_PLANS } from "@/components/marketing/pricing-plans";
+import { BRAND } from "@/components/brand";
+import {
+  M,
+  container,
+  h2,
+  lead,
+  sectionTitle,
+  primaryBtn,
+  secondaryBtn,
+  ghostBtn,
+  outlineBtn,
+  card,
+} from "@/components/marketing/marketing-theme";
+import { GITHUB_URL } from "@/lib/constants";
+import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
-/**
- * Self-host product landing (OSS). Marketing site lives on managed cloud only.
- */
-export default function HomePage() {
+const HERO_TITLE = "Dont Observe - Audit your AI Agent";
+const HERO_VALUE =
+  "When production agents drift, guesswork costs hours. ZizkaDB gives you replay, lineage, and drift alerts so you fix behavior before users notice.";
+
+const MCP_CONFIG = `{
+  "mcpServers": {
+    "zizkadb": {
+      "command": "uvx",
+      "args": ["zizkadb-mcp"],
+      "env": { "ZIZKADB_API_KEY": "zizkadb_live_xxxx" }
+    }
+  }
+}`;
+
+const WHY_BOXES = [
+  {
+    label: "How agents fail in prod",
+    accent: M.danger,
+    items: [
+      "Prompt tweaks silently change decisions",
+      "Tool calls skip policy without anyone noticing",
+      "Same question, different answers across sessions",
+      "Logs show what happened — not why",
+    ],
+  },
+  {
+    label: "What that costs you",
+    accent: BRAND,
+    items: [
+      "Wrong answers reach customers",
+      "Engineering burns time on blind debugging",
+      "Token spend climbs as agents retry",
+      "Trust erodes before you find root cause",
+    ],
+  },
+  {
+    label: "With ZizkaDB",
+    accent: M.success,
+    items: [
+      "Replay any session end-to-end",
+      "Measure drift against your baseline",
+      "Trace decisions with causal lineage",
+      "Catch regressions before they ship",
+    ],
+  },
+];
+
+export default function LandingPage() {
+  const { copied, copy } = useCopyToClipboard();
+
   return (
-    <main
-      style={{
-        minHeight: "100vh",
-        background: "linear-gradient(165deg, #0a0a0a 0%, #111 45%, #0c1a12 100%)",
-        color: "#f5f5f5",
-        fontFamily:
-          "ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif",
-        padding: "48px 24px 64px",
-      }}
-    >
-      <div style={{ maxWidth: 720, margin: "0 auto" }}>
-        <p
-          style={{
-            fontSize: 12,
-            letterSpacing: "0.14em",
-            textTransform: "uppercase",
-            color: "#86efac",
-            marginBottom: 16,
-            fontWeight: 600,
-          }}
-        >
-          ZizkaDB · Open source
-        </p>
-        <h1
-          style={{
-            fontSize: "clamp(2rem, 5vw, 3rem)",
-            lineHeight: 1.15,
-            fontWeight: 700,
-            margin: "0 0 16px",
-            letterSpacing: "-0.02em",
-          }}
-        >
-          Know why your agent did that.
-        </h1>
-        <p style={{ fontSize: 18, lineHeight: 1.6, color: "#a3a3a3", marginBottom: 32 }}>
-          Causal lineage, time-travel state, and a fleet dashboard for AI agents.
-          This repository is the <strong style={{ color: "#e5e5e5" }}>product runtime</strong> —
-          self-host on your machine. Managed cloud marketing and operator tools are not included.
-        </p>
+    <MarketingShell active="home">
+      {/* Hero */}
+      <section
+        className="zdb-section"
+        style={{
+          padding: "88px 40px 72px",
+          position: "relative",
+          overflow: "hidden",
+          background: "#000000",
+          borderBottom: `1px solid ${M.line}`,
+        }}
+      >
+        <HeroOperationalField />
+        <div style={{ ...container(820), textAlign: "center", position: "relative", zIndex: 2 }}>
+          <p style={{ ...sectionTitle, marginBottom: 16 }} className="zdb-section-title">
+            Operational intelligence for AI agents
+          </p>
+          <h1
+            className="zdb-hero-title"
+            style={{
+              fontSize: 48,
+              fontWeight: 800,
+              lineHeight: 1.1,
+              margin: "0 0 20px",
+              letterSpacing: -0.9,
+              color: M.ink,
+            }}
+          >
+            {HERO_TITLE}
+          </h1>
+          <p
+            className="zdb-hero-value"
+            style={{
+              fontSize: 18,
+              color: M.muted,
+              margin: "0 auto 36px",
+              lineHeight: 1.65,
+              maxWidth: 560,
+            }}
+          >
+            {HERO_VALUE}
+          </p>
 
-        <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginBottom: 40 }}>
-          <Link
-            href="/login"
+          <div
+            className="zdb-hero-btns"
             style={{
-              display: "inline-block",
-              background: "#22c55e",
-              color: "#0a0a0a",
-              fontWeight: 700,
-              padding: "12px 20px",
-              borderRadius: 10,
-              textDecoration: "none",
-              fontSize: 14,
+              display: "flex",
+              gap: 12,
+              flexWrap: "wrap",
+              justifyContent: "center",
+              marginBottom: 48,
             }}
           >
-            Open dashboard
-          </Link>
-          <a
-            href="https://github.com/Zizka-ai/ZizkaDB"
-            target="_blank"
-            rel="noreferrer"
-            style={{
-              display: "inline-block",
-              border: "1px solid #333",
-              color: "#e5e5e5",
-              fontWeight: 600,
-              padding: "12px 20px",
-              borderRadius: 10,
-              textDecoration: "none",
-              fontSize: 14,
-            }}
-          >
-            GitHub
-          </a>
-          <a
-            href="https://github.com/Zizka-ai/ZizkaDB/wiki"
-            target="_blank"
-            rel="noreferrer"
-            style={{
-              display: "inline-block",
-              border: "1px solid #333",
-              color: "#e5e5e5",
-              fontWeight: 600,
-              padding: "12px 20px",
-              borderRadius: 10,
-              textDecoration: "none",
-              fontSize: 14,
-            }}
-          >
-            Wiki
-          </a>
+            <Link href="/signup" style={primaryBtn}>
+              Use managed cloud
+            </Link>
+            <a
+              href={GITHUB_URL}
+              target="_blank"
+              rel="noreferrer"
+              style={secondaryBtn}
+            >
+              Self-host open source
+            </a>
+          </div>
+
+          <div style={{ marginTop: 8 }}>
+            <IntegrationStrip dark />
+          </div>
         </div>
+      </section>
 
+      {/* Dual path + live demo */}
+      <section
+        className="zdb-section"
+        style={{ padding: "80px 40px", background: M.bgElevated }}
+      >
+        <div style={container(1100)}>
+          <p style={sectionTitle}>Two ways to run ZizkaDB</p>
+          <h2 className="zdb-section-h2" style={h2}>Same product. Your infrastructure or ours.</h2>
+          <p className="zdb-lead" style={{ ...lead, marginBottom: 48 }}>
+            Explore the dashboard your team gets — self-host the OSS stack or use managed cloud with Fleet.
+          </p>
+
+          <div
+            className="zdb-split"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr",
+              gap: 28,
+              alignItems: "start",
+            }}
+          >
+            <div>
+              <h3 style={{ fontSize: 18, fontWeight: 700, color: M.ink, margin: "0 0 8px" }}>
+                Open source
+              </h3>
+              <p style={{ fontSize: 14, color: M.muted, margin: "0 0 16px", lineHeight: 1.6 }}>
+                Docker Compose on your infra. Activity, Behavior, Reports, and Suggestions out of the box.
+              </p>
+              <LiveDashboardDemo variant="oss" autoRotateMs={6000} />
+              <div style={{ marginTop: 16, display: "flex", gap: 10, flexWrap: "wrap" }}>
+                <Link href="/docs" style={{ ...outlineBtn, fontSize: 13 }}>
+                  Setup guide
+                </Link>
+                <a href={GITHUB_URL} target="_blank" rel="noreferrer" style={{ ...outlineBtn, fontSize: 13 }}>
+                  GitHub
+                </a>
+              </div>
+            </div>
+            <div>
+              <h3 style={{ fontSize: 18, fontWeight: 700, color: M.ink, margin: "0 0 8px" }}>
+                Managed cloud
+              </h3>
+              <p style={{ fontSize: 14, color: M.muted, margin: "0 0 16px", lineHeight: 1.6 }}>
+                Hosted on db.zizka.ai — includes Fleet ranking across agents and projects.
+              </p>
+              <LiveDashboardDemo variant="managed" autoRotateMs={6000} />
+              <div style={{ marginTop: 16 }}>
+                <Link href="/signup" style={{ ...primaryBtn, fontSize: 14, padding: "12px 22px" }}>
+                  Get started
+                </Link>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Why */}
+      <section className="zdb-section" style={{ padding: "80px 40px", background: M.bg }}>
+        <div style={container(1000)}>
+          <p style={sectionTitle}>Why ZizkaDB</p>
+          <h2 className="zdb-section-h2" style={h2}>Stop debugging agents in the dark.</h2>
+          <p className="zdb-lead" style={{ ...lead, marginBottom: 40 }}>
+            Production agents need operational data — not just logs. ZizkaDB monitors behavior so your team can correct it.
+          </p>
+
+          <div
+            className="zdb-why-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              gap: 20,
+            }}
+          >
+            {WHY_BOXES.map((box) => (
+              <div
+                key={box.label}
+                style={{
+                  ...card,
+                  padding: "28px 24px",
+                  display: "flex",
+                  flexDirection: "column",
+                }}
+              >
+                <div
+                  style={{
+                    display: "inline-block",
+                    fontSize: 11,
+                    fontWeight: 800,
+                    letterSpacing: 0.8,
+                    textTransform: "uppercase" as const,
+                    color: box.accent,
+                    marginBottom: 16,
+                    padding: "4px 10px",
+                    background: `${box.accent}18`,
+                    borderRadius: 6,
+                    alignSelf: "flex-start",
+                  }}
+                >
+                  {box.label}
+                </div>
+                <ul
+                  style={{
+                    listStyle: "none",
+                    padding: 0,
+                    margin: 0,
+                    display: "flex",
+                    flexDirection: "column",
+                    gap: 10,
+                  }}
+                >
+                  {box.items.map((item) => (
+                    <li
+                      key={item}
+                      style={{
+                        display: "flex",
+                        gap: 10,
+                        fontSize: 14,
+                        color: M.inkSoft,
+                        lineHeight: 1.55,
+                      }}
+                    >
+                      <span style={{ color: box.accent, fontWeight: 800, flexShrink: 0 }}>
+                        {box.accent === M.success ? "✓" : "·"}
+                      </span>
+                      {item}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <ConversationCompare />
+
+      {/* Integrate */}
+      <section className="zdb-section" style={{ padding: "88px 40px", background: M.bgElevated }}>
+        <div style={container(960)}>
+          <p style={sectionTitle}>For teams building with agents</p>
+          <h2 className="zdb-section-h2" style={h2}>Integrate in an afternoon. Debug in minutes.</h2>
+          <p className="zdb-lead" style={lead}>
+            Log from Python, TypeScript, MCP, or REST. One API key per agent — no heavy infra project.
+          </p>
+
+          <div
+            className="zdb-split zdb-split-3"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "1fr 1fr 1fr",
+              gap: 20,
+            }}
+          >
+            <FeatureCard
+              icon="⚙️"
+              title="Connect your stack"
+              body="Python SDK, TypeScript SDK, MCP, or REST. Self-host with Docker or use managed cloud."
+              actions={
+                <>
+                  <Link href="/docs" style={{ ...secondaryBtn, fontSize: 14, padding: "12px 20px" }}>
+                    5-minute setup
+                  </Link>
+                  <button
+                    type="button"
+                    onClick={() => copy(MCP_CONFIG)}
+                    style={{ ...outlineBtn, cursor: "pointer" }}
+                  >
+                    {copied ? "Copied MCP config" : "Copy MCP config"}
+                  </button>
+                </>
+              }
+            />
+            <FeatureCard
+              icon="🔍"
+              title="Debug production incidents"
+              body="Prompt change broke behavior? Replay the full session, trace the decision chain, find root cause."
+              actions={
+                <Link href="/signup" style={{ ...primaryBtn, fontSize: 14, padding: "12px 22px" }}>
+                  Get started
+                </Link>
+              }
+            />
+            <FeatureCard
+              icon="🏢"
+              title="Enterprise & private cloud"
+              body="Single-tenant VPC deployment with Fleet dashboard, workshops, and dedicated support."
+              actions={
+                <Link href="/enterprise" style={{ ...outlineBtn, fontSize: 14, padding: "12px 22px" }}>
+                  Explore Enterprise
+                </Link>
+              }
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Trust */}
+      <section className="zdb-section" style={{ padding: "72px 40px", background: M.bg }}>
+        <div style={container(960)}>
+          <p style={sectionTitle}>Trust and security</p>
+          <h2 className="zdb-section-h2" style={{ ...h2, marginBottom: 36 }}>Production-ready from day one</h2>
+          <TrustBar />
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section
+        id="pricing"
+        className="zdb-section zdb-section-anchor"
+        style={{ padding: "88px 40px", background: M.bgElevated }}
+      >
+        <div style={container(1120)}>
+          <p style={sectionTitle}>Pricing</p>
+          <h2 className="zdb-section-h2" style={h2}>Self-host free. Scale on cloud when you need to.</h2>
+          <p className="zdb-lead" style={lead}>Full monitoring and session replay on every plan.</p>
+
+          <div
+            className="zdb-price-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(4, 1fr)",
+              gap: 20,
+              alignItems: "stretch",
+            }}
+          >
+            {LANDING_PRICING_PLANS.map((plan) => (
+              <PricingCard key={plan.name} plan={plan} />
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <CompetitorCompare />
+
+      {/* Final CTA */}
+      <section
+        className="zdb-section"
+        style={{
+          padding: "88px 40px",
+          background: "#000000",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        <HeroOperationalField variant="subtle" />
         <div
           style={{
-            background: "#0a0a0a",
-            border: "1px solid #1f1f1f",
-            borderRadius: 14,
-            padding: "20px 22px",
+            ...container(600),
+            textAlign: "center",
+            position: "relative",
+            zIndex: 2,
           }}
         >
-          <div
+          <h2
+            className="zdb-final-cta-title zdb-section-h2"
             style={{
-              fontSize: 11,
-              letterSpacing: "0.1em",
-              textTransform: "uppercase",
-              color: "#737373",
-              marginBottom: 10,
+              fontSize: 36,
+              fontWeight: 700,
+              color: M.ink,
+              margin: "0 0 14px",
+              letterSpacing: -0.6,
+              lineHeight: 1.15,
             }}
           >
-            Quickstart
-          </div>
-          <pre
+            Fix behavior before production breaks
+          </h2>
+          <p
             style={{
-              margin: 0,
-              fontSize: 13,
-              lineHeight: 1.55,
-              color: "#86efac",
-              whiteSpace: "pre-wrap",
-              wordBreak: "break-word",
-              fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
+              fontSize: 17,
+              color: M.muted,
+              margin: "0 0 28px",
+              lineHeight: 1.65,
             }}
           >
-            {`curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash`}
-          </pre>
-          <p style={{ margin: "14px 0 0", fontSize: 13, color: "#737373", lineHeight: 1.5 }}>
-            Then open{" "}
-            <code style={{ color: "#a3a3a3" }}>http://localhost:3001/login</code>
+            Managed cloud on db.zizka.ai, or self-host the open source stack anytime.
           </p>
-        </div>
-
-        <p style={{ marginTop: 36, fontSize: 13, color: "#525252", lineHeight: 1.6 }}>
-          Want managed cloud?{" "}
-          <a href="https://db.zizka.ai" style={{ color: "#86efac" }}>
-            db.zizka.ai
-          </a>
-          {" "}· Prefer self-host docs?{" "}
-          <a
-            href="https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting"
-            style={{ color: "#86efac" }}
+          <div
+            className="zdb-cta-row"
+            style={{
+              display: "flex",
+              gap: 12,
+              justifyContent: "center",
+              flexWrap: "wrap",
+            }}
           >
-            Self-Hosting wiki
-          </a>
-        </p>
-      </div>
-    </main>
+            <Link href="/signup" style={primaryBtn}>
+              Use managed cloud
+            </Link>
+            <Link href="/docs" style={ghostBtn}>
+              Read the docs
+            </Link>
+            <a href={GITHUB_URL} target="_blank" rel="noreferrer" style={ghostBtn}>
+              GitHub
+            </a>
+          </div>
+        </div>
+      </section>
+    </MarketingShell>
+  );
+}
+
+function FeatureCard({
+  icon,
+  title,
+  body,
+  actions,
+}: {
+  icon: string;
+  title: string;
+  body: string;
+  actions: React.ReactNode;
+}) {
+  return (
+    <div className="zdb-feature-card" style={{ ...card, padding: "32px 28px" }}>
+      <div style={{ fontSize: 28, marginBottom: 16 }}>{icon}</div>
+      <h3 style={{ fontSize: 20, fontWeight: 700, margin: "0 0 10px", color: M.ink }}>
+        {title}
+      </h3>
+      <p style={{ fontSize: 15, color: M.muted, lineHeight: 1.65, margin: "0 0 20px" }}>
+        {body}
+      </p>
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>{actions}</div>
+    </div>
   );
 }

--- a/dashboard/app/privacy/page.tsx
+++ b/dashboard/app/privacy/page.tsx
@@ -1,0 +1,204 @@
+import type { Metadata } from 'next'
+import Link from 'next/link'
+import { LegalDocumentLayout, legalStyles as S } from '@/components/marketing/LegalDocumentLayout'
+
+export const metadata: Metadata = {
+  title: 'Privacy Policy',
+  description: 'Privacy policy for ZizkaDB and ZIZKA AI S.L. — GDPR-compliant data processing for managed cloud and website services.',
+}
+
+export default function PrivacyPolicyPage() {
+  return (
+    <LegalDocumentLayout title="Privacy Policy" updated="14 July 2026">
+      <p style={S.p}>
+        This Privacy Policy explains how <strong>ZIZKA AI S.L.</strong> (&quot;ZIZKA AI&quot;, &quot;we&quot;, &quot;us&quot;)
+        processes personal data when you use <strong>ZizkaDB</strong> at{' '}
+        <Link href="/" style={S.a}>db.zizka.ai</Link>, our managed cloud service, documentation, and related websites.
+        It is written to comply with the EU General Data Protection Regulation (GDPR) and applicable Spanish data protection law.
+      </p>
+
+      <h2 style={S.h2}>1. Data controller</h2>
+      <p style={S.p}>
+        <strong>ZIZKA AI S.L.</strong><br />
+        Málaga, Spain<br />
+        CIF B26956078<br />
+        Email: <a href="mailto:privacy@zizka.ai" style={S.a}>privacy@zizka.ai</a>
+      </p>
+      <p style={S.p}>
+        For data protection enquiries or to exercise your rights, contact us at the address above.
+        You may also contact <a href="mailto:founder@zizka.ai" style={S.a}>founder@zizka.ai</a>.
+      </p>
+
+      <h2 style={S.h2}>2. Scope of this policy</h2>
+      <p style={S.p}>This policy applies to:</p>
+      <ul style={S.ul}>
+        <li style={S.li}><strong>Managed cloud</strong> — accounts, API keys, dashboards, and billing at db.zizka.ai</li>
+        <li style={S.li}><strong>Website and marketing</strong> — pages, forms, demo requests, and optional newsletter subscriptions</li>
+        <li style={S.li}><strong>Support and sales contact</strong> — email and contact forms</li>
+      </ul>
+      <p style={S.p}>
+        <strong>Self-hosted ZizkaDB (OSS):</strong> If you run ZizkaDB on your own infrastructure, you are the{' '}
+        <em>data controller</em> for data stored in your instance. We do not access your self-hosted database unless
+        you voluntarily share logs or contact support. Open-source downloads and local Docker usage on your machine
+        are outside our control as controller.
+      </p>
+
+      <h2 style={S.h2}>3. Personal data we process</h2>
+      <p style={S.p}>Depending on how you use ZizkaDB, we may process:</p>
+      <ul style={S.ul}>
+        <li style={S.li}><strong>Account data</strong> — email address, name (if provided), tenant and user identifiers, authentication tokens</li>
+        <li style={S.li}><strong>Billing data</strong> — subscription plan, payment status; card details are processed by our payment provider (we do not store full card numbers)</li>
+        <li style={S.li}><strong>Operational / agent data</strong> — events, agent names, session metadata, and payloads you log via the API or SDK (this may include personal data if you choose to log it)</li>
+        <li style={S.li}><strong>Technical data</strong> — IP address, browser type, device information, API request logs, error reports</li>
+        <li style={S.li}><strong>Communications</strong> — messages you send via contact or enterprise forms</li>
+        <li style={S.li}><strong>Cookie / local storage data</strong> — consent preferences and session identifiers (see Section 9)</li>
+        <li style={S.li}><strong>Optional telemetry</strong> — anonymous SDK install metrics if not disabled (<code style={{ fontFamily: 'monospace', fontSize: 13 }}>ZIZKADB_TELEMETRY=false</code>)</li>
+      </ul>
+
+      <h2 style={S.h2}>4. Purposes and legal bases (GDPR Art. 6)</h2>
+      <ul style={S.ul}>
+        <li style={S.li}>
+          <strong>Provide the service</strong> (account, API, dashboard, support) —{' '}
+          <em>performance of a contract</em> (Art. 6(1)(b))
+        </li>
+        <li style={S.li}>
+          <strong>Billing and fraud prevention</strong> — <em>performance of a contract</em> and{' '}
+          <em>legitimate interests</em> (Art. 6(1)(b), (f))
+        </li>
+        <li style={S.li}>
+          <strong>Security, abuse prevention, and service reliability</strong> —{' '}
+          <em>legitimate interests</em> (Art. 6(1)(f))
+        </li>
+        <li style={S.li}>
+          <strong>Product improvement and aggregated analytics</strong> —{' '}
+          <em>legitimate interests</em>, where not overridden by your rights (Art. 6(1)(f))
+        </li>
+        <li style={S.li}>
+          <strong>Marketing communications</strong> (e.g. product updates you subscribe to) —{' '}
+          <em>consent</em> (Art. 6(1)(a)); you may withdraw at any time
+        </li>
+        <li style={S.li}>
+          <strong>Legal obligations</strong> — e.g. tax and accounting records (Art. 6(1)(c))
+        </li>
+      </ul>
+      <p style={S.p}>
+        Where we rely on legitimate interests, we balance our interests against your rights. You may object to
+        processing based on legitimate interests (see Section 8).
+      </p>
+
+      <h2 style={S.h2}>5. Agent and event data</h2>
+      <p style={S.p}>
+        ZizkaDB stores operational data about AI agents (events, causal links, embeddings for search, baselines).
+        <strong> You control what is logged.</strong> Do not log special category data (health, biometrics, etc.)
+        unless you have a lawful basis and appropriate safeguards. If you log personal data about third parties
+        (e.g. end users of your agents), you are responsible for providing notice and obtaining any required consents.
+      </p>
+
+      <h2 style={S.h2}>6. Processors and sub-processors</h2>
+      <p style={S.p}>
+        We use carefully selected service providers who process data on our instructions under data processing
+        agreements where required by GDPR:
+      </p>
+      <ul style={S.ul}>
+        <li style={S.li}><strong>Cloud infrastructure</strong> — hosting in the EU where practicable</li>
+        <li style={S.li}><strong>Stripe</strong> — payment processing</li>
+        <li style={S.li}><strong>Email provider</strong> — transactional email (e.g. login OTP, billing notices)</li>
+        <li style={S.li}><strong>OpenAI</strong> (optional) — embeddings for semantic search when you configure an API key</li>
+      </ul>
+      <p style={S.p}>
+        We share only the minimum data necessary for each service. Sub-processors are bound by contractual
+        obligations consistent with GDPR. A detailed list is available on request at{' '}
+        <a href="mailto:privacy@zizka.ai" style={S.a}>privacy@zizka.ai</a>.
+      </p>
+
+      <h2 style={S.h2}>7. International transfers</h2>
+      <p style={S.p}>
+        We prefer EU/EEA processing. Where data is transferred outside the EU/EEA (for example, to a sub-processor
+        in the United States), we rely on appropriate safeguards such as the EU Standard Contractual Clauses (SCCs)
+        and supplementary measures where required.
+      </p>
+
+      <h2 style={S.h2}>8. Your rights under GDPR</h2>
+      <p style={S.p}>If you are in the EU/EEA (or where GDPR applies), you have the right to:</p>
+      <ul style={S.ul}>
+        <li style={S.li}><strong>Access</strong> — obtain a copy of your personal data</li>
+        <li style={S.li}><strong>Rectification</strong> — correct inaccurate data</li>
+        <li style={S.li}><strong>Erasure</strong> — request deletion (&quot;right to be forgotten&quot;), subject to legal retention</li>
+        <li style={S.li}><strong>Restriction</strong> — limit processing in certain circumstances</li>
+        <li style={S.li}><strong>Data portability</strong> — receive data in a structured, machine-readable format where applicable</li>
+        <li style={S.li}><strong>Object</strong> — object to processing based on legitimate interests or direct marketing</li>
+        <li style={S.li}><strong>Withdraw consent</strong> — where processing is based on consent, without affecting prior lawful processing</li>
+      </ul>
+      <p style={S.p}>
+        To exercise these rights, email <a href="mailto:privacy@zizka.ai" style={S.a}>privacy@zizka.ai</a>.
+        We respond within one month, extendable where permitted by law. You may also lodge a complaint with the
+        Spanish supervisory authority:{' '}
+        <a href="https://www.aepd.es" target="_blank" rel="noopener noreferrer" style={S.a}>
+          Agencia Española de Protección de Datos (AEPD)
+        </a>.
+      </p>
+      <p style={S.p}>
+        Managed cloud users can export or delete account-related data via dashboard settings where available,
+        or by contacting us.
+      </p>
+
+      <h2 style={S.h2}>9. Cookies and similar technologies</h2>
+      <p style={S.p}>We use cookies and local storage for:</p>
+      <ul style={S.ul}>
+        <li style={S.li}><strong>Strictly necessary</strong> — authentication, security, load balancing (no consent required)</li>
+        <li style={S.li}><strong>Preferences</strong> — cookie consent choice stored locally</li>
+        <li style={S.li}><strong>Analytics / improvement</strong> — only where you accept optional cookies via our banner</li>
+      </ul>
+      <p style={S.p}>
+        You can accept or decline non-essential cookies via the site banner. Declining does not block access to
+        the service. You may clear cookies in your browser at any time.
+      </p>
+
+      <h2 style={S.h2}>10. Retention</h2>
+      <ul style={S.ul}>
+        <li style={S.li}><strong>Account data</strong> — while your account is active, then deleted or anonymised within a reasonable period after closure (subject to legal holds)</li>
+        <li style={S.li}><strong>Agent events</strong> — according to your plan and settings; see <Link href="/trust#integrity" style={S.a}>retention documentation</Link></li>
+        <li style={S.li}><strong>Billing records</strong> — as required by tax and commercial law (typically up to 6–10 years in Spain)</li>
+        <li style={S.li}><strong>Security logs</strong> — limited period for incident investigation (typically up to 90 days unless needed for legal claims)</li>
+      </ul>
+
+      <h2 style={S.h2}>11. Security</h2>
+      <p style={S.p}>
+        We implement appropriate technical and organisational measures including encryption in transit (TLS),
+        access controls, tenant isolation, and regular backups for managed cloud. No method of transmission
+        or storage is 100% secure; report suspected incidents to{' '}
+        <a href="mailto:founder@zizka.ai?subject=Security%20incident" style={S.a}>founder@zizka.ai</a>.
+        See also our <Link href="/trust#security" style={S.a}>security overview</Link>.
+      </p>
+
+      <h2 style={S.h2}>12. Children</h2>
+      <p style={S.p}>
+        ZizkaDB is a B2B developer product and is not directed at children under 16. We do not knowingly collect
+        personal data from children. Contact us if you believe a child has provided data and we will delete it.
+      </p>
+
+      <h2 style={S.h2}>13. Changes to this policy</h2>
+      <p style={S.p}>
+        We may update this policy to reflect legal, technical, or business changes. We will post the revised
+        version on this page with an updated date. Material changes affecting managed cloud customers may be
+        communicated by email or in-dashboard notice where appropriate.
+      </p>
+
+      <h2 style={S.h2}>14. Other ZIZKA AI products</h2>
+      <p style={S.p}>
+        This policy covers ZizkaDB and db.zizka.ai. Other products from ZIZKA AI S.L. (for example{' '}
+        <a href="https://zizka.ai/privacy" target="_blank" rel="noopener noreferrer" style={S.a}>
+          zizka.ai
+        </a>
+        ) may have separate or supplementary privacy information.
+      </p>
+
+      <h2 style={S.h2}>15. Contact</h2>
+      <p style={S.p}>
+        Data protection enquiries: <a href="mailto:privacy@zizka.ai" style={S.a}>privacy@zizka.ai</a><br />
+        General contact: <a href="mailto:founder@zizka.ai" style={S.a}>founder@zizka.ai</a><br />
+        Enterprise: <Link href="/enterprise#contact" style={S.a}>contact form</Link>
+      </p>
+    </LegalDocumentLayout>
+  )
+}

--- a/dashboard/app/signup/checkout/return/page.tsx
+++ b/dashboard/app/signup/checkout/return/page.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { BrandLogo } from '@/components/BrandLogo'
+import { M } from '@/components/marketing/marketing-theme'
+import { getBillingStatus } from '@/lib/api'
+import { getToken } from '@/lib/auth'
+
+// Stripe's success_url lands here after Checkout completes. The
+// checkout.session.completed webhook that actually activates the
+// subscription may lag the redirect by a few hundred ms, so poll billing
+// status briefly before sending the user on to the dashboard -- but always
+// land on /dashboard eventually even if the webhook hasn't arrived yet; the
+// dashboard's own billing UI reflects eventual consistency once it does.
+const POLL_DELAYS_MS = [500, 750, 1000, 1500, 2000]
+
+export default function CheckoutReturnPage() {
+  const router = useRouter()
+
+  useEffect(() => {
+    let cancelled = false
+    const token = getToken()
+    if (!token) {
+      router.replace('/login')
+      return
+    }
+
+    async function poll() {
+      for (const delay of POLL_DELAYS_MS) {
+        if (cancelled) return
+        try {
+          const status = await getBillingStatus(token as string)
+          if (!cancelled && (status.has_access || !status.requires_checkout)) {
+            router.replace('/dashboard')
+            return
+          }
+        } catch {
+          // transient error -- keep polling, don't give up early
+        }
+        await new Promise((resolve) => setTimeout(resolve, delay))
+      }
+      if (!cancelled) router.replace('/dashboard')
+    }
+
+    poll()
+    return () => {
+      cancelled = true
+    }
+  }, [router])
+
+  return (
+    <div
+      style={{
+        minHeight: '100vh',
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 20,
+        background: M.bg,
+        fontFamily: 'Inter, system-ui, sans-serif',
+      }}
+    >
+      <BrandLogo variant="full" />
+      <p style={{ fontSize: 15, color: M.muted }}>Activating your account…</p>
+    </div>
+  )
+}

--- a/dashboard/app/signup/page.tsx
+++ b/dashboard/app/signup/page.tsx
@@ -1,0 +1,421 @@
+"use client";
+
+import { Suspense, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import Link from "next/link";
+import { requestOtp, verifyOtp, createCheckoutSession } from "@/lib/api";
+import {
+  authErrorMessage,
+  isAlreadyRegisteredError,
+  isGdprConsentError,
+} from "@/lib/auth-errors";
+import { setToken } from "@/lib/auth";
+import { OTP_LENGTH } from "@/lib/constants";
+import { useResendCooldown } from "@/hooks/useResendCooldown";
+import {
+  clearSignupSession,
+  getStoredSignupPlan,
+  hasSignupConsent,
+  SIGNUP_CONSENT_MARKETING_KEY,
+  SIGNUP_PLAN_KEY,
+} from "@/lib/signup-funnel";
+import { BrandLogo } from "@/components/BrandLogo";
+import {
+  authPage,
+  authCard,
+  authTitle,
+  authSubtitle,
+  authLabel,
+  authInput,
+  authSubmitBtn,
+  authLink,
+  authMutedLink,
+} from "@/components/marketing/auth-styles";
+import { M } from "@/components/marketing/marketing-theme";
+
+export default function SignupPage() {
+  return (
+    <Suspense fallback={<SignupFallback />}>
+      <SignupForm />
+    </Suspense>
+  );
+}
+
+function SignupFallback() {
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: M.bg,
+        fontFamily: "Inter, system-ui, sans-serif",
+        color: M.faint,
+      }}
+    >
+      Loading…
+    </div>
+  );
+}
+
+function SignupForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [email, setEmail] = useState("");
+  const [otp, setOtp] = useState("");
+  const [step, setStep] = useState<"email" | "otp">("email");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [alreadyRegistered, setAlreadyRegistered] = useState(false);
+  const [navigating, setNavigating] = useState(false);
+  const verifyLock = useRef(false);
+  const verifyFormRef = useRef<HTMLFormElement>(null);
+  const { cooldown, canResend, startCooldown } = useResendCooldown();
+  // Gate the form render until the guard confirms the user belongs on /signup.
+  // Prevents the email screen from flashing before a redirect to /signup/plan
+  // or /signup/start resolves. Monotonic: only ever set true.
+  const [checked, setChecked] = useState(false);
+
+  useEffect(() => {
+    // Always start from email step when entering /signup to avoid stale OTP view.
+    setStep("email");
+    setOtp("");
+    setError("");
+    setAlreadyRegistered(false);
+
+    const planParam = searchParams.get("plan");
+    if (planParam === "pro" || planParam === "team") {
+      sessionStorage.setItem(SIGNUP_PLAN_KEY, planParam);
+    }
+
+    const stored = getStoredSignupPlan();
+    if (!stored) {
+      router.replace("/signup/plan");
+      return;
+    }
+
+    if (!hasSignupConsent()) {
+      router.replace(`/signup/start?plan=${stored}`);
+      return;
+    }
+
+    setChecked(true);
+  }, [searchParams, router]);
+
+  useEffect(() => {
+    if (
+      step !== "otp" ||
+      otp.length !== OTP_LENGTH ||
+      loading ||
+      navigating ||
+      verifyLock.current
+    )
+      return;
+    verifyFormRef.current?.requestSubmit();
+  }, [otp, step, loading, navigating]);
+
+  async function sendSignupOtp() {
+    await requestOtp(email, "signup");
+    setStep("otp");
+    startCooldown();
+  }
+
+  async function handleRequestOtp(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError("");
+    setAlreadyRegistered(false);
+    try {
+      await sendSignupOtp();
+    } catch (e) {
+      setAlreadyRegistered(isAlreadyRegisteredError(e));
+      setError(authErrorMessage(e, "Could not send code. Please try again."));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleResendOtp() {
+    if (!canResend || loading) return;
+    setLoading(true);
+    setError("");
+    setAlreadyRegistered(false);
+    try {
+      await sendSignupOtp();
+    } catch (e) {
+      setAlreadyRegistered(isAlreadyRegisteredError(e));
+      setError(authErrorMessage(e, "Failed to resend code. Try again."));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleVerifyOtp(e: React.FormEvent) {
+    e.preventDefault();
+    if (verifyLock.current || navigating) return;
+    verifyLock.current = true;
+    setLoading(true);
+    setError("");
+    try {
+      const gdprConsent = hasSignupConsent();
+      const marketingConsent =
+        sessionStorage.getItem(SIGNUP_CONSENT_MARKETING_KEY) === "1";
+      if (!gdprConsent) {
+        verifyLock.current = false;
+        setLoading(false);
+        const plan = getStoredSignupPlan() ?? "pro";
+        router.replace(`/signup/start?plan=${plan}`);
+        return;
+      }
+      const data = await verifyOtp(email, otp, {
+        intent: "signup",
+        gdprConsent,
+        marketingConsent,
+      });
+      const plan = getStoredSignupPlan();
+      setToken(data.access_token);
+      clearSignupSession();
+      setNavigating(true);
+      if (plan === "pro" || plan === "team") {
+        try {
+          const session = await createCheckoutSession(data.access_token, plan);
+          window.location.assign(session.url);
+          return;
+        } catch {
+          // Checkout couldn't be started right now -- don't strand the user
+          // on a broken screen. Land on the dashboard instead; its
+          // requires_checkout-driven resume-onboarding screen offers to
+          // retry checkout.
+        }
+      }
+      window.location.assign("/dashboard");
+    } catch (e) {
+      verifyLock.current = false;
+      if (isGdprConsentError(e)) {
+        setLoading(false);
+        const plan = getStoredSignupPlan() ?? "pro";
+        router.replace(`/signup/start?plan=${plan}`);
+        return;
+      }
+      setAlreadyRegistered(isAlreadyRegisteredError(e));
+      setError(authErrorMessage(e, "Invalid or expired code."));
+      setLoading(false);
+    }
+  }
+
+  if (navigating) {
+    return (
+      <div
+        style={{
+          minHeight: "100vh",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          background: M.bg,
+          fontFamily: "Inter, system-ui, sans-serif",
+          color: M.muted,
+        }}
+      >
+        <p style={{ fontSize: 15 }}>Creating your account… taking you to secure checkout next.</p>
+      </div>
+    );
+  }
+
+  // Hold the neutral loader until the guard resolves, so the email/OTP form
+  // never paints before a pending redirect (fixes the signup screen flicker).
+  if (!checked) return <SignupFallback />;
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: M.bg,
+        fontFamily: "Inter, system-ui, sans-serif",
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 420, padding: "0 24px" }}>
+        <div style={{ textAlign: "center", marginBottom: 36 }}>
+          <BrandLogo
+            variant="full"
+            suffix="The operational database for AI agents"
+          />
+        </div>
+
+        {/* Card */}
+        <div style={authCard}>
+          {step === "email" ? (
+            <>
+              <h1 style={authTitle}>Create your account</h1>
+              <p style={authSubtitle}>
+                Enter your email. We send a 6-digit code — no password needed.
+              </p>
+              <form
+                onSubmit={handleRequestOtp}
+                style={{ display: "flex", flexDirection: "column", gap: 16 }}
+              >
+                <div>
+                  <label style={authLabel}>Work email</label>
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    placeholder="you@company.com"
+                    required
+                    autoFocus
+                    style={authInput}
+                    onFocus={(e) => (e.target.style.borderColor = M.brandLight)}
+                    onBlur={(e) => (e.target.style.borderColor = M.lineStrong)}
+                  />
+                </div>
+                {error && (
+                  <p style={{ fontSize: 13, color: M.danger, margin: 0 }}>
+                    {error}
+                    {alreadyRegistered && (
+                      <>
+                        {" "}
+                        <Link
+                          href={`/login?email=${encodeURIComponent(email)}`}
+                          style={{ color: M.brandLight, fontWeight: 600 }}
+                        >
+                          Sign in →
+                        </Link>
+                      </>
+                    )}
+                  </p>
+                )}
+                <button
+                  type="submit"
+                  disabled={loading || !email}
+                  style={{
+                    ...authSubmitBtn,
+                    opacity: loading || !email ? 0.4 : 1,
+                  }}
+                >
+                  {loading ? "Sending..." : "Send verification code →"}
+                </button>
+              </form>
+            </>
+          ) : (
+            <>
+              <h1 style={authTitle}>Verify your email</h1>
+              <p style={authSubtitle}>
+                We sent a 6-digit code to{" "}
+                <strong style={{ color: M.ink }}>{email}</strong>
+              </p>
+              <form
+                ref={verifyFormRef}
+                onSubmit={handleVerifyOtp}
+                style={{ display: "flex", flexDirection: "column", gap: 16 }}
+              >
+                <div>
+                  <label style={authLabel}>Verification code</label>
+                  <input
+                    type="text"
+                    value={otp}
+                    onChange={(e) =>
+                      setOtp(
+                        e.target.value.replace(/\D/g, "").slice(0, OTP_LENGTH),
+                      )
+                    }
+                    placeholder="000000"
+                    required
+                    autoFocus
+                    maxLength={OTP_LENGTH}
+                    disabled={loading}
+                    style={{
+                      ...authInput,
+                      padding: "12px",
+                      fontSize: 28,
+                      textAlign: "center",
+                      letterSpacing: "0.4em",
+                      fontFamily: "monospace",
+                    }}
+                    onFocus={(e) => (e.target.style.borderColor = M.brandLight)}
+                    onBlur={(e) => (e.target.style.borderColor = M.lineStrong)}
+                  />
+                </div>
+                {error && (
+                  <p style={{ fontSize: 13, color: M.danger, margin: 0 }}>
+                    {error}
+                    {alreadyRegistered && (
+                      <>
+                        {" "}
+                        <Link
+                          href={`/login?email=${encodeURIComponent(email)}`}
+                          style={{ color: M.brandLight, fontWeight: 600 }}
+                        >
+                          Sign in →
+                        </Link>
+                      </>
+                    )}
+                  </p>
+                )}
+                <button
+                  type="submit"
+                  disabled={loading || otp.length < OTP_LENGTH}
+                  style={{
+                    ...authSubmitBtn,
+                    opacity: loading || otp.length < OTP_LENGTH ? 0.4 : 1,
+                  }}
+                >
+                  {loading ? "Verifying..." : "Create account →"}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleResendOtp}
+                  disabled={!canResend || loading}
+                  style={{
+                    fontSize: 13,
+                    color: canResend ? M.muted : M.faint,
+                    background: "none",
+                    border: "none",
+                    cursor: canResend && !loading ? "pointer" : "not-allowed",
+                  }}
+                >
+                  {canResend ? "Resend code" : `Resend code in ${cooldown}s`}
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    verifyLock.current = false;
+                    setStep("email");
+                    setOtp("");
+                    setError("");
+                    setAlreadyRegistered(false);
+                  }}
+                  style={{
+                    fontSize: 13,
+                    color: M.faint,
+                    background: "none",
+                    border: "none",
+                    cursor: "pointer",
+                  }}
+                >
+                  ← Use a different email
+                </button>
+              </form>
+            </>
+          )}
+        </div>
+
+        <p
+          style={{
+            textAlign: "center",
+            fontSize: 13,
+            color: M.muted,
+            marginTop: 20,
+          }}
+        >
+          Already have an account?{" "}
+          <Link href="/login" style={authMutedLink}>
+            Sign in →
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/signup/plan/page.tsx
+++ b/dashboard/app/signup/plan/page.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { BrandLogo } from "@/components/BrandLogo";
+import { BRAND, BRAND_DARK } from "@/components/brand";
+import { SIGNUP_PLAN_KEY } from "@/lib/signup-funnel";
+import { M } from "@/components/marketing/marketing-theme";
+import { authPage, authSubtitle, authTitle, authMutedLink, authSubmitBtn, authCard } from "@/components/marketing/auth-styles";
+
+const PLANS = [
+  {
+    id: "pro" as const,
+    name: "Pro",
+    price: "€29",
+    price_sub: "/ month",
+    highlight: true,
+    features: [
+      "50k events / month",
+      "3 active API keys",
+      "Email support",
+    ],
+  },
+  {
+    id: "team" as const,
+    name: "Team",
+    price: "€69",
+    price_sub: "/ month",
+    highlight: false,
+    features: [
+      "100k events / month",
+      "10 active API keys",
+      "Priority support",
+    ],
+  },
+];
+
+export default function SignupPlanPage() {
+  const router = useRouter();
+  const [selected, setSelected] = useState<"pro" | "team">("pro");
+
+  function handleContinue() {
+    if (typeof window !== "undefined") {
+      sessionStorage.setItem(SIGNUP_PLAN_KEY, selected);
+    }
+    router.push(`/signup/start?plan=${selected}`);
+  }
+
+  return (
+    <div
+      style={{
+        ...authPage,
+        padding: "24px 16px",
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 720 }}>
+        <div style={{ textAlign: "center", marginBottom: 28 }}>
+          <BrandLogo variant="full" suffix="Choose your plan" />
+        </div>
+
+        <div style={authCard}>
+          <h1 style={{ ...authTitle, textAlign: "center", margin: "0 0 8px" }}>
+            Select a package
+          </h1>
+          <p style={{ ...authSubtitle, textAlign: "center", margin: "0 0 8px" }}>
+            Pick the plan that fits your team. You can change it later.
+          </p>
+          <p
+            style={{
+              textAlign: "center",
+              margin: "0 0 24px",
+              fontSize: 13,
+              fontWeight: 600,
+              color: M.brandLight,
+            }}
+          >
+            1 month free trial · No charge today · Card required · Cancel anytime
+          </p>
+
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(240px, 1fr))",
+              gap: 16,
+            }}
+          >
+            {PLANS.map((plan) => {
+              const isSelected = selected === plan.id;
+              return (
+                <button
+                  key={plan.id}
+                  type="button"
+                  onClick={() => setSelected(plan.id)}
+                  style={{
+                    textAlign: "left",
+                    cursor: "pointer",
+                    borderRadius: 14,
+                    padding: "22px 20px",
+                    border: isSelected
+                      ? `2px solid ${BRAND}`
+                      : plan.highlight
+                        ? `2px solid ${BRAND}44`
+                        : `1px solid ${M.line}`,
+                    background: isSelected ? "rgba(249,115,22,0.12)" : M.bgElevated,
+                    boxShadow: isSelected
+                      ? "0 8px 24px rgba(249,115,22,0.12)"
+                      : "none",
+                    position: "relative",
+                  }}
+                >
+                  {plan.highlight && (
+                    <span
+                      style={{
+                        position: "absolute",
+                        top: -10,
+                        left: "50%",
+                        transform: "translateX(-50%)",
+                        background: BRAND,
+                        color: "#fff",
+                        fontSize: 10,
+                        fontWeight: 700,
+                        padding: "3px 10px",
+                        borderRadius: 100,
+                      }}
+                    >
+                      POPULAR
+                    </span>
+                  )}
+                  <div
+                    style={{
+                      fontSize: 12,
+                      fontWeight: 800,
+                      color: M.inkSoft,
+                      marginBottom: 8,
+                    }}
+                  >
+                    {plan.name}
+                  </div>
+                  <div
+                    style={{
+                      display: "flex",
+                      alignItems: "baseline",
+                      gap: 4,
+                      marginBottom: 14,
+                    }}
+                  >
+                    <span
+                      style={{ fontSize: 28, fontWeight: 700, color: M.ink }}
+                    >
+                      {plan.price}
+                    </span>
+                    <span
+                      style={{ fontSize: 13, fontWeight: 600, color: M.muted }}
+                    >
+                      {plan.price_sub}
+                    </span>
+                  </div>
+                  <ul
+                    style={{
+                      listStyle: "none",
+                      padding: 0,
+                      margin: 0,
+                      display: "flex",
+                      flexDirection: "column",
+                      gap: 7,
+                    }}
+                  >
+                    {plan.features.map((f) => (
+                      <li
+                        key={f}
+                        style={{
+                          fontSize: 13,
+                          color: M.muted,
+                          display: "flex",
+                          gap: 8,
+                        }}
+                      >
+                        <span style={{ color: M.brandLight, fontWeight: 800 }}>
+                          ✓
+                        </span>{" "}
+                        {f}
+                      </li>
+                    ))}
+                  </ul>
+                  {isSelected && (
+                    <p
+                      style={{
+                        margin: "14px 0 0",
+                        fontSize: 12,
+                        fontWeight: 700,
+                        color: BRAND,
+                      }}
+                    >
+                      Selected
+                    </p>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+
+          <button
+            type="button"
+            onClick={handleContinue}
+            style={{
+              ...authSubmitBtn,
+              width: "100%",
+              marginTop: 24,
+            }}
+          >
+            Continue →
+          </button>
+        </div>
+
+        <p
+          style={{
+            textAlign: "center",
+            fontSize: 13,
+            color: M.faint,
+            marginTop: 20,
+          }}
+        >
+          Not sure yet?{" "}
+          <a
+            href="https://db.zizka.ai/docs"
+            style={authMutedLink}
+          >
+            Explore docs and other options →
+          </a>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/app/signup/start/page.tsx
+++ b/dashboard/app/signup/start/page.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import { Suspense, useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import Link from 'next/link'
+import { BrandLogo } from '@/components/BrandLogo'
+import { SIGNUP_CONSENT_GDPR_KEY, SIGNUP_CONSENT_MARKETING_KEY, SIGNUP_PLAN_KEY, getStoredSignupPlan } from '@/lib/signup-funnel'
+import { authPage, authCard, authTitle, authSubtitle, authSubmitBtn, authMutedLink } from '@/components/marketing/auth-styles'
+import { M } from '@/components/marketing/marketing-theme'
+
+const GUIDELINES = [
+  {
+    title: 'Log every agent step',
+    body: 'Use db.log() with a consistent session_id for each conversation. Link tool calls and responses so baselines and drift detection work from day one.',
+  },
+  {
+    title: 'Create an agent, then connect',
+    body: 'After signup, open the dashboard → create an agent → copy your API key. Connect via Python SDK, TypeScript SDK, MCP, or REST.',
+  },
+  {
+    title: 'Review behavior early',
+    body: 'Once you have a few sessions, use semantic search and baselines in the dashboard to spot when your agent starts behaving differently.',
+  },
+]
+
+function StartFallback() {
+  return (
+    <div style={{
+      minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: M.bg, fontFamily: 'Inter, system-ui, sans-serif', color: M.muted,
+    }}>
+      Loading…
+    </div>
+  )
+}
+
+export default function SignupStartPage() {
+  return (
+    <Suspense fallback={<StartFallback />}>
+      <SignupStartInner />
+    </Suspense>
+  )
+}
+
+function SignupStartInner() {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [plan, setPlan] = useState<'pro' | 'team' | null>(null)
+  const [gdprConsent, setGdprConsent] = useState(false)
+  const [marketingConsent, setMarketingConsent] = useState(false)
+
+  useEffect(() => {
+    const planParam = searchParams.get('plan')
+    const resolved =
+      planParam === 'pro' || planParam === 'team'
+        ? planParam
+        : getStoredSignupPlan()
+    if (!resolved) {
+      router.replace('/signup/plan')
+      return
+    }
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, resolved)
+    setPlan(resolved)
+  }, [searchParams, router])
+
+  function handleContinue() {
+    if (!plan || !gdprConsent) return
+    sessionStorage.setItem(SIGNUP_CONSENT_GDPR_KEY, '1')
+    sessionStorage.setItem(SIGNUP_CONSENT_MARKETING_KEY, marketingConsent ? '1' : '0')
+    router.push(`/signup?plan=${plan}`)
+  }
+
+  if (!plan) return <StartFallback />
+
+  return (
+    <div style={{
+      minHeight: '100vh', display: 'flex', alignItems: 'center', justifyContent: 'center',
+      background: M.bg, fontFamily: 'Inter, system-ui, sans-serif', padding: '24px 16px',
+    }}>
+      <div style={{ width: '100%', maxWidth: 560 }}>
+        <div style={{ textAlign: 'center', marginBottom: 28 }}>
+          <BrandLogo variant="full" suffix="Get started with ZizkaDB" />
+        </div>
+
+        <div style={authCard}>
+          <h1 style={{ ...authTitle, textAlign: 'center', margin: '0 0 8px' }}>Before you begin</h1>
+          <p style={{ ...authSubtitle, textAlign: 'center', margin: '0 0 24px' }}>
+            Three quick tips to get the most from your {plan === 'team' ? 'Team' : 'Pro'} plan.
+          </p>
+
+          <ol style={{ listStyle: 'none', padding: 0, margin: '0 0 28px', display: 'flex', flexDirection: 'column', gap: 16 }}>
+            {GUIDELINES.map((item, i) => (
+              <li
+                key={item.title}
+                style={{
+                  display: 'flex', gap: 14, padding: '16px 18px', borderRadius: 12,
+                  background: M.bgElevated, border: `1px solid ${M.line}`,
+                }}
+              >
+                <span style={{
+                  flexShrink: 0, width: 28, height: 28, borderRadius: '50%',
+                  background: M.brand, color: '#fff', fontSize: 13, fontWeight: 700,
+                  display: 'flex', alignItems: 'center', justifyContent: 'center',
+                }}>
+                  {i + 1}
+                </span>
+                <div>
+                  <div style={{ fontSize: 14, fontWeight: 700, color: M.ink, marginBottom: 4 }}>{item.title}</div>
+                  <div style={{ fontSize: 13, color: M.muted, lineHeight: 1.55 }}>{item.body}</div>
+                </div>
+              </li>
+            ))}
+          </ol>
+
+          <p
+            style={{
+              margin: '0 0 16px',
+              padding: '10px 14px',
+              borderRadius: 10,
+              background: M.bgElevated,
+              border: `1px solid ${M.line}`,
+              fontSize: 13,
+              fontWeight: 600,
+              color: M.brandLight,
+              textAlign: 'center',
+            }}
+          >
+            You won&apos;t be charged until your trial ends — cancel anytime before then.
+          </p>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 14, marginBottom: 24 }}>
+            <label style={{ display: 'flex', gap: 10, alignItems: 'flex-start', cursor: 'pointer', fontSize: 13, color: M.muted, lineHeight: 1.55 }}>
+              <input
+                type="checkbox"
+                checked={gdprConsent}
+                onChange={(e) => setGdprConsent(e.target.checked)}
+                style={{ marginTop: 3, flexShrink: 0 }}
+              />
+              <span>
+                I agree that my data will be processed in accordance with{' '}
+                <strong>GDPR</strong> and the <strong>EU AI Act</strong>.{' '}
+                <span style={{ color: '#ef4444' }}>*</span>
+              </span>
+            </label>
+
+            <label style={{ display: 'flex', gap: 10, alignItems: 'flex-start', cursor: 'pointer', fontSize: 13, color: M.faint, lineHeight: 1.55 }}>
+              <input
+                type="checkbox"
+                checked={marketingConsent}
+                onChange={(e) => setMarketingConsent(e.target.checked)}
+                style={{ marginTop: 3, flexShrink: 0 }}
+              />
+              <span>
+                I would like to receive information about ZizkaDB products and services (optional).
+              </span>
+            </label>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleContinue}
+            disabled={!gdprConsent}
+            style={{
+              ...authSubmitBtn,
+              width: '100%',
+              opacity: gdprConsent ? 1 : 0.45,
+              cursor: gdprConsent ? 'pointer' : 'not-allowed',
+            }}
+          >
+            Continue to create account →
+          </button>
+        </div>
+
+        <p style={{ textAlign: 'center', fontSize: 13, color: M.muted, marginTop: 20 }}>
+          <Link href="/signup/plan" style={authMutedLink}>
+            ← Change plan
+          </Link>
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/dashboard/app/signup/success/page.tsx
+++ b/dashboard/app/signup/success/page.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+
+export default function SignupSuccessRedirect() {
+  const router = useRouter()
+
+  useEffect(() => {
+    router.replace('/dashboard')
+  }, [router])
+
+  return null
+}

--- a/dashboard/app/sitemap.ts
+++ b/dashboard/app/sitemap.ts
@@ -1,0 +1,27 @@
+import type { MetadataRoute } from 'next'
+
+const SITE_URL = process.env.DASHBOARD_URL || 'https://db.zizka.ai'
+
+// Public marketing/docs pages only -- /dashboard and /admin are excluded from
+// robots.ts and have no SEO value, and /login + /signup are auth flows, not
+// content worth ranking. Keep this list in sync with dashboard/app/*/page.tsx
+// as new public pages are added.
+const ROUTES: { path: string; changeFrequency: MetadataRoute.Sitemap[number]['changeFrequency']; priority: number }[] = [
+  { path: '', changeFrequency: 'weekly', priority: 1 },
+  { path: '/docs', changeFrequency: 'weekly', priority: 0.9 },
+  { path: '/enterprise', changeFrequency: 'monthly', priority: 0.8 },
+  { path: '/eu-ai-act', changeFrequency: 'monthly', priority: 0.7 },
+  { path: '/community', changeFrequency: 'daily', priority: 0.7 },
+  { path: '/trust', changeFrequency: 'monthly', priority: 0.5 },
+  { path: '/privacy', changeFrequency: 'yearly', priority: 0.3 },
+]
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date()
+  return ROUTES.map((route) => ({
+    url: `${SITE_URL}${route.path}`,
+    lastModified: now,
+    changeFrequency: route.changeFrequency,
+    priority: route.priority,
+  }))
+}

--- a/dashboard/app/trust/page.tsx
+++ b/dashboard/app/trust/page.tsx
@@ -1,0 +1,1075 @@
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+import { codeInlineOnLight } from "@/lib/content-styles";
+import { SiteNav } from "@/components/SiteNav";
+import { MarketingFooter } from "@/components/marketing/MarketingFooter";
+import { GITHUB_URL, FOUNDER_EMAIL } from "@/lib/constants";
+
+export const metadata = {
+  title: "Technical reference",
+  description:
+    "Architecture, APIs, data model, and integration guide for ZizkaDB — the operational database for AI agents.",
+};
+
+const SECTIONS = [
+  { id: "overview", label: "Overview" },
+  { id: "problem", label: "Problem domain" },
+  { id: "architecture", label: "Architecture" },
+  { id: "data-model", label: "Data model" },
+  { id: "capabilities", label: "Capabilities" },
+  { id: "time-travel", label: "Time travel" },
+  { id: "integrity", label: "Integrity & retention" },
+  { id: "performance", label: "Performance" },
+  { id: "security", label: "Security" },
+  { id: "integration", label: "Integration" },
+  { id: "api", label: "REST API" },
+  { id: "deployment", label: "Deployment" },
+  { id: "comparison", label: "Comparison" },
+  { id: "licensing", label: "Licensing" },
+  { id: "limits", label: "Plan limits" },
+  { id: "faq", label: "FAQ" },
+  { id: "contact", label: "Contact" },
+] as const;
+
+export default function TrustPage() {
+  return (
+    <div
+      style={{
+        fontFamily: "Inter, system-ui, sans-serif",
+        color: "#111",
+        background: "#fff",
+        minHeight: "100vh",
+      }}
+    >
+      <SiteNav active="trust" suffix="Technical" />
+
+      <div style={{ display: "flex", maxWidth: 1100, margin: "0 auto" }}>
+        <aside
+          style={{
+            width: 200,
+            flexShrink: 0,
+            padding: "32px 16px",
+            position: "sticky",
+            top: 56,
+            height: "calc(100vh - 56px)",
+            overflowY: "auto",
+            borderRight: "1px solid #f0f0f0",
+            display: "none",
+          }}
+          className="trust-sidebar"
+        >
+          <div
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              color: "#000000",
+              letterSpacing: 1,
+              textTransform: "uppercase",
+              marginBottom: 10,
+            }}
+          >
+            On this page
+          </div>
+          {SECTIONS.map((s) => (
+            <a
+              key={s.id}
+              href={`#${s.id}`}
+              style={{
+                display: "block",
+                fontSize: 13,
+              color: "#000000",
+                textDecoration: "none",
+                padding: "6px 10px",
+                borderRadius: 6,
+                marginBottom: 2,
+              }}
+            >
+              {s.label}
+            </a>
+          ))}
+        </aside>
+
+        <main
+          style={{
+            flex: 1,
+            maxWidth: 780,
+            padding: "48px 28px 96px",
+            minWidth: 0,
+          }}
+        >
+          <p style={{ fontSize: 12, color: "#000000", marginBottom: 8 }}>
+            Technical reference · May 2026
+          </p>
+          <h1
+            style={{
+              fontSize: 34,
+              fontWeight: 700,
+              letterSpacing: -0.6,
+              margin: "0 0 12px",
+              lineHeight: 1.2,
+            }}
+          >
+            ZizkaDB
+          </h1>
+          <p
+            style={{
+              fontSize: 17,
+              color: "#000000",
+              lineHeight: 1.75,
+              marginBottom: 48,
+            }}
+          >
+            The operational database for AI agents. This document describes
+            architecture, APIs, data semantics, and how ZizkaDB fits alongside
+            vector databases, application databases, and tracing tools.
+          </p>
+
+          <Section id="overview" title="Overview">
+            <p style={p}>
+              ZizkaDB stores <strong>agent events</strong> — decisions, tool
+              calls, messages, and outcomes — with causal links, semantic search
+              over history, reconstruction of logged state at a timestamp, and
+              statistical behavioral baselines per agent.
+            </p>
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Layer</th>
+                  <th style={th}>Role</th>
+                  <th style={th}>Examples</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  [
+                    "Vector retrieval",
+                    "Document / knowledge search by embedding",
+                    "Pinecone, Qdrant, Weaviate",
+                  ],
+                  [
+                    "Application state",
+                    "Transactional app data",
+                    "Postgres, Redis",
+                  ],
+                  [
+                    "Agent operations",
+                    "Decision history, lineage, drift",
+                    "ZizkaDB",
+                  ],
+                  [
+                    "Traces & evals",
+                    "Spans, experiments, framework hooks",
+                    "LangSmith, OpenTelemetry",
+                  ],
+                ].map(([layer, role, ex]) => (
+                  <tr key={layer}>
+                    <td style={td}>
+                      <strong>{layer}</strong>
+                    </td>
+                    <td style={td}>{role}</td>
+                    <td style={td}>{ex}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <pre style={pre}>{`Agent runtime
+ ├── Vector DB          →  RAG / knowledge retrieval
+ ├── Postgres / Redis   →  app state, caches, users
+ ├── ZizkaDB            →  events, why(), at(), baseline, forget()
+ └── OTel / LangSmith   →  distributed traces (optional)`}</pre>
+          </Section>
+
+          <Section id="problem" title="Problem domain">
+            <p style={p}>Production agent systems typically need:</p>
+            <ul style={ul}>
+              <li>
+                <strong>Causal debugging</strong> — walk from a bad output to
+                the event that triggered it
+              </li>
+              <li>
+                <strong>State at time T</strong> — what was logged for an agent
+                before a given timestamp
+              </li>
+              <li>
+                <strong>Cross-session memory</strong> — under your API keys,
+                retention policy, and erasure controls
+              </li>
+              <li>
+                <strong>Behavior change detection</strong> — compare recent
+                sessions to that agent&apos;s historical pattern
+              </li>
+            </ul>
+            <p style={p}>
+              ZizkaDB targets these operational concerns. It does not replace
+              embedding indexes for document RAG or distributed tracing for
+              infrastructure spans.
+            </p>
+          </Section>
+
+          <Section id="architecture" title="Architecture">
+            <h3 style={h3}>Managed (db.zizka.ai)</h3>
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Component</th>
+                  <th style={th}>Technology</th>
+                  <th style={th}>Notes</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ["Dashboard", "Next.js 14", "PM2 :3001, nginx TLS"],
+                  ["API", "FastAPI (Python)", "Docker :8000"],
+                  [
+                    "Primary store",
+                    "Postgres + pgvector",
+                    "Events, tenants, metadata",
+                  ],
+                  ["Vector search", "Qdrant", "Semantic search index"],
+                  ["Cache", "Redis", "Sessions / cache"],
+                  [
+                    "Edge",
+                    "nginx",
+                    "/ → dashboard, /v1/ → API, /swagger → OpenAPI",
+                  ],
+                ].map(([c, t, n]) => (
+                  <tr key={c}>
+                    <td style={td}>{c}</td>
+                    <td style={td}>{t}</td>
+                    <td style={td}>{n}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <h3 style={h3}>Self-hosted</h3>
+            <p style={p}>
+              Docker Compose stack: Postgres (pgvector), Qdrant, Redis, API.
+              Dashboard is optional (run from{" "}
+              <code style={codeInline}>dashboard/</code>). Requires{" "}
+              <code style={codeInline}>OPENAI_API_KEY</code> for
+              embedding-backed features; logging and causal APIs work without
+              it.
+            </p>
+            <Code>{`git clone https://github.com/Zizka-ai/ZizkaDB
+cp .env.example infra/.env
+docker compose -f infra/docker-compose.yml up -d`}</Code>
+          </Section>
+
+          <Section id="data-model" title="Data model">
+            <p style={p}>
+              Every record is an <strong>event</strong>:
+            </p>
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Field</th>
+                  <th style={th}>Type</th>
+                  <th style={th}>Description</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ["agent", "string", "Agent identifier (fleet key)"],
+                  [
+                    "event",
+                    "string",
+                    "Event type label (e.g. tool_call, user_message)",
+                  ],
+                  ["data", "JSON object", "Arbitrary payload you control"],
+                  ["parent_id", "UUID (optional)", "Causal parent event"],
+                  [
+                    "session_id",
+                    "string (optional)",
+                    "Groups a run / conversation",
+                  ],
+                  [
+                    "metadata",
+                    "JSON (optional)",
+                    "Tenant tags (user_id, env, etc.)",
+                  ],
+                  [
+                    "timestamp",
+                    "ISO 8601",
+                    "Server-assigned or client-provided",
+                  ],
+                  ["checksum", "SHA-256", "Hash over canonical payload bytes"],
+                ].map(([f, t, d]) => (
+                  <tr key={f}>
+                    <td style={td}>
+                      <code style={codeInline}>{f}</code>
+                    </td>
+                    <td style={td}>{t}</td>
+                    <td style={td}>{d}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p style={p}>
+              <strong>Multi-tenancy:</strong> API keys (
+              <code style={codeInline}>zizkadb_live_*</code>) scope all reads
+              and writes to a tenant. Dashboard auth uses email OTP → JWT.
+            </p>
+          </Section>
+
+          <Section id="capabilities" title="Capabilities">
+            {[
+              {
+                name: "Event logging",
+                api: "POST /v1/events",
+                sdk: "db.log(...)",
+                detail: "Append events. Use parent_id to build causal trees.",
+              },
+              {
+                name: "Causal lineage",
+                api: "GET /v1/events/{id}/why",
+                sdk: "db.why(event_id)",
+                detail: "Returns ancestor chain from event to root.",
+              },
+              {
+                name: "Semantic search",
+                api: "POST /v1/search",
+                sdk: "db.search(query, agent=..., limit=...)",
+                detail:
+                  "Embeddings via OpenAI text-embedding-3-small on ingest.",
+              },
+              {
+                name: "Time travel",
+                api: "GET /v1/events/at",
+                sdk: "db.at(agent, timestamp)",
+                detail:
+                  "Aggregate logged events ≤ timestamp into a state snapshot.",
+              },
+              {
+                name: "Context injection",
+                api: "POST /v1/memory/context",
+                sdk: "db.context_for(agent, task, max_tokens=...)",
+                detail:
+                  "Recent + semantically relevant events formatted for system prompts.",
+              },
+              {
+                name: "Behavioral baseline",
+                api: "GET /v1/agents/{id}/baseline",
+                sdk: "db.baseline(agent, recent_window=...)",
+                detail:
+                  "Drift score vs historical event distribution; needs session volume.",
+              },
+              {
+                name: "Session diff",
+                api: "GET /v1/memory/diff/{session_id}",
+                sdk: "db.memory_diff(session_id)",
+                detail:
+                  "Summary of event counts, errors, and changes within a session.",
+              },
+              {
+                name: "GDPR erasure",
+                api: "DELETE /v1/memory/forget",
+                sdk: "db.forget(filter_key, filter_value)",
+                detail:
+                  "Deletes events (and vectors) matching metadata filter.",
+              },
+            ].map((cap) => (
+              <div
+                key={cap.name}
+                style={{
+                  marginBottom: 20,
+                  paddingBottom: 20,
+                  borderBottom: "1px solid #f0f0f0",
+                }}
+              >
+                <div style={{ fontWeight: 600, fontSize: 15, marginBottom: 6 }}>
+                  {cap.name}
+                </div>
+                <div style={{ fontSize: 13, color: "#000000", marginBottom: 6 }}>
+                  <code style={codeInline}>{cap.api}</code> ·{" "}
+                  <code style={codeInline}>{cap.sdk}</code>
+                </div>
+                <p style={{ ...p, margin: 0 }}>{cap.detail}</p>
+              </div>
+            ))}
+          </Section>
+
+          <Section id="time-travel" title="Time travel semantics">
+            <p style={p}>
+              <code style={codeInline}>at(agent, timestamp)</code> reconstructs{" "}
+              <strong>logged state</strong> by aggregating all events for that
+              agent with <code style={codeInline}>timestamp ≤ T</code>. The
+              returned structure reflects what was recorded in ZizkaDB, not a
+              re-execution of the LLM or tools.
+            </p>
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Property</th>
+                  <th style={th}>Behavior</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  [
+                    "Determinism",
+                    "Same event log → same reconstructed snapshot",
+                  ],
+                  [
+                    "LLM outputs",
+                    "Not re-generated; only stored payloads are returned",
+                  ],
+                  [
+                    "Checksums",
+                    "Per-event SHA-256 enables integrity verification of stored payloads",
+                  ],
+                  [
+                    "Completeness",
+                    "Depends on what your integration logged (gaps = missing parent events)",
+                  ],
+                ].map(([prop, beh]) => (
+                  <tr key={prop}>
+                    <td style={td}>{prop}</td>
+                    <td style={td}>{beh}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Section>
+
+          <Section id="integrity" title="Integrity & retention">
+            <ul style={ul}>
+              <li>
+                Events are stored in <strong>Postgres</strong> with an
+                append-by-default write pattern; each payload includes a{" "}
+                <strong>SHA-256 checksum</strong> for integrity verification.
+              </li>
+              <li>
+                <code style={codeInline}>forget()</code> removes events matching
+                metadata filters (GDPR right to erasure) — storage is not
+                WORM/immutable.
+              </li>
+              <li>
+                Managed plans enforce <strong>retention windows</strong> (90
+                days Pro, 1 year Team); self-hosted retention is
+                operator-defined.
+              </li>
+              <li>
+                Bulk signed audit export is on the product roadmap; today,
+                export via API/query and verify checksums per event.
+              </li>
+            </ul>
+          </Section>
+
+          <Section id="performance" title="Performance expectations">
+            <p style={p}>
+              ZizkaDB is built for normal agent loops — tool calls, messages,
+              and decisions — not for blockchain-scale write throughput. Stack:
+              Postgres (events), Qdrant (vectors), Redis (cache).
+            </p>
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Mode</th>
+                  <th style={th}>Write path</th>
+                  <th style={th}>Typical use</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  [
+                    "Logging only",
+                    "Postgres INSERT + SHA-256 checksum",
+                    "Fast enough for typical agent step loops",
+                  ],
+                  [
+                    "With semantic search",
+                    "Above + OpenAI embedding + Qdrant upsert (per log)",
+                    "Fine for normal volume; embedding adds network latency",
+                  ],
+                  [
+                    "why() / query",
+                    "Postgres reads on explicit event_id or filters",
+                    "No hidden session state on the server",
+                  ],
+                ].map(([mode, path, use]) => (
+                  <tr key={mode}>
+                    <td style={td}>
+                      <strong>{mode}</strong>
+                    </td>
+                    <td style={td}>{path}</td>
+                    <td style={td}>{use}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p style={p}>
+              High-frequency fleets (thousands of parallel writes per second)
+              are not a v1 target. Async embedding queues and published
+              benchmarks are on the roadmap as usage grows.
+            </p>
+          </Section>
+
+          <Section id="security" title="Security (early stage)">
+            <p style={p}>
+              ZizkaDB v1 is aimed at developers and small teams — not enterprise
+              compliance certification yet. Here is what we do today:
+            </p>
+            <ul style={ul}>
+              <li>
+                <strong>In transit:</strong> TLS on managed cloud (
+                <code style={codeInline}>db.zizka.ai</code> via nginx).
+              </li>
+              <li>
+                <strong>Tenant isolation:</strong> every API call scoped by API
+                key or JWT to a <code style={codeInline}>tenant_id</code>; no
+                cross-tenant reads.
+              </li>
+              <li>
+                <strong>At rest:</strong> standard Postgres / disk encryption on
+                the operator&apos;s infrastructure (AWS EBS on managed; your
+                disk when self-hosted).
+              </li>
+              <li>
+                <strong>BYOK embedding keys:</strong> encrypted in Postgres
+                (Fernet) when you bring your own OpenAI key.
+              </li>
+              <li>
+                <strong>GDPR erasure:</strong>{" "}
+                <code style={codeInline}>forget()</code> deletes matching events
+                and vectors.
+              </li>
+              <li>
+                <strong>Telemetry:</strong> one anonymous SDK/MCP startup ping —
+                opt out with{" "}
+                <code style={codeInline}>ZIZKADB_TELEMETRY=false</code>.
+              </li>
+            </ul>
+            <p style={p}>
+              <strong>Not claimed today:</strong> SOC 2, HIPAA, or formal DPAs.
+              For enterprise security review and VPC deployment, see{" "}
+              <Link href="/enterprise" style={link}>
+                /enterprise
+              </Link>{" "}
+              or contact{" "}
+              <a href={`mailto:${FOUNDER_EMAIL}`} style={link}>
+                {FOUNDER_EMAIL}
+              </a>
+              .
+            </p>
+          </Section>
+
+          <Section id="integration" title="Integration">
+            <p style={p}>
+              <strong>Concurrency:</strong> Python and TypeScript SDKs are{" "}
+              <strong>stateless HTTP clients</strong> — no thread-local storage
+              or <code style={codeInline}>contextvars</code>. Pass{" "}
+              <code style={codeInline}>agent</code>,{" "}
+              <code style={codeInline}>session_id</code>,{" "}
+              <code style={codeInline}>parent_id</code>, and{" "}
+              <code style={codeInline}>event_id</code> explicitly on each call.
+              Safe in FastAPI, Celery, and parallel async workers.
+            </p>
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Surface</th>
+                  <th style={th}>Install</th>
+                  <th style={th}>Use case</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  [
+                    "Python SDK",
+                    "pip install zizkadb-sdk",
+                    "FastAPI, notebooks, batch",
+                  ],
+                  [
+                    "TypeScript SDK",
+                    "npm install zizkadb-sdk",
+                    "Node, Bun, Deno, edge",
+                  ],
+                  [
+                    "MCP server",
+                    "uvx zizkadb-mcp",
+                    "Claude Desktop, Cursor — no app refactor",
+                  ],
+                  ["REST", "curl / any HTTP", "Go, Rust, Java, mobile"],
+                ].map(([s, i, u]) => (
+                  <tr key={s}>
+                    <td style={td}>{s}</td>
+                    <td style={td}>
+                      <code style={codeInline}>{i}</code>
+                    </td>
+                    <td style={td}>{u}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p style={p}>
+              Cloud default host:{" "}
+              <code style={codeInline}>https://db.zizka.ai</code>. Self-host:
+              pass <code style={codeInline}>host=</code> to the SDK or set{" "}
+              <code style={codeInline}>ZIZKADB_HOST</code> for MCP.
+            </p>
+            <Code lang="python">{`from zizkadb import ZizkaDB
+
+db = ZizkaDB("zizkadb_live_xxxx")  # managed
+# db = ZizkaDB(host="http://localhost:8000")  # self-host
+
+msg = await db.log(agent="bot", event="user_message", data={"text": "..."})
+tool = await db.log(agent="bot", event="tool_call", data={...}, parent_id=msg.event_id)
+chain = await db.why(tool.event_id)`}</Code>
+            <h3 style={h3}>Cursor MCP (30 seconds)</h3>
+            <p style={p}>
+              Add to <code style={codeInline}>~/.cursor/mcp.json</code> or
+              project <code style={codeInline}>.cursor/mcp.json</code>, then
+              reload MCP:
+            </p>
+            <Code lang="json">{`{
+  "mcpServers": {
+    "zizkadb": {
+      "command": "uvx",
+      "args": ["zizkadb-mcp"],
+      "env": { "ZIZKADB_API_KEY": "zizkadb_live_xxxx" }
+    }
+  }
+}`}</Code>
+            <p style={p}>
+              Self-host: use this block instead (dev key auto-injected on
+              localhost):
+            </p>
+            <Code lang="json">{`{
+  "mcpServers": {
+    "zizkadb": {
+      "command": "uvx",
+      "args": ["zizkadb-mcp"],
+      "env": { "ZIZKADB_HOST": "http://localhost:8000" }
+    }
+  }
+}`}</Code>
+            <h3 style={h3}>MCP tools</h3>
+            <p style={p}>
+              <code style={codeInline}>log_event</code>,{" "}
+              <code style={codeInline}>search_memory</code>,{" "}
+              <code style={codeInline}>get_context</code>,{" "}
+              <code style={codeInline}>why</code>,{" "}
+              <code style={codeInline}>query_events</code>,{" "}
+              <code style={codeInline}>time_travel</code>,{" "}
+              <code style={codeInline}>memory_diff</code>,{" "}
+              <code style={codeInline}>forget</code> — see{" "}
+              <Link href="/docs" style={link}>
+                setup guide
+              </Link>{" "}
+              for config.
+            </p>
+            <p style={p}>
+              Telemetry: one anonymous SDK startup ping (name, version, OS,
+              cloud vs self-host). Opt out:{" "}
+              <code style={codeInline}>ZIZKADB_TELEMETRY=false</code>.
+            </p>
+          </Section>
+
+          <Section id="api" title="REST API">
+            <p style={p}>
+              Base URL <code style={codeInline}>https://db.zizka.ai</code>.
+              Auth:{" "}
+              <code style={codeInline}>
+                Authorization: Bearer &lt;token&gt;
+              </code>
+              . Interactive schema:{" "}
+              <Link href="/swagger" style={link}>
+                /swagger
+              </Link>
+              .
+            </p>
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Method</th>
+                  <th style={th}>Path</th>
+                  <th style={th}>Purpose</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ["POST", "/v1/events", "Log event"],
+                  ["GET", "/v1/events", "Query events"],
+                  ["GET", "/v1/events/{id}/why", "Causal chain"],
+                  ["GET", "/v1/events/at", "State at timestamp"],
+                  ["POST", "/v1/search", "Semantic search"],
+                  ["POST", "/v1/memory/context", "Prompt context block"],
+                  ["GET", "/v1/memory/diff/{session_id}", "Session summary"],
+                  ["DELETE", "/v1/memory/forget", "Metadata erasure"],
+                  ["GET", "/v1/agents", "List agents"],
+                  ["GET", "/v1/agents/{id}/baseline", "Drift / baseline"],
+                  ["GET", "/health", "Health check"],
+                ].map(([m, path, purpose]) => (
+                  <tr key={path}>
+                    <td style={td}>
+                      <code style={codeInline}>{m}</code>
+                    </td>
+                    <td style={td}>
+                      <code style={codeInline}>{path}</code>
+                    </td>
+                    <td style={td}>{purpose}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Section>
+
+          <Section id="deployment" title="Deployment">
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Mode</th>
+                  <th style={th}>Cost</th>
+                  <th style={th}>Data residency</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ["Self-hosted", "Free (AGPL core)", "Your VPC / machine"],
+                  ["Managed Pro", "€29/mo", "Zizka cloud"],
+                  ["Managed Team", "€69/mo", "Zizka cloud + higher limits"],
+                  ["Enterprise", "Contact sales", "Customer VPC (Model A)"],
+                ].map(([m, c, d]) => (
+                  <tr key={m}>
+                    <td style={td}>{m}</td>
+                    <td style={td}>{c}</td>
+                    <td style={td}>{d}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p style={p}>
+              Onboarding:{" "}
+              <Link href="/signup" style={link}>
+                signup
+              </Link>{" "}
+              → email OTP → Settings → API key → SDK or MCP env. For Enterprise
+              VPC deployment, see{" "}
+              <Link href="/enterprise" style={link}>
+                /enterprise
+              </Link>
+              .
+            </p>
+          </Section>
+
+          <Section id="comparison" title="Comparison">
+            <p style={p}>
+              Capability matrix (May 2026). Verify competitor docs before
+              external debates; ~ = partial support.
+            </p>
+            <div style={{ overflowX: "auto" }}>
+              <table style={table}>
+                <thead>
+                  <tr>
+                    <th style={th}>Capability</th>
+                    <th style={{ ...th, textAlign: "center" }}>LangSmith</th>
+                    <th style={{ ...th, textAlign: "center" }}>Mem0</th>
+                    <th style={{ ...th, textAlign: "center" }}>Pinecone</th>
+                    <th
+                      style={{
+                        ...th,
+                        textAlign: "center",
+                        background: "#f5fffe",
+                      }}
+                    >
+                      ZizkaDB
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {[
+                    ["Agent event logging", "✓", "✗", "✗", "✓"],
+                    ["Causal lineage", "~", "✗", "✗", "✓"],
+                    ["Time travel (logged state at T)", "✗", "✗", "✗", "✓"],
+                    ["Semantic search on agent history", "✗", "✓", "✓", "✓"],
+                    ["Any framework / model", "~", "✓", "✓", "✓"],
+                    ["Behavioral baseline / drift", "✗", "✗", "✗", "✓"],
+                    ["Cross-agent fleet queries", "✗", "✗", "✗", "✓"],
+                    ["Per-event checksum", "✗", "✗", "✗", "✓"],
+                    ["Self-host (free tier)", "✓", "✓", "✗", "✓"],
+                  ].map(([cap, ...vals]) => (
+                    <tr key={cap}>
+                      <td style={td}>{cap}</td>
+                      {vals.map((v, j) => (
+                        <td
+                          key={j}
+                          style={{
+                            ...td,
+                            textAlign: "center",
+                            background: j === 3 ? "#f5fffe" : undefined,
+                            fontWeight: j === 3 ? 600 : 400,
+                          }}
+                        >
+                          {v}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Section>
+
+          <Section id="licensing" title="Licensing">
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Component</th>
+                  <th style={th}>License</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  ["Core API + self-host stack", "AGPL-3.0"],
+                  ["Python SDK", "AGPL-3.0"],
+                  ["TypeScript SDK", "AGPL-3.0"],
+                  ["MCP server", "MIT"],
+                ].map(([c, l]) => (
+                  <tr key={c}>
+                    <td style={td}>{c}</td>
+                    <td style={td}>{l}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p style={p}>
+              AGPL applies when you modify and distribute the server. MCP is MIT
+              for IDE integration. Commercial embedding requires legal review.
+              Enterprise VPC deployments use a separate commercial license — see{" "}
+              <Link href="/enterprise" style={link}>
+                /enterprise
+              </Link>
+              .
+            </p>
+          </Section>
+
+          <Section id="limits" title="Plan limits">
+            <table style={table}>
+              <thead>
+                <tr>
+                  <th style={th}>Plan</th>
+                  <th style={th}>Events / month</th>
+                  <th style={th}>Retention</th>
+                </tr>
+              </thead>
+              <tbody>
+                {[
+                  [
+                    "Self-hosted",
+                    "Unlimited (your hardware)",
+                    "Operator-defined",
+                  ],
+                  ["Pro (€29/mo)", "50k", "90 days"],
+                  ["Team (€69/mo)", "100k", "1 year"],
+                  ["Enterprise", "Contact sales", "Custom (VPC)"],
+                ].map(([plan, ev, ret]) => (
+                  <tr key={plan}>
+                    <td style={td}>{plan}</td>
+                    <td style={td}>{ev}</td>
+                    <td style={td}>{ret}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <p style={p}>
+              Baseline/drift requires sufficient{" "}
+              <code style={codeInline}>session_id</code> coverage; early agents
+              report <code style={codeInline}>warming_up</code> or{" "}
+              <code style={codeInline}>insufficient_data</code>.
+            </p>
+          </Section>
+
+          <Section id="faq" title="FAQ">
+            {[
+              {
+                q: "How is this different from LangSmith?",
+                a: "LangSmith focuses on LangChain-centric tracing and evals. ZizkaDB is a standalone operational store with causal trees, time travel over logged state, fleet baselines, and framework-agnostic ingestion.",
+              },
+              {
+                q: "How is this different from Mem0?",
+                a: "Mem0 optimizes long-term memory retrieval for prompts. ZizkaDB adds causal lineage, session replay, drift baselines, and checksum-backed event storage.",
+              },
+              {
+                q: "Do we replace Pinecone?",
+                a: "No. Pinecone indexes documents for RAG. ZizkaDB indexes agent decision history. Most teams use both.",
+              },
+              {
+                q: "Does ZizkaDB wrap LLM calls?",
+                a: "No. You call log() at existing decision points. Optional parent_id links causality.",
+              },
+              {
+                q: "Latency impact?",
+                a: "Logging is async HTTP. Embedding runs on ingest; hot path is typically fire-and-forget await db.log(...).",
+              },
+              {
+                q: "PII and GDPR?",
+                a: "You control data and metadata. forget() deletes by metadata filter. Self-host keeps data in your infrastructure.",
+              },
+              {
+                q: "PyPI package name?",
+                a: "Install zizkadb-sdk (not the unrelated agentdb package). Import: from zizkadb import ZizkaDB.",
+              },
+            ].map((item) => (
+              <div key={item.q} style={{ marginBottom: 20 }}>
+                <div
+                  style={{ fontWeight: 600, fontSize: 14.5, marginBottom: 6 }}
+                >
+                  {item.q}
+                </div>
+                <p style={{ ...p, margin: 0 }}>{item.a}</p>
+              </div>
+            ))}
+          </Section>
+
+          <Section id="contact" title="Contact">
+            <table style={table}>
+              <tbody>
+                {[
+                  ["Product", "https://db.zizka.ai"],
+                  ["Docs", "https://db.zizka.ai/docs"],
+                  ["API", "https://db.zizka.ai/swagger"],
+                  ["GitHub", GITHUB_URL],
+                  ["Email", FOUNDER_EMAIL],
+                ].map(([k, v]) => (
+                  <tr key={k}>
+                    <td style={{ ...td, width: "28%", fontWeight: 500 }}>
+                      {k}
+                    </td>
+                    <td style={td}>
+                      {k === "Email" ? (
+                        <a href={`mailto:${FOUNDER_EMAIL}`} style={link}>
+                          {FOUNDER_EMAIL}
+                        </a>
+                      ) : (
+                        <a
+                          href={v}
+                          style={link}
+                          target={k === "GitHub" ? "_blank" : undefined}
+                          rel="noreferrer"
+                        >
+                          {v}
+                        </a>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </Section>
+        </main>
+      </div>
+
+      <MarketingFooter />
+
+      <style>{`
+        @media (min-width: 900px) {
+          .trust-sidebar { display: block !important; }
+        }
+      `}</style>
+    </div>
+  );
+}
+
+function Section({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <section id={id} style={{ marginBottom: 56, scrollMarginTop: 72 }}>
+      <h2
+        style={{
+          fontSize: 22,
+          fontWeight: 700,
+          marginBottom: 16,
+          letterSpacing: -0.3,
+          paddingTop: id === "overview" ? 0 : 8,
+          borderTop: id === "overview" ? "none" : "1px solid #f0f0f0",
+        }}
+      >
+        {title}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+function Code({ children, lang }: { children: string; lang?: string }) {
+  return (
+    <pre style={pre}>
+      {lang && (
+        <span
+          style={{
+            display: "block",
+            fontSize: 10,
+            color: "#999",
+            marginBottom: 8,
+            textTransform: "uppercase",
+            letterSpacing: 1,
+            fontFamily: "sans-serif",
+          }}
+        >
+          {lang}
+        </span>
+      )}
+      {children}
+    </pre>
+  );
+}
+
+const p: CSSProperties = {
+  fontSize: 15,
+  color: "#000000",
+  lineHeight: 1.75,
+  margin: "0 0 14px",
+};
+const ul: CSSProperties = {
+  margin: "0 0 14px",
+  paddingLeft: 22,
+  fontSize: 15,
+  color: "#000000",
+  lineHeight: 1.8,
+};
+const h3: CSSProperties = {
+  fontSize: 15,
+  fontWeight: 600,
+  margin: "24px 0 10px",
+  color: "#000000",
+};
+const codeInline: CSSProperties = codeInlineOnLight;
+const link: CSSProperties = { color: "#000000", fontWeight: 500 };
+const table: CSSProperties = {
+  width: "100%",
+  borderCollapse: "collapse",
+  fontSize: 14,
+  margin: "12px 0",
+};
+const th: CSSProperties = {
+  textAlign: "left",
+  padding: "10px 12px",
+  borderBottom: "2px solid #eee",
+  color: "#000000",
+  fontWeight: 600,
+  fontSize: 13,
+};
+const td: CSSProperties = {
+  padding: "10px 12px",
+  borderBottom: "1px solid #f0f0f0",
+  color: "#000000",
+  verticalAlign: "top",
+};
+const pre: CSSProperties = {
+  margin: "12px 0",
+  padding: 16,
+  background: "#fafafa",
+  border: "1px solid #eee",
+  borderRadius: 10,
+  fontSize: 12.5,
+  lineHeight: 1.65,
+  overflowX: "auto",
+  fontFamily: "JetBrains Mono, Menlo, monospace",
+};

--- a/dashboard/components/BrandLogo.tsx
+++ b/dashboard/components/BrandLogo.tsx
@@ -10,6 +10,8 @@ type BrandLogoProps = {
   variant?: 'nav' | 'full' | 'mark'
   /** Show "ZizkaDB" text beside the mark (nav only) */
   showWordmark?: boolean
+  /** light = dark text on white panels · dark = white text on black/navy marketing */
+  theme?: 'light' | 'dark'
   href?: string
   suffix?: string
 }
@@ -47,13 +49,21 @@ function LogoMark({ variant }: { variant: 'nav' | 'full' | 'mark' }) {
 export function BrandLogo({
   variant = 'nav',
   showWordmark = true,
+  theme = 'dark',
   href = '/',
   suffix,
 }: BrandLogoProps) {
+  const isDark = theme === 'dark'
   const wordmarkStyle: CSSProperties = {
     fontWeight: 700,
     fontSize: variant === 'full' ? 22 : 15,
-    color: variant === 'full' ? '#111' : '#111',
+    color: isDark ? '#ffffff' : '#111111',
+  }
+  const suffixStyle: CSSProperties = {
+    fontSize: variant === 'full' ? 13 : 12,
+    color: isDark ? 'rgba(255,255,255,0.55)' : '#888888',
+    marginTop: variant === 'full' ? 4 : undefined,
+    marginLeft: variant === 'nav' ? (suffix ? 2 : 4) : undefined,
   }
 
   const inner = variant === 'full' ? (
@@ -63,7 +73,7 @@ export function BrandLogo({
         <div style={{ ...wordmarkStyle, marginTop: 10 }}>ZizkaDB</div>
       )}
       {suffix && (
-        <div style={{ fontSize: 13, color: '#888', marginTop: 4 }}>{suffix}</div>
+        <div style={suffixStyle}>{suffix}</div>
       )}
     </div>
   ) : (
@@ -73,9 +83,9 @@ export function BrandLogo({
         <>
           <span style={wordmarkStyle}>ZizkaDB</span>
           {suffix ? (
-            <span style={{ fontSize: 12, color: '#aaa', marginLeft: 2 }}>/ {suffix}</span>
+            <span style={suffixStyle}>/ {suffix}</span>
           ) : (
-            <span style={{ fontSize: 12, color: '#aaa', marginLeft: 4 }}>by Zizka AI</span>
+            <span className="brand-logo-tagline" style={suffixStyle}>by Zizka AI</span>
           )}
         </>
       )}

--- a/dashboard/components/CookiePrivacyConsent.tsx
+++ b/dashboard/components/CookiePrivacyConsent.tsx
@@ -1,0 +1,112 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import type { CSSProperties } from 'react'
+
+type Choice = 'accepted' | 'declined'
+
+const KEY = 'zizkadb_privacy_consent'
+
+export function CookiePrivacyConsent() {
+  const [choice, setChoice] = useState<Choice | null>(null)
+
+  useEffect(() => {
+    try {
+      const v = window.localStorage.getItem(KEY)
+      if (v === 'accepted' || v === 'declined') setChoice(v)
+      else setChoice(null)
+    } catch {
+      setChoice(null)
+    }
+  }, [])
+
+  const visible = choice === null
+
+  const styles = useMemo(() => {
+    const wrap: CSSProperties = {
+      position: 'fixed',
+      left: 16,
+      right: 16,
+      bottom: 16,
+      zIndex: 2000,
+      display: visible ? 'flex' : 'none',
+      justifyContent: 'center',
+      pointerEvents: visible ? 'auto' : 'none',
+    }
+    const card: CSSProperties = {
+      width: 'min(980px, 100%)',
+      background: '#111',
+      border: '1px solid #1f1f1f',
+      borderRadius: 14,
+      padding: '14px 16px',
+      color: '#e5e5e5',
+      display: 'flex',
+      gap: 14,
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      flexWrap: 'wrap',
+      boxShadow: '0 18px 50px rgba(0,0,0,0.45)',
+    }
+    const text: CSSProperties = {
+      fontSize: 13,
+      lineHeight: 1.5,
+      color: '#e5e5e5',
+      flex: '1 1 520px',
+    }
+    const actions: CSSProperties = { display: 'flex', gap: 10, flex: '0 0 auto' }
+    const btn: CSSProperties = {
+      border: '1px solid #2a2a2a',
+      background: '#0a0a0a',
+      color: '#e5e5e5',
+      borderRadius: 10,
+      padding: '8px 12px',
+      fontSize: 13,
+      fontWeight: 600,
+      cursor: 'pointer',
+    }
+    const btnPrimary: CSSProperties = {
+      border: '1px solid #f97316',
+      background: '#f97316',
+      color: '#111',
+    }
+    const link: CSSProperties = { color: '#a3a3a3', textDecoration: 'underline' }
+
+    return { wrap, card, text, actions, btn, btnPrimary, link }
+  }, [visible])
+
+  const decide = (v: Choice) => {
+    try {
+      window.localStorage.setItem(KEY, v)
+    } catch {
+      // ignore
+    }
+    setChoice(v)
+  }
+
+  return (
+    <div style={styles.wrap} aria-hidden={!visible}>
+      <div style={styles.card} role="dialog" aria-label="Cookie and privacy notice">
+        <div style={styles.text}>
+          <strong style={{ color: '#fff' }}>Cookie and Privacy Consent</strong>
+          <div style={{ marginTop: 4, color: '#a3a3a3' }}>
+            We use cookies/local storage for essential site functionality and to improve the product. You can accept or
+            decline — you’ll still have full access either way.{' '}
+            <a href="/privacy" style={styles.link}>
+              Privacy policy
+            </a>
+            .
+          </div>
+        </div>
+        <div style={styles.actions}>
+          <button type="button" style={styles.btn} onClick={() => decide('declined')}>
+            Decline
+          </button>
+          <button type="button" style={{ ...styles.btn, ...styles.btnPrimary }} onClick={() => decide('accepted')}>
+            Accept
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/dashboard/components/MarketingSubscribePopup.tsx
+++ b/dashboard/components/MarketingSubscribePopup.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { submitMarketingSubscription } from '@/lib/marketing'
+
+const DISMISS_KEY = 'zizkadb_marketing_popup_dismissed_at'
+const SUBMITTED_KEY = 'zizkadb_marketing_popup_submitted_at'
+
+function nowMs() {
+  return Date.now()
+}
+
+function parseMs(v: string | null): number | null {
+  if (!v) return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+export function MarketingSubscribePopup() {
+  const [open, setOpen] = useState(false)
+  const [email, setEmail] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const timer = useRef<number | null>(null)
+
+  useEffect(() => {
+    // Show after 15 seconds, unless recently dismissed or already submitted.
+    const dismissed = parseMs(window.localStorage.getItem(DISMISS_KEY))
+    const submitted = parseMs(window.localStorage.getItem(SUBMITTED_KEY))
+
+    // If already submitted, never show again.
+    if (submitted) return
+
+    // If dismissed in last 7 days, don't show again yet.
+    if (dismissed && nowMs() - dismissed < 7 * 24 * 60 * 60 * 1000) return
+
+    timer.current = window.setTimeout(() => setOpen(true), 15_000)
+    return () => {
+      if (timer.current) window.clearTimeout(timer.current)
+    }
+  }, [])
+
+  const styles = useMemo(() => {
+    return {
+      backdrop: {
+        position: 'fixed' as const,
+        inset: 0,
+        zIndex: 1900,
+        background: 'rgba(0,0,0,0.55)',
+        display: open ? 'flex' : 'none',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: 16,
+      },
+      card: {
+        width: 'min(560px, 100%)',
+        background: '#0d0d0d',
+        border: '1px solid #1f1f1f',
+        borderRadius: 16,
+        padding: '20px 18px',
+        color: '#e5e5e5',
+        boxShadow: '0 18px 60px rgba(0,0,0,0.55)',
+      },
+      h: { fontSize: 18, fontWeight: 700, marginBottom: 6, color: '#fff' },
+      p: { fontSize: 13.5, color: '#a3a3a3', lineHeight: 1.55, marginBottom: 14 },
+      row: { display: 'flex', gap: 10, flexWrap: 'wrap' as const },
+      input: {
+        flex: '1 1 260px',
+        padding: '10px 12px',
+        background: '#0a0a0a',
+        border: '1px solid #2a2a2a',
+        borderRadius: 10,
+        color: '#fff',
+        fontSize: 14,
+        outline: 'none',
+      },
+      btn: {
+        flex: '0 0 auto',
+        padding: '10px 14px',
+        borderRadius: 10,
+        border: '1px solid #f97316',
+        background: '#f97316',
+        color: '#111',
+        fontSize: 14,
+        fontWeight: 700,
+        cursor: 'pointer',
+        opacity: busy ? 0.7 : 1,
+      },
+      err: {
+        marginTop: 10,
+        padding: '10px 12px',
+        background: '#1a0000',
+        border: '1px solid #ef444440',
+        borderRadius: 10,
+        color: '#f87171',
+        fontSize: 13,
+      },
+      small: { marginTop: 10, fontSize: 12, color: '#737373' },
+    }
+  }, [open, busy])
+
+  const close = () => {
+    try {
+      window.localStorage.setItem(DISMISS_KEY, String(nowMs()))
+    } catch {
+      // ignore
+    }
+    setOpen(false)
+  }
+
+  const submit = async () => {
+    setBusy(true)
+    setErr('')
+    try {
+      await submitMarketingSubscription({ email: email.trim() })
+      try {
+        window.localStorage.setItem(SUBMITTED_KEY, String(nowMs()))
+      } catch {
+        // ignore
+      }
+      setOpen(false)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to subscribe')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div
+      style={styles.backdrop}
+      role="dialog"
+      aria-label="Marketing subscription"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) close()
+      }}
+    >
+      <div style={styles.card} onMouseDown={(e) => e.stopPropagation()}>
+        <div style={styles.h}>Want to learn more about AI Agent Audits?</div>
+        <div style={styles.p}>
+          Get occasional updates on audits, causal lineage, and self-hosted best practices. No spam.
+        </div>
+
+        <div style={styles.row}>
+          <input
+            style={styles.input}
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="you@example.com"
+            inputMode="email"
+            autoComplete="email"
+            disabled={busy}
+          />
+          <button
+            type="button"
+            style={styles.btn}
+            disabled={busy || email.trim().length < 3}
+            onClick={submit}
+          >
+            Subscribe
+          </button>
+        </div>
+
+        {err && <div style={styles.err}>{err}</div>}
+
+        <div style={styles.small}>Tip: click outside this box to dismiss.</div>
+      </div>
+    </div>
+  )
+}
+

--- a/dashboard/components/SiteNav.tsx
+++ b/dashboard/components/SiteNav.tsx
@@ -1,0 +1,242 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import type { CSSProperties } from "react";
+import { BrandLogo } from "./BrandLogo";
+import {
+  BRAND,
+  BRAND_DARK,
+  BRAND_LIGHT,
+  brandCtaStyle,
+  enterpriseNavLinkStyle,
+} from "./brand";
+
+export type SiteNavActive =
+  | "docs"
+  | "community"
+  | "trust"
+  | "explorer"
+  | "home"
+  | "enterprise";
+
+type SiteNavProps = {
+  active?: SiteNavActive;
+  /** e.g. "Docs" shows as "ZizkaDB / Docs" */
+  suffix?: string;
+};
+
+const linkStyle = (on: boolean): CSSProperties => ({
+  fontSize: 14,
+  color: on ? "#fff" : "#ffffff",
+  fontWeight: on ? 600 : 400,
+  textDecoration: "none",
+});
+
+const mobileLinkStyle = (on: boolean): CSSProperties => ({
+  display: "block",
+  padding: "14px 0",
+  fontSize: 16,
+  fontWeight: on ? 600 : 500,
+  color: on ? "#fff" : "#ffffff",
+  textDecoration: "none",
+  borderBottom: "1px solid rgba(255,255,255,0.08)",
+});
+
+export function SiteNav({ active, suffix }: SiteNavProps) {
+  const enterpriseActive = active === "enterprise";
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  useEffect(() => {
+    document.body.style.overflow = menuOpen ? "hidden" : "";
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [menuOpen]);
+
+  return (
+    <>
+      <style>{`
+        .site-nav-enterprise:not([data-active="true"]):hover {
+          border-color: ${BRAND_LIGHT} !important;
+          box-shadow: 0 2px 12px rgba(249,115,22,0.18) !important;
+          color: ${BRAND_DARK} !important;
+        }
+        .site-nav-enterprise:focus-visible {
+          outline: 2px solid ${BRAND};
+          outline-offset: 2px;
+        }
+        .site-nav-menu-btn {
+          align-items: center;
+          justify-content: center;
+          width: 40px;
+          height: 40px;
+          padding: 0;
+          border: 1px solid rgba(255,255,255,0.16);
+          border-radius: 10px;
+          background: rgba(255,255,255,0.06);
+          color: #fff;
+          cursor: pointer;
+        }
+        .site-nav-menu-btn:focus-visible {
+          outline: 2px solid ${BRAND};
+          outline-offset: 2px;
+        }
+        .site-nav-mobile-backdrop {
+          position: fixed;
+          inset: 0;
+          top: 56px;
+          background: rgba(0,0,0,0.55);
+          z-index: 98;
+        }
+        .site-nav-mobile-panel {
+          position: fixed;
+          top: 56px;
+          left: 0;
+          right: 0;
+          max-height: calc(100dvh - 56px);
+          overflow-y: auto;
+          background: rgba(6,6,16,0.98);
+          border-bottom: 1px solid rgba(255,255,255,0.1);
+          padding: 8px 20px 24px;
+          padding-bottom: calc(24px + env(safe-area-inset-bottom));
+          z-index: 99;
+        }
+      `}</style>
+      <nav
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          padding: "0 max(16px, env(safe-area-inset-left)) 0 max(16px, env(safe-area-inset-right))",
+          height: 56,
+          borderBottom: "1px solid rgba(255,255,255,0.08)",
+          position: "sticky",
+          top: 0,
+          background: "rgba(6,6,16,0.92)",
+          backdropFilter: "blur(10px)",
+          zIndex: 100,
+          gap: 12,
+          minWidth: 0,
+        }}
+      >
+        <div style={{ minWidth: 0, flexShrink: 1 }}>
+          <BrandLogo suffix={suffix} />
+        </div>
+
+        <div
+          className="site-nav-links"
+          style={{ display: "flex", alignItems: "center", gap: 20, flexShrink: 0 }}
+        >
+          <Link href="/docs" style={linkStyle(active === "docs")}>
+            Docs
+          </Link>
+          <Link href="/community" style={linkStyle(active === "community")}>
+            Community
+          </Link>
+          <a href="/swagger" style={linkStyle(active === "explorer")}>
+            API Explorer
+          </a>
+          <Link
+            href="/enterprise"
+            className="site-nav-enterprise"
+            data-active={enterpriseActive ? "true" : "false"}
+            style={enterpriseNavLinkStyle(enterpriseActive)}
+          >
+            Enterprise
+          </Link>
+          <Link
+            href="/login"
+            style={{
+              fontSize: 14,
+              fontWeight: 500,
+              color: "rgba(255,255,255,0.85)",
+              textDecoration: "none",
+              padding: "7px 16px",
+              border: "1px solid rgba(255,255,255,0.16)",
+              borderRadius: 8,
+            }}
+          >
+            Sign in
+          </Link>
+          <Link href="/signup" style={brandCtaStyle}>
+            Get started
+          </Link>
+        </div>
+
+        <button
+          type="button"
+          className="site-nav-menu-btn"
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+          aria-expanded={menuOpen}
+          onClick={() => setMenuOpen((o) => !o)}
+        >
+          {menuOpen ? (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M6 6l12 12M18 6L6 18" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          ) : (
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden>
+              <path d="M4 7h16M4 12h16M4 17h16" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
+            </svg>
+          )}
+        </button>
+      </nav>
+
+      {menuOpen && (
+        <div className="site-nav-mobile-drawer">
+          <button
+            type="button"
+            className="site-nav-mobile-backdrop"
+            aria-label="Close menu"
+            onClick={() => setMenuOpen(false)}
+          />
+          <div className="site-nav-mobile-panel" role="dialog" aria-modal="true" aria-label="Navigation">
+            <Link href="/docs" style={mobileLinkStyle(active === "docs")} onClick={() => setMenuOpen(false)}>
+              Docs
+            </Link>
+            <Link href="/community" style={mobileLinkStyle(active === "community")} onClick={() => setMenuOpen(false)}>
+              Community
+            </Link>
+            <a href="/swagger" style={mobileLinkStyle(active === "explorer")} onClick={() => setMenuOpen(false)}>
+              API Explorer
+            </a>
+            <Link
+              href="/enterprise"
+              style={mobileLinkStyle(enterpriseActive)}
+              onClick={() => setMenuOpen(false)}
+            >
+              Enterprise
+            </Link>
+            <div style={{ display: "flex", flexDirection: "column", gap: 10, marginTop: 20 }}>
+              <Link
+                href="/login"
+                onClick={() => setMenuOpen(false)}
+                style={{
+                  display: "flex",
+                  justifyContent: "center",
+                  padding: "12px 16px",
+                  fontSize: 15,
+                  fontWeight: 600,
+                  color: "rgba(255,255,255,0.9)",
+                  textDecoration: "none",
+                  border: "1px solid rgba(255,255,255,0.16)",
+                  borderRadius: 10,
+                }}
+              >
+                Sign in
+              </Link>
+              <Link
+                href="/signup"
+                onClick={() => setMenuOpen(false)}
+                style={{ ...brandCtaStyle, justifyContent: "center", width: "100%" }}
+              >
+                Get started
+              </Link>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/dashboard/components/brand.ts
+++ b/dashboard/components/brand.ts
@@ -1,0 +1,46 @@
+/** Brand colors */
+export const BRAND = "#f97316";
+export const BRAND_DARK = "#ea580c";
+export const BRAND_LIGHT = "#fdba74";
+export const BRAND_PALE = "#fed7aa";
+export const BRAND_MUTED = "#9a3412";
+export const BRAND_SHADOW_TINT = "rgba(249,115,22,0.1)";
+
+export const brandLogoStyle = {
+  width: 28,
+  height: 28,
+  borderRadius: 7,
+  background: BRAND,
+  display: "flex" as const,
+  alignItems: "center" as const,
+  justifyContent: "center" as const,
+};
+
+export const enterpriseNavLinkStyle = (active: boolean) =>
+  ({
+    fontSize: 13,
+    fontWeight: 700,
+    letterSpacing: 0.25,
+    color: active ? "#fff" : "#9a3412",
+    textDecoration: "none",
+    padding: "7px 14px",
+    borderRadius: 8,
+    border: `1px solid ${active ? BRAND : BRAND_PALE}`,
+    background: active
+      ? `linear-gradient(135deg, ${BRAND} 0%, ${BRAND_DARK} 100%)`
+      : `linear-gradient(135deg, #fff 0%, ${BRAND_PALE}40 100%)`,
+    boxShadow: active
+      ? "0 2px 10px rgba(249,115,22,0.3)"
+      : "0 1px 4px rgba(249,115,22,0.08)",
+  }) as const;
+
+export const brandCtaStyle = {
+  fontSize: 14,
+  fontWeight: 600,
+  color: "#fff",
+  textDecoration: "none",
+  padding: "8px 18px",
+  background: `linear-gradient(135deg, ${BRAND} 0%, ${BRAND_DARK} 100%)`,
+  borderRadius: 8,
+  boxShadow: "0 2px 12px rgba(249,115,22,0.35)",
+};

--- a/dashboard/components/marketing/CalendlyBookModal.tsx
+++ b/dashboard/components/marketing/CalendlyBookModal.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { M, secondaryBtn } from './marketing-theme'
+
+const CALENDLY_URL = process.env.NEXT_PUBLIC_CALENDLY_URL ?? 'https://calendly.com/founder-zizka/15-minutes'
+
+type Props = {
+  open: boolean
+  onClose: () => void
+}
+
+declare global {
+  interface Window {
+    Calendly?: {
+      initInlineWidget: (opts: { url: string; parentElement: HTMLElement }) => void
+    }
+  }
+}
+
+function loadCalendlyScript(): Promise<void> {
+  if (window.Calendly) return Promise.resolve()
+  return new Promise((resolve, reject) => {
+    const existing = document.querySelector('script[src*="calendly.com/assets/external/widget.js"]')
+    if (existing) {
+      existing.addEventListener('load', () => resolve())
+      existing.addEventListener('error', () => reject(new Error('Calendly failed to load')))
+      if (window.Calendly) resolve()
+      return
+    }
+    const script = document.createElement('script')
+    script.src = 'https://assets.calendly.com/assets/external/widget.js'
+    script.async = true
+    script.onload = () => resolve()
+    script.onerror = () => reject(new Error('Calendly failed to load'))
+    document.head.appendChild(script)
+  })
+}
+
+export function CalendlyBookModal({ open, onClose }: Props) {
+  const embedRef = useRef<HTMLDivElement>(null)
+  const [booked, setBooked] = useState(false)
+  const [loadErr, setLoadErr] = useState('')
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !booked) onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose, booked])
+
+  useEffect(() => {
+    if (!open) return
+
+    const onMessage = (e: MessageEvent) => {
+      if (e.origin !== 'https://calendly.com') return
+      if (e.data?.event === 'calendly.event_scheduled') {
+        setBooked(true)
+      }
+    }
+    window.addEventListener('message', onMessage)
+    return () => window.removeEventListener('message', onMessage)
+  }, [open])
+
+  useEffect(() => {
+    if (!open) {
+      setBooked(false)
+      setLoadErr('')
+      return
+    }
+    if (booked) return
+
+    let cancelled = false
+    setLoadErr('')
+
+    loadCalendlyScript()
+      .then(() => {
+        if (cancelled || !embedRef.current) return
+        embedRef.current.innerHTML = ''
+        window.Calendly?.initInlineWidget({
+          url: CALENDLY_URL,
+          parentElement: embedRef.current,
+        })
+      })
+      .catch(() => {
+        if (!cancelled) setLoadErr('Could not load the scheduler. Try again or open Calendly in a new tab.')
+      })
+
+    return () => { cancelled = true }
+  }, [open, booked])
+
+  if (!open) return null
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="book-demo-title"
+      style={{
+        position: 'fixed', inset: 0, zIndex: 200,
+        background: 'rgba(0,0,0,0.45)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        padding: 16,
+      }}
+      onClick={booked ? onClose : undefined}
+    >
+      <div
+        style={{
+          width: '100%', maxWidth: booked ? 440 : 520, background: '#fff', borderRadius: 16,
+          border: `1px solid ${M.line}`, boxShadow: '0 24px 64px rgba(0,0,0,0.18)',
+          overflow: 'hidden',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        {booked ? (
+          <div style={{ padding: '32px 28px', textAlign: 'center' }}>
+            <h2 id="book-demo-title" style={{ margin: '0 0 12px', fontSize: 22, fontWeight: 800, color: '#000' }}>
+              You&apos;re booked
+            </h2>
+            <p style={{ margin: '0 0 24px', fontSize: 15, fontWeight: 600, color: '#000', lineHeight: 1.55 }}>
+              Thank you for booking a demo call with ZizkaDB. A confirmation email has been sent.
+            </p>
+            <button type="button" onClick={onClose} style={{ ...secondaryBtn, border: 'none', cursor: 'pointer' }}>
+              Close
+            </button>
+          </div>
+        ) : (
+          <>
+            <div style={{ padding: '18px 20px 0', display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+              <h2 id="book-demo-title" style={{ margin: 0, fontSize: 18, fontWeight: 800, color: '#000' }}>
+                Book a 15-minute demo
+              </h2>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Close"
+                style={{
+                  background: 'none', border: 'none', fontSize: 22, lineHeight: 1,
+                  color: '#000', cursor: 'pointer', padding: 4,
+                }}
+              >
+                ×
+              </button>
+            </div>
+            {loadErr ? (
+              <div style={{ padding: '16px 20px 24px' }}>
+                <p style={{ margin: '0 0 16px', fontSize: 14, color: '#b91c1c', fontWeight: 600 }}>{loadErr}</p>
+                <a href={CALENDLY_URL} target="_blank" rel="noreferrer" style={{ ...secondaryBtn, display: 'inline-flex' }}>
+                  Open Calendly →
+                </a>
+              </div>
+            ) : (
+              <div ref={embedRef} style={{ minWidth: 320, height: 680 }} />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/components/marketing/CompetitorCompare.tsx
+++ b/dashboard/components/marketing/CompetitorCompare.tsx
@@ -1,0 +1,211 @@
+import Link from "next/link";
+import { BRAND } from "@/components/brand";
+import { M, container, h2, lead, sectionTitle, secondaryBtn, outlineBtn } from "./marketing-theme";
+import { GITHUB_URL } from "@/lib/constants";
+
+const ROWS: [string, string, string, string, string][] = [
+  ["Agent event logging", "✓", "✗", "✗", "✓"],
+  ["Causal lineage", "~", "✗", "✗", "✓"],
+  ["Time travel (state at T)", "✗", "✗", "✗", "✓"],
+  ["Semantic search on history", "✗", "✓", "✓", "✓"],
+  ["Behavioral baseline / drift", "✗", "✗", "✗", "✓"],
+  ["Cross-agent fleet queries", "✗", "✗", "✗", "✓"],
+  ["Self-host free", "✓", "✓", "✗", "✓"],
+];
+
+const COLS = [
+  "Capability",
+  "LangSmith",
+  "Mem0",
+  "Pinecone",
+  "ZizkaDB",
+] as const;
+
+const MOBILE_COMPETITORS = ["LangSmith", "Mem0", "Pinecone", "ZizkaDB"] as const;
+
+function cellColor(v: string) {
+  return v === "✓" ? M.success : v === "~" ? BRAND : M.muted;
+}
+
+export function CompetitorCompare() {
+  return (
+    <section
+      id="compare"
+      className="zdb-section"
+      style={{ padding: "88px 40px", background: M.bg }}
+    >
+      <div style={container(980)}>
+        <p style={sectionTitle}>Compare</p>
+        <h2 className="zdb-section-h2" style={h2}>
+          Operational database vs traces, memory, and vectors
+        </h2>
+        <p className="zdb-lead" style={lead}>
+          Vector DBs store embeddings. Traces show spans. ZizkaDB stores agent
+          decisions, lineage, and drift.
+        </p>
+
+        <div
+          className="zdb-compare-table-wrap"
+          style={{
+            overflowX: "auto",
+            marginBottom: 28,
+            borderRadius: 16,
+            border: `1px solid ${M.line}`,
+            WebkitOverflowScrolling: "touch",
+          }}
+        >
+          <table
+            style={{ width: "100%", borderCollapse: "collapse", minWidth: 640 }}
+          >
+            <thead>
+              <tr style={{ background: M.surface }}>
+                {COLS.map((col, i) => (
+                  <th
+                    key={col}
+                    style={{
+                      padding: "14px 16px",
+                      textAlign: i === 0 ? "left" : "center",
+                      fontSize: 13,
+                      fontWeight: 800,
+                      color: M.inkSoft,
+                      borderBottom: `2px solid ${M.line}`,
+                      background: i === 4 ? "rgba(249,115,22,0.12)" : M.surface,
+                    }}
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {ROWS.map(([cap, ...vals]) => (
+                <tr key={cap}>
+                  <td
+                    style={{
+                      padding: "12px 16px",
+                      fontSize: 13,
+                      fontWeight: 600,
+                      color: M.inkSoft,
+                      borderBottom: `1px solid ${M.line}`,
+                      background: M.bgElevated,
+                    }}
+                  >
+                    {cap}
+                  </td>
+                  {vals.map((v, j) => (
+                    <td
+                      key={j}
+                      style={{
+                        padding: "12px 16px",
+                        textAlign: "center",
+                        fontSize: 15,
+                        fontWeight: 800,
+                        color: cellColor(v),
+                        borderBottom: `1px solid ${M.line}`,
+                        background: j === 3 ? "rgba(249,115,22,0.08)" : M.bgElevated,
+                      }}
+                    >
+                      {v}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <div
+          className="zdb-compare-mobile"
+          style={{
+            flexDirection: "column",
+            gap: 12,
+            marginBottom: 28,
+          }}
+        >
+          {ROWS.map(([cap, ...vals]) => (
+            <div
+              key={cap}
+              style={{
+                borderRadius: 14,
+                border: `1px solid ${M.line}`,
+                background: M.bgElevated,
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  padding: "12px 16px",
+                  fontSize: 14,
+                  fontWeight: 700,
+                  color: M.ink,
+                  borderBottom: `1px solid ${M.line}`,
+                  background: M.surface,
+                }}
+              >
+                {cap}
+              </div>
+              <div
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "repeat(2, 1fr)",
+                  gap: 1,
+                  background: M.line,
+                }}
+              >
+                {vals.map((v, j) => (
+                  <div
+                    key={MOBILE_COMPETITORS[j]}
+                    style={{
+                      padding: "10px 12px",
+                      background: j === 3 ? "rgba(249,115,22,0.08)" : M.bgElevated,
+                      textAlign: "center",
+                    }}
+                  >
+                    <div style={{ fontSize: 10, fontWeight: 700, color: M.faint, marginBottom: 4 }}>
+                      {MOBILE_COMPETITORS[j]}
+                    </div>
+                    <div style={{ fontSize: 16, fontWeight: 800, color: cellColor(v) }}>{v}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <p
+          style={{
+            textAlign: "center",
+            fontSize: 13,
+            fontWeight: 600,
+            color: M.muted,
+            margin: "0 0 20px",
+          }}
+        >
+          ~ = partial support. Verify competitor docs before external debates.
+        </p>
+
+        <div
+          className="zdb-cta-row"
+          style={{
+            display: "flex",
+            gap: 12,
+            justifyContent: "center",
+            flexWrap: "wrap",
+          }}
+        >
+          <a
+            href={GITHUB_URL}
+            target="_blank"
+            rel="noreferrer"
+            style={{ ...secondaryBtn, fontWeight: 700 }}
+          >
+            View on GitHub →
+          </a>
+          <Link href="/trust#comparison" style={{ ...outlineBtn, fontWeight: 700 }}>
+            Full comparison
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/dashboard/components/marketing/ConversationCompare.tsx
+++ b/dashboard/components/marketing/ConversationCompare.tsx
@@ -1,0 +1,174 @@
+import { BRAND, BRAND_SHADOW_TINT } from "@/components/brand";
+import { M, container, h2, lead } from "./marketing-theme";
+
+export function ConversationCompare() {
+  return (
+    <section
+      id="demo"
+      className="zdb-section"
+      style={{ padding: "88px 40px", background: M.bgElevated }}
+    >
+      <div style={container(980)}>
+        <h2 className="zdb-section-h2" style={h2}>See what changes when you can replay any session</h2>
+        <p className="zdb-lead" style={lead}>
+          Same incident. Without ZizkaDB you guess. With it you see the exact
+          decision trail.
+        </p>
+
+        <div
+          className="zdb-compare-grid"
+          style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 24 }}
+        >
+          <ComparePanel
+            title="Without ZizkaDB"
+            subtitle="Your team today"
+            muted
+            messages={[
+              {
+                role: "Customer",
+                text: "Your bot told me refunds take 30 days. That is wrong.",
+              },
+              {
+                role: "Your team",
+                text: "Can you send a screenshot? We will check the logs.",
+              },
+              {
+                role: "Engineering",
+                text: "Logs show nothing useful. Maybe a prompt issue?",
+              },
+            ]}
+            footer="Hours lost. Still no root cause."
+          />
+          <ComparePanel
+            title="With ZizkaDB"
+            subtitle="Same incident, 2 minutes later"
+            highlight
+            messages={[
+              {
+                role: "Drift alert",
+                text: "Refund answers changed after prompt v2 deploy.",
+              },
+              {
+                role: "Replay",
+                text: "Agent skipped policy doc, used outdated FAQ chunk.",
+              },
+              {
+                role: "Fix",
+                text: "Roll back prompt. Confirm baseline restored.",
+              },
+            ]}
+            footer="Root cause found. Prompt rolled back."
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function ComparePanel({
+  title,
+  subtitle,
+  messages,
+  footer,
+  muted,
+  highlight,
+}: {
+  title: string;
+  subtitle: string;
+  messages: { role: string; text: string }[];
+  footer: string;
+  muted?: boolean;
+  highlight?: boolean;
+}) {
+  return (
+    <div
+      style={{
+        borderRadius: 20,
+        overflow: "hidden",
+        border: highlight ? `2px solid ${BRAND}` : `1px solid ${M.line}`,
+        boxShadow: highlight
+          ? `0 16px 48px ${BRAND_SHADOW_TINT}`
+          : "0 4px 20px rgba(0,0,0,0.25)",
+      }}
+    >
+      <div
+        style={{
+          padding: "18px 20px",
+          background: highlight
+            ? "linear-gradient(135deg, rgba(249,115,22,0.15), rgba(17,24,39,0.9))"
+            : M.surface,
+          borderBottom: `1px solid ${M.line}`,
+        }}
+      >
+        <div
+          style={{
+            fontSize: 11,
+            fontWeight: 800,
+            letterSpacing: 0.6,
+            color: M.faint,
+            marginBottom: 4,
+          }}
+        >
+          {title.toUpperCase()}
+        </div>
+        <div style={{ fontSize: 16, fontWeight: 700, color: M.ink }}>
+          {subtitle}
+        </div>
+      </div>
+      <div
+        style={{
+          padding: "18px 20px",
+          background: M.bgElevated,
+          display: "flex",
+          flexDirection: "column",
+          gap: 12,
+        }}
+      >
+        {messages.map((m, i) => (
+          <div
+            key={i}
+            style={{
+              padding: "12px 14px",
+              borderRadius: 12,
+              background: muted
+                ? M.surface
+                : highlight && i === 0
+                  ? "rgba(249,115,22,0.12)"
+                  : M.surfaceHover,
+              border: `1px solid ${M.line}`,
+            }}
+          >
+            <div
+              style={{
+                fontSize: 10,
+                fontWeight: 800,
+                color: M.faint,
+                marginBottom: 4,
+              }}
+            >
+              {m.role}
+            </div>
+            <div style={{ fontSize: 13, color: M.inkSoft, lineHeight: 1.5 }}>
+              {m.text}
+            </div>
+          </div>
+        ))}
+        <div
+          style={{
+            marginTop: 4,
+            fontSize: 13,
+            fontWeight: 700,
+            lineHeight: 1.5,
+            color: muted ? M.muted : M.success,
+            padding: "12px 14px",
+            borderRadius: 12,
+            background: muted ? M.surface : "rgba(34,197,94,0.1)",
+            border: `1px solid ${M.line}`,
+          }}
+        >
+          {footer}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/components/marketing/HeroOperationalField.tsx
+++ b/dashboard/components/marketing/HeroOperationalField.tsx
@@ -1,0 +1,220 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+const BG = '#000000'
+
+type Star = {
+  theta: number
+  phi: number
+  radius: number
+  size: number
+  twinklePhase: number
+  twinkleSpeed: number
+  baseAlpha: number
+  pointed: boolean
+  warm: boolean
+}
+
+function mulberry32(seed: number) {
+  return () => {
+    seed |= 0
+    seed = (seed + 0x6d2b79f5) | 0
+    let t = Math.imul(seed ^ (seed >>> 15), 1 | seed)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+function createStars(count: number, seed: number): Star[] {
+  const rand = mulberry32(seed)
+  return Array.from({ length: count }, () => {
+    const pointed = rand() > 0.58
+    return {
+      theta: rand() * Math.PI * 2,
+      phi: Math.acos(2 * rand() - 1),
+      radius: 0.82 + rand() * 0.18,
+      size: pointed ? 1.6 + rand() * 2.4 : 0.5 + rand() * 0.9,
+      twinklePhase: rand() * Math.PI * 2,
+      twinkleSpeed: 0.9 + rand() * 2.2,
+      baseAlpha: 0.22 + rand() * 0.5,
+      pointed,
+      warm: rand() > 0.88,
+    }
+  })
+}
+
+function starColor(alpha: number, warm: boolean) {
+  return warm ? `rgba(255, 228, 196, ${alpha})` : `rgba(220, 228, 240, ${alpha})`
+}
+
+function drawPointedStar(
+  ctx: CanvasRenderingContext2D,
+  x: number,
+  y: number,
+  size: number,
+  alpha: number,
+  warm: boolean,
+) {
+  const color = starColor(alpha, warm)
+  ctx.strokeStyle = color
+  ctx.lineWidth = 0.55
+  ctx.lineCap = 'round'
+
+  const r = size
+  ctx.beginPath()
+  ctx.moveTo(x, y - r)
+  ctx.lineTo(x, y + r)
+  ctx.moveTo(x - r, y)
+  ctx.lineTo(x + r, y)
+  const d = r * 0.55
+  ctx.moveTo(x - d, y - d)
+  ctx.lineTo(x + d, y + d)
+  ctx.moveTo(x + d, y - d)
+  ctx.lineTo(x - d, y + d)
+  ctx.stroke()
+
+  ctx.fillStyle = color
+  ctx.beginPath()
+  ctx.arc(x, y, Math.max(0.35, size * 0.18), 0, Math.PI * 2)
+  ctx.fill()
+}
+
+function renderFrame(
+  ctx: CanvasRenderingContext2D,
+  width: number,
+  height: number,
+  stars: Star[],
+  rotation: number,
+  timeMs: number,
+  subtle: boolean,
+) {
+  ctx.fillStyle = BG
+  ctx.fillRect(0, 0, width, height)
+
+  const cx = width / 2
+  const cy = height / 2
+  const scale = Math.min(width, height) * 0.52
+  const cosR = Math.cos(rotation)
+  const sinR = Math.sin(rotation)
+  const dim = subtle ? 0.72 : 1
+
+  const projected = stars
+    .map((star) => {
+      const x3 = Math.cos(star.theta) * Math.sin(star.phi) * star.radius
+      const y3 = Math.cos(star.phi) * star.radius
+      const z3 = Math.sin(star.theta) * Math.sin(star.phi) * star.radius
+
+      const xr = x3 * cosR + z3 * sinR
+      const zr = -x3 * sinR + z3 * cosR
+
+      const twinkle = 0.5 + 0.5 * Math.sin(timeMs * 0.001 * star.twinkleSpeed + star.twinklePhase)
+      const depth = 0.3 + 0.7 * ((zr + 1) / 2)
+      const alpha = Math.min(0.85, star.baseAlpha * twinkle * depth * dim)
+
+      return {
+        sx: cx + xr * scale,
+        sy: cy + y3 * scale,
+        z: zr,
+        alpha,
+        star,
+      }
+    })
+    .sort((a, b) => a.z - b.z)
+
+  for (const p of projected) {
+    if (p.alpha < 0.04) continue
+    if (p.star.pointed) {
+      drawPointedStar(ctx, p.sx, p.sy, p.star.size, p.alpha, p.star.warm)
+    } else {
+      ctx.fillStyle = starColor(p.alpha, p.star.warm)
+      ctx.beginPath()
+      ctx.arc(p.sx, p.sy, p.star.size * 0.45, 0, Math.PI * 2)
+      ctx.fill()
+    }
+  }
+}
+
+type Props = {
+  variant?: 'hero' | 'subtle'
+}
+
+export function HeroOperationalField({ variant = 'hero' }: Props) {
+  const subtle = variant === 'subtle'
+  const canvasRef = useRef<HTMLCanvasElement>(null)
+  const wrapRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const canvas = canvasRef.current
+    const wrap = wrapRef.current
+    if (!canvas || !wrap) return
+
+    const ctx = canvas.getContext('2d')
+    if (!ctx) return
+
+    const stars = createStars(subtle ? 90 : 160, subtle ? 909 : 404)
+    let frameId = 0
+    let rotation = 0
+    let start = performance.now()
+    const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    const rotSpeed = subtle ? 0.000035 : 0.00007
+
+    const resize = () => {
+      const dpr = Math.min(window.devicePixelRatio || 1, 2)
+      const { width, height } = wrap.getBoundingClientRect()
+      canvas.width = Math.max(1, Math.floor(width * dpr))
+      canvas.height = Math.max(1, Math.floor(height * dpr))
+      canvas.style.width = `${width}px`
+      canvas.style.height = `${height}px`
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
+    }
+
+    resize()
+    const ro = new ResizeObserver(resize)
+    ro.observe(wrap)
+
+    const tick = (now: number) => {
+      const { width, height } = wrap.getBoundingClientRect()
+      if (!reducedMotion) {
+        rotation += rotSpeed * (now - start)
+        start = now
+      }
+      renderFrame(ctx, width, height, stars, rotation, now, subtle)
+      if (!reducedMotion) frameId = requestAnimationFrame(tick)
+    }
+
+    frameId = requestAnimationFrame(tick)
+
+    return () => {
+      cancelAnimationFrame(frameId)
+      ro.disconnect()
+    }
+  }, [subtle])
+
+  return (
+    <div
+      ref={wrapRef}
+      aria-hidden
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: BG,
+        pointerEvents: 'none',
+        zIndex: 0,
+        overflow: 'hidden',
+      }}
+    >
+      <canvas ref={canvasRef} style={{ display: 'block', width: '100%', height: '100%' }} />
+      {/* Soft center dim so headline stays dominant */}
+      <div
+        style={{
+          position: 'absolute',
+          inset: 0,
+          background: subtle
+            ? 'radial-gradient(ellipse 60% 55% at 50% 45%, rgba(0,0,0,0.5) 0%, transparent 72%)'
+            : 'radial-gradient(ellipse 58% 52% at 50% 42%, rgba(0,0,0,0.62) 0%, transparent 70%)',
+        }}
+      />
+    </div>
+  )
+}

--- a/dashboard/components/marketing/IntegrationStrip.tsx
+++ b/dashboard/components/marketing/IntegrationStrip.tsx
@@ -1,0 +1,49 @@
+import { M } from './marketing-theme'
+
+const INTEGRATIONS = [
+  { name: 'Python SDK', sub: 'pip install zizkadb-sdk' },
+  { name: 'TypeScript SDK', sub: 'npm i zizkadb-sdk' },
+  { name: 'Cursor MCP', sub: 'Native tools' },
+  { name: 'REST API', sub: 'Any language' },
+  { name: 'Open source', sub: 'AGPL · self-host' },
+  { name: 'Managed cloud', sub: 'db.zizka.ai' },
+]
+
+export function IntegrationStrip({ dark = false }: { dark?: boolean }) {
+  const text = dark ? '#fff' : '#000'
+  const subText = dark ? '#ffffff' : '#000000'
+  return (
+    <div>
+      <p style={{
+        fontSize: 13, fontWeight: 700, textAlign: 'center', marginBottom: 14,
+        color: text, letterSpacing: 0.3,
+      }}>
+        Works with your stack
+      </p>
+      <div style={{
+        display: 'flex', flexWrap: 'wrap', gap: 10, justifyContent: 'center',
+      }}>
+        {INTEGRATIONS.map(item => (
+          <div
+            key={item.name}
+            className="zdb-integration-pill"
+            style={{
+              padding: '10px 14px', borderRadius: 12,
+              background: dark ? 'rgba(255,255,255,0.08)' : '#fff',
+              border: dark ? '1px solid rgba(255,255,255,0.2)' : `1px solid ${M.line}`,
+              minWidth: 120, textAlign: 'center',
+              boxSizing: 'border-box',
+            }}
+          >
+            <div style={{ fontSize: 13, fontWeight: 700, color: text }}>
+              {item.name}
+            </div>
+            <div style={{ fontSize: 11, fontWeight: 600, color: subText, marginTop: 2 }}>
+              {item.sub}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/components/marketing/LegalDocumentLayout.tsx
+++ b/dashboard/components/marketing/LegalDocumentLayout.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+import { SiteNav } from '@/components/SiteNav'
+import { MarketingFooter } from '@/components/marketing/MarketingFooter'
+import { MarketingPageStyles } from '@/components/marketing/MarketingPageStyles'
+
+type LegalDocumentLayoutProps = {
+  title: string
+  updated: string
+  children: ReactNode
+}
+
+export function LegalDocumentLayout({ title, updated, children }: LegalDocumentLayoutProps) {
+  return (
+    <div style={{ fontFamily: 'Inter, system-ui, sans-serif', color: '#111', background: '#fff', minHeight: '100vh' }}>
+      <MarketingPageStyles />
+      <SiteNav />
+
+      <main style={{ maxWidth: 720, margin: '0 auto', padding: '48px 24px 80px' }}>
+        <p style={{ fontSize: 11, fontWeight: 700, letterSpacing: 0.8, textTransform: 'uppercase', color: '#000000', margin: '0 0 8px' }}>
+          Legal
+        </p>
+        <h1 style={{ fontSize: 34, fontWeight: 800, margin: '0 0 8px', letterSpacing: -0.5 }}>{title}</h1>
+        <p style={{ fontSize: 14, color: '#000000', margin: '0 0 40px' }}>Last updated: {updated}</p>
+        {children}
+        <div style={{ marginTop: 48, paddingTop: 24, borderTop: '1px solid #eee' }}>
+          <Link href="/" style={{ fontSize: 14, color: '#111', fontWeight: 500, textDecoration: 'none' }}>
+            ← Back to ZizkaDB
+          </Link>
+        </div>
+      </main>
+
+      <MarketingFooter />
+    </div>
+  )
+}
+
+export const legalStyles = {
+  h2: { fontSize: 18, fontWeight: 700, color: '#000000', margin: '36px 0 12px' } as const,
+  p: { fontSize: 15, color: '#000000', lineHeight: 1.75, margin: '0 0 14px' } as const,
+  ul: { margin: '0 0 14px', paddingLeft: 22, fontSize: 15, color: '#000000', lineHeight: 1.8 } as const,
+  li: { marginBottom: 6 } as const,
+  a: { color: '#000000', fontWeight: 500 } as const,
+}

--- a/dashboard/components/marketing/LiveDashboardDemo.tsx
+++ b/dashboard/components/marketing/LiveDashboardDemo.tsx
@@ -1,0 +1,302 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { useCallback, useEffect, useState } from 'react'
+import { M } from './marketing-theme'
+import { BRAND, BRAND_LIGHT } from '@/components/brand'
+
+type TabId = 'activity' | 'behavior' | 'reports' | 'suggestions' | 'fleet'
+
+type Props = {
+  variant: 'oss' | 'managed'
+  /** Auto-rotate tabs every N ms; 0 = off */
+  autoRotateMs?: number
+}
+
+const OSS_TABS: { id: TabId; label: string }[] = [
+  { id: 'activity', label: 'Activity' },
+  { id: 'behavior', label: 'Behavior' },
+  { id: 'reports', label: 'Reports' },
+  { id: 'suggestions', label: 'Suggestions' },
+]
+
+const MANAGED_TABS = [...OSS_TABS, { id: 'fleet' as const, label: 'Fleet' }]
+
+export function LiveDashboardDemo({ variant, autoRotateMs = 0 }: Props) {
+  const tabs = variant === 'managed' ? MANAGED_TABS : OSS_TABS
+  const [active, setActive] = useState<TabId>('activity')
+
+  const rotate = useCallback(() => {
+    setActive((prev) => {
+      const idx = tabs.findIndex((t) => t.id === prev)
+      return tabs[(idx + 1) % tabs.length].id
+    })
+  }, [tabs])
+
+  useEffect(() => {
+    if (!autoRotateMs) return
+    const id = window.setInterval(rotate, autoRotateMs)
+    return () => window.clearInterval(id)
+  }, [autoRotateMs, rotate])
+
+  return (
+    <div
+      style={{
+        borderRadius: 16,
+        border: `1px solid ${M.previewBorder}`,
+        background: M.previewBg,
+        overflow: 'hidden',
+        boxShadow: '0 24px 64px rgba(0,0,0,0.45)',
+      }}
+    >
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '12px 16px',
+          borderBottom: `1px solid ${M.line}`,
+          background: M.previewSurface,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#ef4444' }} />
+          <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#fbbf24' }} />
+          <span style={{ width: 10, height: 10, borderRadius: '50%', background: '#22c55e' }} />
+        </div>
+        <span style={{ fontSize: 12, color: M.faint, fontWeight: 500 }}>
+          {variant === 'managed' ? 'Managed cloud' : 'Self-hosted'} · demo
+        </span>
+      </div>
+
+      <div
+        style={{
+          display: 'flex',
+          gap: 4,
+          padding: '10px 12px 0',
+          borderBottom: `1px solid ${M.line}`,
+          overflowX: 'auto',
+        }}
+      >
+        {tabs.map((tab) => {
+          const on = active === tab.id
+          return (
+            <button
+              key={tab.id}
+              type="button"
+              onClick={() => setActive(tab.id)}
+              style={{
+                flexShrink: 0,
+                padding: '8px 14px',
+                fontSize: 13,
+                fontWeight: on ? 600 : 500,
+                color: on ? M.ink : M.muted,
+                background: on ? 'rgba(249,115,22,0.12)' : 'transparent',
+                border: 'none',
+                borderBottom: on ? `2px solid ${BRAND}` : '2px solid transparent',
+                borderRadius: '8px 8px 0 0',
+                cursor: 'pointer',
+              }}
+            >
+              {tab.label}
+            </button>
+          )
+        })}
+      </div>
+
+      <div style={{ padding: 16, minHeight: 220 }}>
+        {active === 'activity' && <ActivityPanel />}
+        {active === 'behavior' && <BehaviorPanel />}
+        {active === 'reports' && <ReportsPanel />}
+        {active === 'suggestions' && <SuggestionsPanel />}
+        {active === 'fleet' && variant === 'managed' && <FleetPanel />}
+      </div>
+    </div>
+  )
+}
+
+function ActivityPanel() {
+  const rows = [
+    { time: '14:02:11', event: 'tool_call', detail: 'search_policy_docs', status: 'ok' },
+    { time: '14:02:09', event: 'llm_response', detail: 'Refund window is 14 days…', status: 'warn' },
+    { time: '14:01:58', event: 'session_start', detail: 'customer-4821', status: 'ok' },
+  ]
+  return (
+    <div>
+      <PanelTitle>Recent sessions</PanelTitle>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {rows.map((r) => (
+          <div
+            key={r.time + r.detail}
+            className="zdb-demo-activity-row"
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '72px 88px 1fr 56px',
+              gap: 8,
+              alignItems: 'center',
+              padding: '10px 12px',
+              borderRadius: 10,
+              background: M.previewSurface,
+              fontSize: 12,
+            }}
+          >
+            <span style={{ color: M.faint, fontFamily: 'monospace' }}>{r.time}</span>
+            <span style={{ color: BRAND_LIGHT, fontWeight: 600 }}>{r.event}</span>
+            <span style={{ color: M.inkSoft, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+              {r.detail}
+            </span>
+            <StatusPill status={r.status} />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function BehaviorPanel() {
+  return (
+    <div>
+      <PanelTitle>Baseline vs last 24h</PanelTitle>
+      <div className="zdb-demo-behavior-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 10 }}>
+        <MetricCard label="Tool accuracy" value="94%" delta="-6%" bad />
+        <MetricCard label="Avg tokens" value="1.2k" delta="+18%" bad />
+        <MetricCard label="Escalations" value="3" delta="+2" bad />
+      </div>
+      <p style={{ margin: '14px 0 0', fontSize: 12, color: M.muted, lineHeight: 1.5 }}>
+        Drift detected after prompt v2 deploy — refund answers shifted from policy doc to stale FAQ chunk.
+      </p>
+    </div>
+  )
+}
+
+function ReportsPanel() {
+  return (
+    <div>
+      <PanelTitle>Behavior change report</PanelTitle>
+      <div
+        style={{
+          padding: 14,
+          borderRadius: 10,
+          background: M.previewSurface,
+          border: `1px solid ${M.line}`,
+        }}
+      >
+        <div style={{ fontSize: 13, fontWeight: 600, color: M.ink, marginBottom: 8 }}>
+          Weekly summary · support-bot
+        </div>
+        <ul style={{ margin: 0, paddingLeft: 18, fontSize: 12, color: M.muted, lineHeight: 1.65 }}>
+          <li>Refund intent answers diverged from baseline on Tue</li>
+          <li>3 sessions flagged for manual review</li>
+          <li>Recommended: roll back prompt v2, refresh FAQ embeddings</li>
+        </ul>
+      </div>
+    </div>
+  )
+}
+
+function SuggestionsPanel() {
+  const items = [
+    { title: 'Pin policy doc for refund intent', impact: 'High' },
+    { title: 'Add guardrail on FAQ retrieval', impact: 'Medium' },
+    { title: 'Re-run baseline after prompt fix', impact: 'Low' },
+  ]
+  return (
+    <div>
+      <PanelTitle>Suggested fixes</PanelTitle>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {items.map((item) => (
+          <div
+            key={item.title}
+            style={{
+              display: 'flex',
+              justifyContent: 'space-between',
+              alignItems: 'center',
+              padding: '10px 12px',
+              borderRadius: 10,
+              background: M.previewSurface,
+              fontSize: 12,
+            }}
+          >
+            <span style={{ color: M.inkSoft }}>{item.title}</span>
+            <span
+              style={{
+                fontSize: 10,
+                fontWeight: 700,
+                padding: '3px 8px',
+                borderRadius: 99,
+                background: 'rgba(249,115,22,0.15)',
+                color: BRAND_LIGHT,
+              }}
+            >
+              {item.impact}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function FleetPanel() {
+  const agents = [
+    { name: 'support-bot', score: 72, trend: 'down' },
+    { name: 'sales-assistant', score: 91, trend: 'up' },
+    { name: 'onboarding', score: 88, trend: 'flat' },
+  ]
+  return (
+    <div>
+      <PanelTitle>Fleet ranking</PanelTitle>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {agents.map((a, i) => (
+          <div
+            key={a.name}
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '24px 1fr 48px 32px',
+              gap: 10,
+              alignItems: 'center',
+              padding: '10px 12px',
+              borderRadius: 10,
+              background: M.previewSurface,
+              fontSize: 12,
+            }}
+          >
+            <span style={{ color: M.faint, fontWeight: 700 }}>#{i + 1}</span>
+            <span style={{ color: M.inkSoft, fontWeight: 500 }}>{a.name}</span>
+            <span style={{ color: M.ink, fontWeight: 700, textAlign: 'right' }}>{a.score}</span>
+            <span style={{ color: a.trend === 'down' ? M.danger : a.trend === 'up' ? M.success : M.faint }}>
+              {a.trend === 'down' ? '↓' : a.trend === 'up' ? '↑' : '→'}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function PanelTitle({ children }: { children: ReactNode }) {
+  return (
+    <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 0.5, color: M.faint, marginBottom: 12, textTransform: 'uppercase' }}>
+      {children}
+    </div>
+  )
+}
+
+function MetricCard({ label, value, delta, bad }: { label: string; value: string; delta: string; bad?: boolean }) {
+  return (
+    <div style={{ padding: 12, borderRadius: 10, background: M.previewSurface, textAlign: 'center' }}>
+      <div style={{ fontSize: 10, color: M.faint, marginBottom: 4 }}>{label}</div>
+      <div style={{ fontSize: 20, fontWeight: 700, color: M.ink }}>{value}</div>
+      <div style={{ fontSize: 11, fontWeight: 600, color: bad ? M.danger : M.success, marginTop: 4 }}>{delta}</div>
+    </div>
+  )
+}
+
+function StatusPill({ status }: { status: string }) {
+  const color = status === 'ok' ? M.success : status === 'warn' ? M.warn : M.danger
+  return (
+    <span style={{ fontSize: 10, fontWeight: 700, color, textTransform: 'uppercase' }}>
+      {status}
+    </span>
+  )
+}

--- a/dashboard/components/marketing/MarketingFooter.tsx
+++ b/dashboard/components/marketing/MarketingFooter.tsx
@@ -1,0 +1,115 @@
+import Link from 'next/link'
+import { BrandLogo } from '@/components/BrandLogo'
+import { ZIZKADB_COMPANY, ZIZKADB_FOOTER_COLUMNS, type FooterLink } from './footer-config'
+import { M } from './marketing-theme'
+
+const YEAR = new Date().getFullYear()
+
+function FooterAnchor({ link }: { link: FooterLink }) {
+  const style = {
+    color: '#ffffff',
+    textDecoration: 'none' as const,
+    fontSize: 14,
+    lineHeight: 1.5,
+    display: 'inline-block' as const,
+  }
+
+  if (link.external || link.href.startsWith('http') || link.href.startsWith('mailto:')) {
+    return (
+      <a href={link.href} target="_blank" rel="noopener noreferrer" style={style}>
+        {link.label}
+      </a>
+    )
+  }
+
+  return (
+    <Link href={link.href} style={style}>
+      {link.label}
+    </Link>
+  )
+}
+
+export function MarketingFooter() {
+  return (
+    <footer className="zdb-footer" style={{ background: M.bg, color: '#ffffff' }}>
+      <div
+        className="zdb-footer-grid"
+        style={{
+          maxWidth: 1100,
+          margin: '0 auto',
+          padding: '56px 40px 40px',
+          display: 'grid',
+          gridTemplateColumns: '1.4fr repeat(3, 1fr)',
+          gap: 40,
+        }}
+      >
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 16 }}>
+            <BrandLogo variant="mark" showWordmark={false} href="/" />
+            <span style={{ fontSize: 18, fontWeight: 700, color: '#fff', letterSpacing: -0.3 }}>ZizkaDB</span>
+          </div>
+          <p style={{ margin: '0 0 20px', fontSize: 14, lineHeight: 1.65, color: '#ffffff', maxWidth: 280 }}>
+            Dont Observe - Audit your AI Agent. Causal lineage, time travel, and drift for production agents.
+          </p>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            <a
+              href={ZIZKADB_COMPANY.zizkaAiUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{ fontSize: 14, color: '#ffffff', textDecoration: 'none' }}
+            >
+              zizka.ai →
+            </a>
+          </div>
+        </div>
+
+        {ZIZKADB_FOOTER_COLUMNS.map((col) => (
+          <div key={col.title}>
+            <div
+              style={{
+                fontSize: 11,
+                fontWeight: 700,
+                letterSpacing: 0.9,
+                textTransform: 'uppercase',
+                color: '#ffffff',
+                marginBottom: 16,
+              }}
+            >
+              {col.title}
+            </div>
+            <ul style={{ listStyle: 'none', margin: 0, padding: 0, display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {col.links.map((link) => (
+                <li key={link.label}>
+                  <FooterAnchor link={link} />
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ borderTop: '1px solid rgba(255,255,255,0.08)' }}>
+        <div
+          className="zdb-footer-meta"
+          style={{
+            maxWidth: 1100,
+            margin: '0 auto',
+            padding: '20px 40px 28px',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'flex-start',
+            flexWrap: 'wrap',
+            gap: 12,
+            fontSize: 12,
+            color: '#ffffff',
+          }}
+        >
+          <span>© {YEAR} {ZIZKADB_COMPANY.name}</span>
+          <span style={{ textAlign: 'right' }}>
+            {ZIZKADB_COMPANY.location} · {ZIZKADB_COMPANY.taxId}
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+}

--- a/dashboard/components/marketing/MarketingPageStyles.tsx
+++ b/dashboard/components/marketing/MarketingPageStyles.tsx
@@ -1,0 +1,165 @@
+import { BRAND } from "@/components/brand";
+
+export function MarketingPageStyles() {
+  return (
+    <style>{`
+      .zdb-section-anchor {
+        scroll-margin-top: 72px;
+      }
+      .zdb-marketing-root {
+        overflow-x: clip;
+        max-width: 100%;
+      }
+      .zdb-faq-summary::-webkit-details-marker {
+        display: none;
+      }
+      .zdb-faq-summary:focus-visible {
+        outline: 2px solid ${BRAND};
+        outline-offset: -2px;
+      }
+      .zdb-connect-submit:focus-visible {
+        outline: 2px solid ${BRAND};
+        outline-offset: 2px;
+      }
+      .zdb-price-grid {
+        align-items: stretch !important;
+      }
+      .zdb-pricing-card {
+        height: 100%;
+      }
+      .zdb-pricing-card-footer a:hover {
+        opacity: 0.92;
+      }
+      .zdb-pricing-card-footer a:focus-visible {
+        outline: 2px solid ${BRAND};
+        outline-offset: 2px;
+      }
+      .zdb-footer-grid a:hover {
+        color: #fff !important;
+      }
+      .site-nav-menu-btn {
+        display: none;
+      }
+      .site-nav-mobile-drawer {
+        display: none;
+      }
+      .zdb-compare-mobile {
+        display: none;
+      }
+      @media (max-width: 1024px) {
+        .zdb-connect-grid { grid-template-columns: 1fr !important; }
+        .zdb-feature-grid { grid-template-columns: repeat(2, 1fr) !important; }
+        .zdb-price-grid { grid-template-columns: repeat(2, 1fr) !important; }
+        .zdb-why-grid { grid-template-columns: repeat(2, 1fr) !important; }
+        .zdb-split-3 { grid-template-columns: 1fr !important; }
+        .zdb-section {
+          padding-left: 24px !important;
+          padding-right: 24px !important;
+        }
+        .zdb-trust-grid { grid-template-columns: repeat(2, 1fr) !important; }
+      }
+      @media (max-width: 768px) {
+        .site-nav-links { display: none !important; }
+        .site-nav-cta { display: none !important; }
+        .site-nav-menu-btn { display: inline-flex !important; }
+        .site-nav-mobile-drawer { display: block !important; }
+        .zdb-section {
+          padding-left: 20px !important;
+          padding-right: 20px !important;
+          padding-top: 48px !important;
+          padding-bottom: 48px !important;
+        }
+        .zdb-hero-title {
+          font-size: 32px !important;
+          letter-spacing: -0.7px !important;
+        }
+        .zdb-hero-value { font-size: 16px !important; }
+        .zdb-section-h2 {
+          font-size: 26px !important;
+          letter-spacing: -0.4px !important;
+        }
+        .zdb-final-cta-title { font-size: 28px !important; }
+        .zdb-lead {
+          font-size: 16px !important;
+          margin-bottom: 32px !important;
+        }
+        .zdb-connect-grid { grid-template-columns: 1fr !important; gap: 12px !important; }
+        .zdb-compare-grid { grid-template-columns: 1fr !important; }
+        .zdb-split { grid-template-columns: 1fr !important; }
+        .zdb-split-3 { grid-template-columns: 1fr !important; }
+        .zdb-why-grid { grid-template-columns: 1fr !important; }
+        .zdb-price-grid { grid-template-columns: 1fr !important; }
+        .zdb-tier-grid { grid-template-columns: 1fr !important; }
+        .zdb-trust-grid { grid-template-columns: 1fr !important; }
+        .zdb-feature-grid { grid-template-columns: 1fr !important; }
+        .zdb-resource-grid { grid-template-columns: 1fr 1fr !important; }
+        .zdb-hero-btns {
+          flex-direction: column !important;
+          align-items: stretch !important;
+        }
+        .zdb-hero-btns a, .zdb-hero-btns button {
+          justify-content: center !important;
+          width: 100%;
+        }
+        .zdb-cta-row {
+          flex-direction: column !important;
+          align-items: stretch !important;
+        }
+        .zdb-cta-row a, .zdb-cta-row button {
+          justify-content: center !important;
+          width: 100%;
+        }
+        .brand-logo-tagline { display: none !important; }
+        .zdb-demo-activity-row {
+          display: flex !important;
+          flex-direction: column !important;
+          align-items: flex-start !important;
+          gap: 6px !important;
+        }
+        .zdb-demo-behavior-grid { grid-template-columns: 1fr !important; }
+        .zdb-integration-pill {
+          min-width: 0 !important;
+          flex: 1 1 calc(50% - 5px) !important;
+          max-width: calc(50% - 5px);
+        }
+        .zdb-compare-table-wrap { display: none !important; }
+        .zdb-compare-mobile { display: flex !important; }
+        .zdb-footer-grid {
+          grid-template-columns: 1fr !important;
+          gap: 32px !important;
+          padding: 40px 20px 32px !important;
+        }
+        .zdb-footer-meta {
+          flex-direction: column !important;
+          padding: 16px 20px 24px !important;
+        }
+        .zdb-footer-meta span { text-align: left !important; }
+        .zdb-feature-card { padding: 24px 20px !important; }
+        .zdb-feature-card h3 { font-size: 18px !important; }
+      }
+      @media (max-width: 480px) {
+        .zdb-section {
+          padding-left: 16px !important;
+          padding-right: 16px !important;
+        }
+        .zdb-hero-title {
+          font-size: 28px !important;
+          letter-spacing: -0.55px !important;
+        }
+        .zdb-section-h2 { font-size: 24px !important; }
+        .zdb-final-cta-title { font-size: 26px !important; }
+        .zdb-integration-pill {
+          flex: 1 1 100% !important;
+          max-width: 100% !important;
+        }
+        .zdb-resource-grid { grid-template-columns: 1fr !important; }
+      }
+      @media (max-width: 1024px) and (min-width: 769px) {
+        .zdb-footer-grid { grid-template-columns: 1fr 1fr !important; }
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .site-nav-mobile-drawer { transition: none !important; }
+      }
+    `}</style>
+  );
+}

--- a/dashboard/components/marketing/MarketingShell.tsx
+++ b/dashboard/components/marketing/MarketingShell.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import { SiteNav, type SiteNavActive } from '@/components/SiteNav'
+import { MarketingFooter } from './MarketingFooter'
+import { MarketingPageStyles } from './MarketingPageStyles'
+import { M } from './marketing-theme'
+
+type Props = {
+  children: ReactNode
+  active?: SiteNavActive
+  suffix?: string
+  /** Skip footer on minimal auth screens if needed */
+  showFooter?: boolean
+}
+
+export function MarketingShell({ children, active, suffix, showFooter = true }: Props) {
+  return (
+    <div
+      className="zdb-marketing-root"
+      style={{
+        minHeight: '100vh',
+        fontFamily: 'Inter, system-ui, sans-serif',
+        color: M.ink,
+        background: M.bg,
+      }}
+    >
+      <MarketingPageStyles />
+      <SiteNav active={active} suffix={suffix} />
+      {children}
+      {showFooter ? <MarketingFooter /> : null}
+    </div>
+  )
+}

--- a/dashboard/components/marketing/PricingCard.tsx
+++ b/dashboard/components/marketing/PricingCard.tsx
@@ -1,0 +1,142 @@
+import { BRAND, BRAND_SHADOW_TINT } from "@/components/brand";
+import Link from "next/link";
+import { M, pricingCardShell, pricingCtaStyle } from "./marketing-theme";
+import type { PricingPlan } from "./pricing-plans";
+
+export function PricingCard({ plan }: { plan: PricingPlan }) {
+  const filledCta = !!(plan.highlight || plan.ctaPrimary);
+  const compactPrice = plan.price.length > 12;
+
+  return (
+    <div
+      className="zdb-pricing-card"
+      style={{
+        ...pricingCardShell,
+        border: plan.highlight ? `2px solid ${BRAND}` : `1px solid ${M.line}`,
+        position: "relative",
+        boxShadow: plan.highlight ? `0 12px 40px ${BRAND_SHADOW_TINT}` : "none",
+      }}
+    >
+      {plan.highlight && (
+        <div
+          style={{
+            position: "absolute",
+            top: -11,
+            left: "50%",
+            transform: "translateX(-50%)",
+            background: BRAND,
+            color: "#fff",
+            fontSize: 10,
+            fontWeight: 700,
+            padding: "3px 12px",
+            borderRadius: 100,
+            letterSpacing: 0.3,
+          }}
+        >
+          POPULAR
+        </div>
+      )}
+
+      <div className="zdb-pricing-card-header">
+        <div
+          style={{
+            fontSize: 12,
+            fontWeight: 800,
+            color: M.ink,
+            marginBottom: 8,
+            letterSpacing: 0.2,
+          }}
+        >
+          {plan.name}
+        </div>
+        <div
+          style={{
+            display: "flex",
+            alignItems: "baseline",
+            gap: 6,
+            marginBottom: 16,
+            minHeight: 40,
+          }}
+        >
+          <span
+            style={{
+              fontSize: compactPrice ? 22 : 32,
+              fontWeight: 700,
+              color: M.ink,
+              lineHeight: 1.15,
+            }}
+          >
+            {plan.price}
+          </span>
+          <span style={{ fontSize: 13, fontWeight: 600, color: M.ink }}>
+            {plan.sub}
+          </span>
+        </div>
+      </div>
+
+      <ul
+        className="zdb-pricing-card-body"
+        style={{
+          listStyle: "none",
+          padding: 0,
+          margin: 0,
+          display: "flex",
+          flexDirection: "column",
+          gap: 8,
+          flex: 1,
+        }}
+      >
+        {plan.features.map((f) => (
+          <li
+            key={f}
+            style={{
+              fontSize: 13.5,
+              color: M.ink,
+              display: "flex",
+              gap: 8,
+              fontWeight: 500,
+              lineHeight: 1.45,
+            }}
+          >
+            <span style={{ color: M.ink, fontWeight: 800, flexShrink: 0 }}>
+              ✓
+            </span>
+            <span>{f}</span>
+          </li>
+        ))}
+      </ul>
+
+      <div
+        className="zdb-pricing-card-footer"
+        style={{ marginTop: "auto", paddingTop: 20 }}
+      >
+        <Link
+          href={plan.href}
+          style={{
+            ...pricingCtaStyle(filledCta),
+            display: "block",
+            textAlign: "center",
+          }}
+        >
+          {plan.cta}
+        </Link>
+        <div style={{ minHeight: 40, marginTop: 8 }}>
+          {plan.note ? (
+            <p
+              style={{
+                textAlign: "center",
+                fontSize: 11,
+                color: "#555",
+                margin: 0,
+                fontWeight: 600,
+                lineHeight: 1.4,
+              }}
+            >
+              {plan.note}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/components/marketing/TrustBar.tsx
+++ b/dashboard/components/marketing/TrustBar.tsx
@@ -1,0 +1,72 @@
+import { M } from "./marketing-theme";
+
+const TRUST_ITEMS = [
+  {
+    icon: "📦",
+    title: "Open source",
+    body: "AGPL license. Inspect, fork, self-host free.",
+  },
+  {
+    icon: "🏠",
+    title: "Self-host free",
+    body: "Docker Compose on your own infrastructure.",
+  },
+  {
+    icon: "🔒",
+    title: "Checksum-backed events",
+    body: "Tamper-evident decision history.",
+  },
+  {
+    icon: "🇪🇺",
+    title: "Managed cloud",
+    body: "db.zizka.ai when you want zero ops.",
+  },
+];
+
+export function TrustBar() {
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${TRUST_ITEMS.length}, 1fr)`,
+        gap: 16,
+      }}
+      className="zdb-trust-grid"
+    >
+      {TRUST_ITEMS.map((item) => (
+        <div
+          key={item.title}
+          style={{
+            padding: "20px 18px",
+            borderRadius: 16,
+            background: "#fff",
+            border: `1px solid ${M.line}`,
+            textAlign: "center",
+          }}
+        >
+          <div style={{ fontSize: 24, marginBottom: 10 }}>{item.icon}</div>
+          <div
+            style={{
+              fontSize: 14,
+              fontWeight: 700,
+              color: "#000",
+              marginBottom: 6,
+            }}
+          >
+            {item.title}
+          </div>
+          <div
+            style={{
+              fontSize: 12,
+              fontWeight: 500,
+              color: "#000",
+              lineHeight: 1.5,
+            }}
+          >
+            {item.body}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/components/marketing/auth-styles.ts
+++ b/dashboard/components/marketing/auth-styles.ts
@@ -1,0 +1,77 @@
+import { BRAND, BRAND_DARK } from '@/components/brand'
+import { M, authPanel } from './marketing-theme'
+
+export const authPage = {
+  minHeight: '100vh',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  background: M.bg,
+  fontFamily: 'Inter, system-ui, sans-serif',
+} as const
+
+export const authCard = authPanel
+
+export const authTitle = {
+  fontSize: 20,
+  fontWeight: 700,
+  color: M.ink,
+  marginBottom: 6,
+} as const
+
+export const authSubtitle = {
+  fontSize: 14,
+  color: M.muted,
+  marginBottom: 24,
+  lineHeight: 1.6,
+} as const
+
+export const authLabel = {
+  display: 'block',
+  fontSize: 13,
+  fontWeight: 500,
+  color: M.muted,
+  marginBottom: 6,
+} as const
+
+export const authInput = {
+  width: '100%',
+  boxSizing: 'border-box' as const,
+  padding: '10px 14px',
+  borderRadius: 9,
+  fontSize: 14,
+  border: `1px solid ${M.lineStrong}`,
+  outline: 'none',
+  color: M.ink,
+  background: M.bgElevated,
+}
+
+export const authSubmitBtn = {
+  padding: '11px',
+  borderRadius: 9,
+  fontSize: 14,
+  fontWeight: 600,
+  background: `linear-gradient(135deg, ${BRAND} 0%, ${BRAND_DARK} 100%)`,
+  color: '#fff',
+  border: 'none',
+  cursor: 'pointer',
+} as const
+
+export const authLink = {
+  color: M.brandLight,
+  fontWeight: 600,
+  textDecoration: 'none',
+} as const
+
+export const authMutedLink = {
+  color: M.muted,
+  textDecoration: 'none',
+  fontWeight: 500,
+} as const
+
+export const authFootnote = {
+  fontSize: 12,
+  color: M.faint,
+  textAlign: 'center' as const,
+  margin: 0,
+}

--- a/dashboard/components/marketing/enterprise/EnterpriseConnectForm.tsx
+++ b/dashboard/components/marketing/enterprise/EnterpriseConnectForm.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+import { COPY } from "./enterprise-copy";
+import { submitDemoRequest } from "@/lib/demo";
+import { M } from "../marketing-theme";
+import { BRAND, BRAND_DARK } from "@/components/brand";
+
+const inputStyle = {
+  width: "100%",
+  padding: "11px 14px",
+  borderRadius: 10,
+  border: `1px solid ${M.line}`,
+  fontSize: 14,
+  fontFamily: "inherit",
+  boxSizing: "border-box" as const,
+};
+
+const labelStyle = {
+  display: "block",
+  fontSize: 13,
+  fontWeight: 600,
+  color: "#000",
+  marginBottom: 6,
+};
+
+type Props = {
+  id?: string;
+};
+
+export function EnterpriseConnectForm({ id }: Props) {
+  const [firstName, setFirstName] = useState("");
+  const [lastName, setLastName] = useState("");
+  const [email, setEmail] = useState("");
+  const [company, setCompany] = useState("");
+  const [position, setPosition] = useState("");
+  const [website, setWebsite] = useState("");
+  const [botcheck, setBotcheck] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  async function handleSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (botcheck) return;
+    setLoading(true);
+    setError("");
+    try {
+      await submitDemoRequest({
+        first_name: firstName.trim(),
+        last_name: lastName.trim(),
+        email: email.trim(),
+        company_name: company.trim(),
+        website: website.trim(),
+        position: position.trim() || undefined,
+        source: "enterprise",
+      });
+      setSuccess(true);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : COPY.form.genericError;
+      setError(msg.includes("Too many") ? COPY.form.rateLimit : msg);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  if (success) {
+    return (
+      <div
+        id={id}
+        role="status"
+        aria-live="polite"
+        style={{
+          padding: "24px",
+          borderRadius: 14,
+          background: "#fff",
+          border: `1px solid ${M.line}`,
+          textAlign: "center",
+          fontSize: 15,
+          fontWeight: 600,
+          color: "#000",
+        }}
+      >
+        {COPY.form.success}
+      </div>
+    );
+  }
+
+  return (
+    <form
+      id={id}
+      onSubmit={handleSubmit}
+      className="zdb-connect-form"
+      style={{
+        position: "relative",
+        padding: "24px",
+        borderRadius: 14,
+        background: "#fff",
+        border: `1px solid ${M.line}`,
+        display: "flex",
+        flexDirection: "column",
+        gap: 14,
+        textAlign: "left",
+      }}
+    >
+      <div
+        className="zdb-split"
+        style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}
+      >
+        <div>
+          <label htmlFor="ent-first" style={labelStyle}>
+            First name
+          </label>
+          <input
+            id="ent-first"
+            required
+            value={firstName}
+            onChange={(e) => setFirstName(e.target.value)}
+            style={inputStyle}
+          />
+        </div>
+        <div>
+          <label htmlFor="ent-last" style={labelStyle}>
+            Last name
+          </label>
+          <input
+            id="ent-last"
+            required
+            value={lastName}
+            onChange={(e) => setLastName(e.target.value)}
+            style={inputStyle}
+          />
+        </div>
+      </div>
+      <div>
+        <label htmlFor="ent-email" style={labelStyle}>
+          Work email
+        </label>
+        <input
+          id="ent-email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+      <div>
+        <label htmlFor="ent-company" style={labelStyle}>
+          Company
+        </label>
+        <input
+          id="ent-company"
+          required
+          value={company}
+          onChange={(e) => setCompany(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+      <div>
+        <label htmlFor="ent-position" style={labelStyle}>
+          Role / title (optional)
+        </label>
+        <input
+          id="ent-position"
+          value={position}
+          onChange={(e) => setPosition(e.target.value)}
+          style={inputStyle}
+        />
+      </div>
+      <div>
+        <label htmlFor="ent-website" style={labelStyle}>
+          Company website
+        </label>
+        <input
+          id="ent-website"
+          required
+          value={website}
+          onChange={(e) => setWebsite(e.target.value)}
+          placeholder={COPY.form.websiteHint}
+          style={inputStyle}
+        />
+      </div>
+      <input
+        type="text"
+        name="botcheck"
+        value={botcheck}
+        onChange={(e) => setBotcheck(e.target.value)}
+        tabIndex={-1}
+        autoComplete="off"
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          left: "-9999px",
+          opacity: 0,
+          height: 0,
+          width: 0,
+        }}
+      />
+      {error && (
+        <p
+          style={{ margin: 0, fontSize: 13, color: "#b91c1c", fontWeight: 600 }}
+          role="alert"
+        >
+          {error}
+        </p>
+      )}
+      <button
+        type="submit"
+        disabled={loading}
+        className="zdb-connect-submit"
+        style={{
+          marginTop: 4,
+          padding: "13px 20px",
+          borderRadius: 10,
+          border: "none",
+          cursor: loading ? "wait" : "pointer",
+          background: `linear-gradient(135deg, ${BRAND} 0%, ${BRAND_DARK} 100%)`,
+          color: "#fff",
+          fontWeight: 700,
+          fontSize: 15,
+          opacity: loading ? 0.7 : 1,
+        }}
+      >
+        {loading ? "Sending…" : "Let's connect"}
+      </button>
+    </form>
+  );
+}

--- a/dashboard/components/marketing/enterprise/enterprise-copy.ts
+++ b/dashboard/components/marketing/enterprise/enterprise-copy.ts
@@ -1,0 +1,10 @@
+import { FOUNDER_EMAIL } from "@/lib/constants";
+
+export const COPY = {
+  form: {
+    success: "Thanks — we will reach out within one business day.",
+    rateLimit: `Too many requests. Try again later or email ${FOUNDER_EMAIL}.`,
+    genericError: `Something went wrong. Email ${FOUNDER_EMAIL} and we will help.`,
+    websiteHint: "Company domain or linkedin.com/company/…",
+  },
+} as const;

--- a/dashboard/components/marketing/footer-config.ts
+++ b/dashboard/components/marketing/footer-config.ts
@@ -1,0 +1,56 @@
+export type FooterLink = {
+  label: string
+  href: string
+  external?: boolean
+}
+
+export type FooterColumn = {
+  title: string
+  links: FooterLink[]
+}
+
+const GITHUB = 'https://github.com/Zizka-ai/ZizkaDB'
+const WIKI = 'https://github.com/Zizka-ai/ZizkaDB/wiki'
+const ZIZKA_AI = 'https://zizka.ai'
+
+export const ZIZKADB_FOOTER_COLUMNS: FooterColumn[] = [
+  {
+    title: 'Product',
+    links: [
+      { label: 'Docs', href: '/docs' },
+      { label: 'Enterprise', href: '/enterprise' },
+      { label: 'EU AI Act', href: '/eu-ai-act' },
+      { label: 'Pricing', href: '/#pricing' },
+      { label: 'Compare', href: '/#compare' },
+      { label: 'Trust & security', href: '/trust' },
+      { label: 'API explorer', href: '/swagger' },
+    ],
+  },
+  {
+    title: 'Resources',
+    links: [
+      { label: 'Self-host (OSS)', href: GITHUB, external: true },
+      { label: 'Wiki', href: WIKI, external: true },
+      { label: 'Community', href: '/community' },
+      { label: 'MCP setup', href: '/docs#mcp' },
+    ],
+  },
+  {
+    title: 'Legal',
+    links: [
+      { label: 'Terms', href: `${ZIZKA_AI}/terms`, external: true },
+      { label: 'Privacy', href: '/privacy' },
+      { label: 'Security', href: '/trust#security' },
+      { label: 'Contact', href: '/enterprise#contact' },
+      { label: 'Responsible disclosure', href: 'mailto:founder@zizka.ai?subject=Security%20disclosure', external: true },
+    ],
+  },
+]
+
+export const ZIZKADB_COMPANY = {
+  name: 'ZIZKA AI S.L.',
+  location: 'Málaga, Spain',
+  taxId: 'CIF B26956078',
+  email: 'founder@zizka.ai',
+  zizkaAiUrl: ZIZKA_AI,
+}

--- a/dashboard/components/marketing/marketing-theme.ts
+++ b/dashboard/components/marketing/marketing-theme.ts
@@ -1,0 +1,169 @@
+import { BRAND, BRAND_DARK, BRAND_LIGHT, BRAND_PALE } from '@/components/brand'
+
+/** Unified marketing palette — aligned with zizka.ai (dark navy + orange). */
+export const M = {
+  brand: BRAND,
+  brandDark: BRAND_DARK,
+  brandLight: BRAND_LIGHT,
+  brandPale: BRAND_PALE,
+
+  bg: '#060610',
+  bgElevated: '#0b0f1a',
+  surface: '#111827',
+  surfaceHover: '#1a2234',
+  ink: '#ffffff',
+  inkSoft: '#ffffff',
+  muted: '#ffffff',
+  faint: '#ffffff',
+  line: 'rgba(255,255,255,0.1)',
+  lineStrong: 'rgba(255,255,255,0.16)',
+
+  success: '#22c55e',
+  danger: '#f87171',
+  warn: '#fbbf24',
+
+  heroBg: 'linear-gradient(145deg, #060610 0%, #0b0f1a 42%, #111827 100%)',
+  heroGlowOrange: 'radial-gradient(ellipse 80% 60% at 20% 20%, rgba(249,115,22,0.18) 0%, transparent 55%)',
+  heroGlowBlue: 'radial-gradient(ellipse 70% 50% at 85% 30%, rgba(249,115,22,0.08) 0%, transparent 55%)',
+  heroBorder: 'rgba(255,255,255,0.08)',
+  previewBg: '#0b0f16',
+  previewBorder: 'rgba(255,255,255,0.12)',
+  previewSurface: '#161c26',
+
+  /** Legacy aliases — dark sections (enterprise, compare panels). */
+  wash: '#0b0f1a',
+  blue: BRAND,
+  bluePale: 'rgba(249,115,22,0.12)',
+} as const
+
+export const container = (max = 960) => ({ maxWidth: max, margin: '0 auto' } as const)
+
+export const h2 = {
+  fontSize: 32,
+  fontWeight: 700,
+  letterSpacing: -0.5,
+  color: M.ink,
+  margin: '0 0 12px',
+  textAlign: 'center' as const,
+  lineHeight: 1.25,
+}
+
+export const sectionTitle = {
+  fontSize: 13,
+  fontWeight: 700,
+  letterSpacing: 0.5,
+  color: M.brandLight,
+  textAlign: 'center' as const,
+  margin: '0 0 8px',
+  textTransform: 'uppercase' as const,
+}
+
+export const card = {
+  background: M.surface,
+  borderRadius: 16,
+  border: `1px solid ${M.line}`,
+  boxShadow: '0 8px 32px rgba(0,0,0,0.35)',
+} as const
+
+export const lead = {
+  fontSize: 17,
+  color: M.muted,
+  lineHeight: 1.65,
+  textAlign: 'center' as const,
+  maxWidth: 580,
+  margin: '0 auto 40px',
+}
+
+export const primaryBtn = {
+  display: 'inline-flex' as const,
+  alignItems: 'center' as const,
+  justifyContent: 'center' as const,
+  gap: 8,
+  padding: '14px 28px',
+  background: `linear-gradient(135deg, ${BRAND} 0%, ${BRAND_DARK} 100%)`,
+  color: '#fff',
+  borderRadius: 12,
+  textDecoration: 'none',
+  fontWeight: 700,
+  fontSize: 15,
+  border: 'none',
+  cursor: 'pointer',
+  boxShadow: '0 4px 24px rgba(249,115,22,0.38)',
+}
+
+export const secondaryBtn = {
+  display: 'inline-flex' as const,
+  alignItems: 'center' as const,
+  justifyContent: 'center' as const,
+  gap: 8,
+  padding: '14px 24px',
+  background: 'rgba(255,255,255,0.06)',
+  color: M.ink,
+  borderRadius: 12,
+  textDecoration: 'none',
+  fontWeight: 600,
+  fontSize: 15,
+  border: `1px solid ${M.lineStrong}`,
+}
+
+export const ghostBtn = {
+  display: 'inline-flex' as const,
+  alignItems: 'center' as const,
+  gap: 8,
+  padding: '14px 24px',
+  background: 'rgba(255,255,255,0.06)',
+  color: M.inkSoft,
+  borderRadius: 12,
+  textDecoration: 'none',
+  fontWeight: 600,
+  fontSize: 15,
+  border: `1px solid ${M.lineStrong}`,
+}
+
+export const outlineBtn = {
+  display: 'inline-flex' as const,
+  alignItems: 'center' as const,
+  gap: 8,
+  padding: '12px 20px',
+  background: 'transparent',
+  color: M.inkSoft,
+  borderRadius: 10,
+  textDecoration: 'none',
+  fontWeight: 600,
+  fontSize: 14,
+  border: `1px solid ${M.lineStrong}`,
+}
+
+export const pricingCardShell = {
+  background: M.surface,
+  borderRadius: 16,
+  padding: '28px 24px',
+  height: '100%',
+  display: 'flex',
+  flexDirection: 'column',
+  border: `1px solid ${M.line}`,
+} as const
+
+export function pricingCtaStyle(filled: boolean) {
+  return {
+    padding: '11px 16px',
+    borderRadius: 10,
+    textDecoration: 'none',
+    fontWeight: 600,
+    fontSize: 14,
+    background: filled ? BRAND : 'transparent',
+    color: filled ? '#fff' : M.inkSoft,
+    border: filled ? 'none' : `1px solid ${M.lineStrong}`,
+    transition: 'opacity 0.15s ease, box-shadow 0.15s ease',
+    boxShadow: filled ? '0 4px 14px rgba(249,115,22,0.25)' : 'none',
+  } as const
+}
+
+/** Shared panel for signup/login on dark marketing shell. */
+export const authPanel = {
+  background: M.surface,
+  borderRadius: 16,
+  padding: '28px 24px',
+  border: `1px solid ${M.line}`,
+  boxShadow: '0 8px 40px rgba(0,0,0,0.4)',
+} as const

--- a/dashboard/components/marketing/pricing-plans.ts
+++ b/dashboard/components/marketing/pricing-plans.ts
@@ -1,0 +1,59 @@
+export interface PricingPlan {
+  name: string
+  price: string
+  sub: string
+  features: readonly string[]
+  cta: string
+  href: string
+  highlight: boolean
+  ctaPrimary?: boolean
+  note?: string
+}
+
+export const LANDING_PRICING_PLANS: readonly PricingPlan[] = [
+  {
+    name: 'Self-Hosted',
+    price: 'Free',
+    sub: 'forever',
+    features: ['1 API key', 'Your infrastructure', 'Docker Compose', 'Community support'],
+    cta: 'Setup guide',
+    href: '/docs',
+    highlight: false,
+    ctaPrimary: false,
+  },
+  {
+    name: 'Pro',
+    price: '\u20ac29',
+    sub: '/ month',
+    features: ['50k events / month', '3 active API keys', 'Email support'],
+    cta: 'Get started',
+    href: '/signup?plan=pro',
+    highlight: true,
+    ctaPrimary: true,
+  },
+  {
+    name: 'Team',
+    price: '\u20ac69',
+    sub: '/ month',
+    features: ['100k events / month', '10 active API keys', 'Priority support'],
+    cta: 'Get started',
+    href: '/signup?plan=team',
+    highlight: false,
+    ctaPrimary: false,
+  },
+  {
+    name: 'Enterprise',
+    price: 'Annual License',
+    sub: '1 Year',
+    features: [
+      'Single-tenant VPC deployment',
+      'Up to 50 agents',
+      'Fleet dashboard and ranking',
+      'Install + integration workshop',
+    ],
+    cta: "Let's Connect",
+    href: '/enterprise#contact',
+    highlight: false,
+    ctaPrimary: true,
+  },
+]

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -699,6 +699,16 @@ export async function getBillingStatus(token: string): Promise<BillingStatus> {
   return apiFetch('/v1/billing/status', token)
 }
 
+export async function createCheckoutSession(
+  token: string,
+  plan: 'pro' | 'team',
+): Promise<{ url: string }> {
+  return apiFetch('/v1/billing/checkout-session', token, {
+    method: 'POST',
+    body: JSON.stringify({ plan }),
+  })
+}
+
 export interface AccountOptions {
   managed_cloud: boolean
   retention_trial_available?: boolean

--- a/dashboard/lib/auth-errors.ts
+++ b/dashboard/lib/auth-errors.ts
@@ -4,6 +4,18 @@ export function isNoAccountError(err: unknown): boolean {
   return err instanceof AuthRequestError && err.status === 404;
 }
 
+export function isAlreadyRegisteredError(err: unknown): boolean {
+  return err instanceof AuthRequestError && err.status === 409;
+}
+
+export function isGdprConsentError(err: unknown): boolean {
+  return (
+    err instanceof AuthRequestError &&
+    err.status === 401 &&
+    err.message.toLowerCase().includes("gdpr consent")
+  );
+}
+
 export function authErrorMessage(err: unknown, fallback: string): string {
   if (err instanceof AuthRequestError || err instanceof Error) {
     return err.message;

--- a/dashboard/lib/community.ts
+++ b/dashboard/lib/community.ts
@@ -1,0 +1,88 @@
+import { API } from './api'
+
+export type CommunityCategory = 'question' | 'experience' | 'showcase'
+
+export interface CommunityPostListItem {
+  id: string
+  author_name: string
+  category: CommunityCategory
+  title: string
+  excerpt: string
+  image_urls: string[]
+  reply_count: number
+  created_at: string
+}
+
+export interface CommunityReply {
+  id: string
+  author_name: string
+  body: string
+  created_at: string
+}
+
+export interface CommunityPostDetail extends CommunityPostListItem {
+  body: string
+  replies: CommunityReply[]
+}
+
+async function communityFetch(path: string, options: RequestInit = {}) {
+  const res = await fetch(`${API}${path}`, options)
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }))
+    const detail = err.detail
+    throw new Error(typeof detail === 'string' ? detail : 'Request failed')
+  }
+  return res.json()
+}
+
+export function listCommunityPosts(category?: CommunityCategory) {
+  const qs = category ? `?category=${category}` : ''
+  return communityFetch(`/v1/community/posts${qs}`) as Promise<CommunityPostListItem[]>
+}
+
+export function getCommunityPost(id: string) {
+  return communityFetch(`/v1/community/posts/${id}`) as Promise<CommunityPostDetail>
+}
+
+export function createCommunityPost(payload: {
+  author_name: string
+  author_email?: string
+  category: CommunityCategory
+  title: string
+  body: string
+  image_urls: string[]
+}) {
+  return communityFetch('/v1/community/posts', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...payload, website: '' }),
+  }) as Promise<{ id: string }>
+}
+
+export function createCommunityReply(
+  postId: string,
+  payload: { author_name: string; author_email?: string; body: string },
+) {
+  return communityFetch(`/v1/community/posts/${postId}/replies`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...payload, website: '' }),
+  })
+}
+
+export async function uploadCommunityImage(file: File): Promise<string> {
+  const form = new FormData()
+  form.append('file', file)
+  const res = await fetch(`${API}/v1/community/upload`, { method: 'POST', body: form })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: 'Upload failed' }))
+    throw new Error(err.detail ?? 'Upload failed')
+  }
+  const data = await res.json() as { url: string }
+  return data.url
+}
+
+export function mediaUrl(path: string) {
+  if (path.startsWith('http')) return path
+  return `${API}${path}`
+}

--- a/dashboard/lib/constants.ts
+++ b/dashboard/lib/constants.ts
@@ -1,3 +1,5 @@
+export const GITHUB_URL = "https://github.com/Zizka-ai/ZizkaDB";
+export const FOUNDER_EMAIL = "founder@zizka.ai";
 export const POLL_INTERVAL_MS = 10_000;
 export const OTP_LENGTH = 6;
 export const IS_DEV_MODE = process.env.NEXT_PUBLIC_DEV_MODE === "true";

--- a/dashboard/lib/content-styles.ts
+++ b/dashboard/lib/content-styles.ts
@@ -1,0 +1,32 @@
+import type { CSSProperties } from 'react'
+
+/** Body copy on dark marketing/docs surfaces */
+export const textOnDark: CSSProperties = { color: '#ffffff' }
+
+/** Body copy on white/light surfaces */
+export const textOnLight: CSSProperties = { color: '#000000' }
+
+/** Inline code chip on dark pages — white background, black text */
+export const codeInlineLight: CSSProperties = {
+  fontFamily: 'monospace',
+  background: '#ffffff',
+  color: '#000000',
+  padding: '2px 6px',
+  borderRadius: 4,
+}
+
+/** Inline code on dark background (no chip) */
+export const codeMonoDark: CSSProperties = {
+  fontFamily: 'monospace',
+  color: '#ffffff',
+}
+
+/** Inline code on white/light background (no chip) */
+export const codeInlineOnLight: CSSProperties = {
+  fontFamily: 'monospace',
+  fontSize: 12.5,
+  background: '#f5f5f5',
+  color: '#000000',
+  padding: '2px 6px',
+  borderRadius: 4,
+}

--- a/dashboard/lib/demo.ts
+++ b/dashboard/lib/demo.ts
@@ -1,0 +1,25 @@
+import { API } from './api'
+
+export interface DemoRequestPayload {
+  first_name: string
+  last_name: string
+  email: string
+  company_name: string
+  website: string
+  position?: string
+  source?: 'enterprise' | 'landing' | 'newsletter'
+}
+
+export async function submitDemoRequest(payload: DemoRequestPayload) {
+  const res = await fetch(`${API}/v1/demo-requests`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...payload, botcheck: '' }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }))
+    const detail = err.detail
+    throw new Error(typeof detail === 'string' ? detail : 'Request failed')
+  }
+  return res.json() as Promise<{ id: string; created_at: string }>
+}

--- a/dashboard/lib/marketing.ts
+++ b/dashboard/lib/marketing.ts
@@ -1,0 +1,20 @@
+import { API } from './api'
+
+export interface MarketingSubscriptionPayload {
+  email: string
+}
+
+export async function submitMarketingSubscription(payload: MarketingSubscriptionPayload) {
+  const res = await fetch(`${API}/v1/marketing-subscriptions`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...payload, source: 'popup', botcheck: '' }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }))
+    const detail = err.detail
+    throw new Error(typeof detail === 'string' ? detail : 'Request failed')
+  }
+  return res.json() as Promise<{ ok: true }>
+}
+

--- a/dashboard/lib/signup-funnel.ts
+++ b/dashboard/lib/signup-funnel.ts
@@ -1,15 +1,23 @@
-/** Session helpers for managed-cloud signup (keys cleared on account delete). */
+/** sessionStorage keys for the signup funnel (plan → consent → OTP). */
 
-const SIGNUP_PLAN_KEY = "signup_plan";
-const SIGNUP_CONSENT_GDPR_KEY = "signup_consent_gdpr";
-const SIGNUP_CONSENT_MARKETING_KEY = "signup_consent_marketing";
+export const SIGNUP_PLAN_KEY = 'signup_plan'
+export const SIGNUP_CONSENT_GDPR_KEY = 'signup_consent_gdpr'
+export const SIGNUP_CONSENT_MARKETING_KEY = 'signup_consent_marketing'
 
 export function clearSignupSession(): void {
-  try {
-    sessionStorage.removeItem(SIGNUP_PLAN_KEY);
-    sessionStorage.removeItem(SIGNUP_CONSENT_GDPR_KEY);
-    sessionStorage.removeItem(SIGNUP_CONSENT_MARKETING_KEY);
-  } catch {
-    /* ignore */
-  }
+  if (typeof window === 'undefined') return
+  sessionStorage.removeItem(SIGNUP_PLAN_KEY)
+  sessionStorage.removeItem(SIGNUP_CONSENT_GDPR_KEY)
+  sessionStorage.removeItem(SIGNUP_CONSENT_MARKETING_KEY)
+}
+
+export function hasSignupConsent(): boolean {
+  if (typeof window === 'undefined') return false
+  return sessionStorage.getItem(SIGNUP_CONSENT_GDPR_KEY) === '1'
+}
+
+export function getStoredSignupPlan(): 'pro' | 'team' | null {
+  if (typeof window === 'undefined') return null
+  const stored = sessionStorage.getItem(SIGNUP_PLAN_KEY)
+  return stored === 'pro' || stored === 'team' ? stored : null
 }

--- a/docs/enterprise-page-qa.md
+++ b/docs/enterprise-page-qa.md
@@ -1,0 +1,43 @@
+# Enterprise page — production QA checklist
+
+Use this checklist before merging or after deploying `/enterprise` and related backend changes.
+
+## Automated gates
+
+Run from repo root:
+
+```bash
+cd dashboard && npm run lint && npm run build
+cd ../core && pytest tests/test_demo_requests.py tests/test_rate_limiting.py::TestDemoRequestsRateLimiting -q
+```
+
+Copy guardrails (must return no matches except explicit negations):
+
+```bash
+rg -i 'SOC 2|HIPAA|SAML|SCIM|PagerDuty|Slack alert|SLA guarantee|detects hallucination' \
+  dashboard/components/marketing/enterprise dashboard/app/enterprise
+```
+
+## Manual smoke (~5 min)
+
+- [ ] `/enterprise` — sections in order: Hero → What is → Fleet → Capabilities → Why enterprises choose → Security → Deployment → Pricing → FAQ → Contact form (`#contact`) → Technical resources → footer
+- [ ] Nav highlights **Enterprise** on desktop and mobile
+- [ ] **Let's connect** (hero) scrolls to `#contact`; first name field is focusable (`id="ent-first"`)
+- [ ] Submit connect form → **201**; admin demo requests tab shows `source=enterprise` and role when filled
+- [ ] Invalid `source` rejected server-side (422) — covered by pytest
+- [ ] **Book demo** opens Calendly modal; **ESC** closes
+- [ ] Mobile **375px**: nav CTA row visible, no horizontal overflow
+- [ ] All `TECHNICAL_LINKS` in resources strip resolve (no 404), including **EU AI Act** → `/eu-ai-act`
+- [ ] Resources grid (`.ent-resource-grid`) collapses to 2 columns on tablet, 1 on mobile — no cramped 3-column squeeze at 375px
+- [ ] Trust `#limits` shows Enterprise row; landing `#pricing` Enterprise card links to `/enterprise#contact`
+- [ ] `/trust`, `/docs`, `/community` show shared marketing footer with Enterprise link
+
+## Rate limiting note
+
+Demo request rate limits use the same in-memory pattern as auth OTP and community posts (`core/api/demo_requests.py`). In multi-worker deployments, effective limit is multiplied by worker count — consistent with the rest of the API today.
+
+## Lead form contract
+
+- Frontend: `EnterpriseConnectForm` sends `source: 'enterprise'` via `submitDemoRequest`; honeypot field is `botcheck` (off-screen)
+- Backend: `POST /v1/demo-requests` stores optional `position`, allowlisted `source`, client IP
+- Admin: search includes name, email, company, website, role, source


### PR DESCRIPTION
## Summary

- Restores the full public marketing site from `zizkadb-cloud`: landing page (tagline: "Dont Observe - Audit your AI Agent"), `/enterprise`, `/eu-ai-act`, `/docs`, `/trust`, `/community`, `/signup`, `/privacy`, and shared marketing components (`SiteNav`, `MarketingFooter`, etc.)
- Adds public backend routes: `POST /v1/demo-requests`, `GET/POST /v1/community/*`, `POST /v1/marketing-subscriptions`, with idempotent DDL for `marketing_subscriptions`, `email_suppressions`, and demo-request `position`/`source` columns
- Includes a follow-up migration for legacy installs that still have `community_posts.image_url` so `/v1/community/posts` works on existing databases, plus `dashboard/.dockerignore` to speed Docker builds

Ports cloud PRs #21 (EU AI Act + contrast fixes), #22 (dashboard fixes), and #23 (tagline). PR #20 (Token Usage) was already on OSS via #115.

## Test plan

- [x] `ruff check core/` passes
- [x] `pytest core/tests/test_demo_requests.py` passes
- [x] Live smoke: `/`, `/enterprise`, `/eu-ai-act`, `/docs`, `/trust`, `/community` → HTTP 200
- [x] Live smoke: `GET /v1/community/posts`, `POST /v1/demo-requests`, `POST /v1/marketing-subscriptions` → 200/201
- [ ] CI (lint + unit tests + dashboard build)


Made with [Cursor](https://cursor.com)