### PR TITLE
Add telemetry country capture and optional dashboard update opt-in (p…

### DIFF
--- a/core/api/telemetry.py
+++ b/core/api/telemetry.py
@@ -2,26 +2,56 @@
 POST /v1/telemetry — anonymous SDK usage ping.
 
 No auth required. Never returns errors (always 200).
-Stores: install_id, sdk, sdk_version, runtime version, OS, mode, first_seen, last_seen, ping_count.
+Stores: install_id, sdk, sdk_version, runtime, OS, mode, country_code,
+first_seen, last_seen, ping_count.
+
+POST /v1/telemetry/updates — optional email opt-in for product/security updates.
 """
 
-from fastapi import APIRouter, Request
-from pydantic import BaseModel
-from db.connection import get_pool
+from __future__ import annotations
+
 import logging
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, EmailStr, Field
+
+from api.utils import client_ip
+from db.connection import get_pool
+from services.country_from_request import country_code_from_request
+from services.email_suppress import is_suppressed
+from services.rate_limiter import RateLimiter, RedisStorage, SlidingWindowStrategy
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
+UPDATES_RATE_WINDOW_SEC = 3600
+UPDATES_RATE_MAX = 20
+
+updates_limiter = RateLimiter(
+    limit=UPDATES_RATE_MAX,
+    window_sec=UPDATES_RATE_WINDOW_SEC,
+    storage=RedisStorage(key_prefix="ratelimit:telemetry-updates"),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many requests. Try again later.",
+)
+
 
 class TelemetryPing(BaseModel):
-    install_id:  str
-    sdk:         str = "unknown"
+    install_id: str
+    sdk: str = "unknown"
     sdk_version: str = "unknown"
-    python:      str | None = None
-    node:        str | None = None
-    os:          str = "unknown"
-    mode:        str = "cloud"   # "cloud" | "self-hosted"
+    python: str | None = None
+    node: str | None = None
+    os: str = "unknown"
+    mode: str = "cloud"  # "cloud" | "self-hosted"
+
+
+class TelemetryUpdatesBody(BaseModel):
+    email: EmailStr
+    install_id: str | None = Field(default=None, max_length=128)
+    sdk: str = Field(default="unknown", max_length=32)
+    source: str = Field(default="dashboard", max_length=64)
+    botcheck: str | None = None
 
 
 @router.post("", status_code=200)
@@ -30,18 +60,20 @@ async def receive_ping(body: TelemetryPing, request: Request):
     try:
         pool = get_pool()
         runtime = body.python or body.node or "unknown"
+        country = country_code_from_request(request)
 
         await pool.execute(
             """
             INSERT INTO sdk_telemetry
-                (install_id, sdk, sdk_version, runtime, os, mode)
-            VALUES ($1, $2, $3, $4, $5, $6)
+                (install_id, sdk, sdk_version, runtime, os, mode, country_code)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
             ON CONFLICT (install_id)
             DO UPDATE SET
-                last_seen   = NOW(),
-                ping_count  = sdk_telemetry.ping_count + 1,
-                sdk_version = EXCLUDED.sdk_version,
-                mode        = EXCLUDED.mode
+                last_seen     = NOW(),
+                ping_count    = sdk_telemetry.ping_count + 1,
+                sdk_version   = EXCLUDED.sdk_version,
+                mode          = EXCLUDED.mode,
+                country_code  = COALESCE(EXCLUDED.country_code, sdk_telemetry.country_code)
             """,
             body.install_id[:128],
             body.sdk[:32],
@@ -49,8 +81,54 @@ async def receive_ping(body: TelemetryPing, request: Request):
             runtime[:64],
             body.os[:32],
             body.mode[:32],
+            country,
         )
     except Exception as e:
-        logger.debug(f"Telemetry insert failed (non-critical): {e}")
+        logger.debug("Telemetry insert failed (non-critical): %s", e)
 
+    return {"ok": True}
+
+
+@router.post("/updates", status_code=201)
+async def subscribe_updates(body: TelemetryUpdatesBody, request: Request):
+    """Optional email opt-in for SDK/product update notices."""
+    if body.botcheck:
+        raise HTTPException(status_code=400, detail="Invalid submission")
+
+    ip = client_ip(request)
+    await updates_limiter.check(ip)
+
+    pool = get_pool()
+    email = str(body.email).strip().lower()
+    if await is_suppressed(pool, email):
+        return {"ok": True, "suppressed": True}
+
+    install_id = (body.install_id or "").strip()[:128] or None
+    sdk = (body.sdk or "unknown").strip()[:32]
+    source = (body.source or "dashboard").strip()[:64]
+    country = country_code_from_request(request)
+    ua = (request.headers.get("user-agent") or "")[:2000]
+
+    await pool.execute(
+        """
+        INSERT INTO sdk_update_subscriptions
+            (email, install_id, sdk, country_code, source, user_agent)
+        VALUES ($1, $2, $3, $4, $5, $6)
+        ON CONFLICT (LOWER(email)) DO UPDATE
+          SET install_id   = COALESCE(EXCLUDED.install_id, sdk_update_subscriptions.install_id),
+              sdk          = EXCLUDED.sdk,
+              country_code = COALESCE(EXCLUDED.country_code, sdk_update_subscriptions.country_code),
+              source       = EXCLUDED.source,
+              user_agent   = EXCLUDED.user_agent,
+              updated_at   = NOW()
+        """,
+        email,
+        install_id,
+        sdk,
+        country,
+        source,
+        ua,
+    )
+
+    logger.info("telemetry updates opt-in: %s (%s)", email, source)
     return {"ok": True}

--- a/core/db/connection.py
+++ b/core/db/connection.py
@@ -202,10 +202,33 @@ async def init_db():
             runtime TEXT NOT NULL DEFAULT 'unknown',
             os TEXT NOT NULL DEFAULT 'unknown',
             mode TEXT NOT NULL DEFAULT 'cloud',
+            country_code CHAR(2),
             first_seen TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             last_seen TIMESTAMPTZ NOT NULL DEFAULT NOW(),
             ping_count INTEGER NOT NULL DEFAULT 1
         )
+    """)
+
+    await _pg_pool.execute("""
+        ALTER TABLE sdk_telemetry ADD COLUMN IF NOT EXISTS country_code CHAR(2);
+    """)
+
+    await _pg_pool.execute("""
+        CREATE TABLE IF NOT EXISTS sdk_update_subscriptions (
+            subscription_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+            email           VARCHAR(255) NOT NULL,
+            install_id      TEXT,
+            sdk             VARCHAR(32) NOT NULL DEFAULT 'unknown',
+            country_code    CHAR(2),
+            source          VARCHAR(64) NOT NULL DEFAULT 'dashboard',
+            user_agent      TEXT,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_sdk_update_subscriptions_email
+            ON sdk_update_subscriptions (LOWER(email));
+        CREATE INDEX IF NOT EXISTS idx_sdk_update_subscriptions_created
+            ON sdk_update_subscriptions (created_at DESC);
     """)
 
 

--- a/core/db/schema.sql
+++ b/core/db/schema.sql
@@ -154,7 +154,22 @@ CREATE TABLE IF NOT EXISTS sdk_telemetry (
     runtime      VARCHAR(50),
     os           VARCHAR(50),
     mode         VARCHAR(30),
+    country_code CHAR(2),
     first_seen   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     last_seen    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     ping_count   INT NOT NULL DEFAULT 1
 );
+
+CREATE TABLE IF NOT EXISTS sdk_update_subscriptions (
+    subscription_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    email           VARCHAR(255) NOT NULL,
+    install_id      TEXT,
+    sdk             VARCHAR(32) NOT NULL DEFAULT 'unknown',
+    country_code    CHAR(2),
+    source          VARCHAR(64) NOT NULL DEFAULT 'dashboard',
+    user_agent      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_sdk_update_subscriptions_email
+    ON sdk_update_subscriptions (LOWER(email));

--- a/core/requirements.txt
+++ b/core/requirements.txt
@@ -6,6 +6,7 @@ pydantic[email]>=2.7.0
 redis>=5.0.4
 qdrant-client>=1.13.0,<1.14.0
 httpx>=0.27.0
+geoip2>=4.8.0
 PyJWT>=2.8.0
 bcrypt>=4.1.3
 cryptography>=42.0.0

--- a/core/services/country_from_request.py
+++ b/core/services/country_from_request.py
@@ -1,0 +1,70 @@
+"""Resolve ISO 3166-1 alpha-2 country codes from HTTP requests (no raw IP stored)."""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from fastapi import Request
+
+from api.utils import client_ip
+
+log = logging.getLogger(__name__)
+
+_COUNTRY_HEADERS = (
+    "cf-ipcountry",
+    "x-vercel-ip-country",
+    "x-country-code",
+    "cloudfront-viewer-country",
+)
+
+
+def _is_private_or_local_ip(ip: str) -> bool:
+    if not ip or ip == "unknown":
+        return True
+    try:
+        addr = ipaddress.ip_address(ip.split("%")[0])
+        return addr.is_private or addr.is_loopback or addr.is_link_local
+    except ValueError:
+        return True
+
+
+@lru_cache(maxsize=1)
+def _geoip_reader():
+    path = (os.getenv("GEOIP_COUNTRY_DB_PATH") or "").strip()
+    if not path or not Path(path).is_file():
+        return None
+    try:
+        import geoip2.database
+
+        return geoip2.database.Reader(path)
+    except Exception as exc:
+        log.warning("GeoIP database unavailable at %s: %s", path, exc)
+        return None
+
+
+def country_code_from_ip(ip: str) -> str | None:
+    if _is_private_or_local_ip(ip):
+        return None
+    reader = _geoip_reader()
+    if not reader:
+        return None
+    try:
+        return reader.country(ip).country.iso_code
+    except Exception:
+        return None
+
+
+def country_code_from_request(request: Request) -> str | None:
+    for header in _COUNTRY_HEADERS:
+        raw = request.headers.get(header)
+        if not raw:
+            continue
+        code = raw.strip().upper()
+        if len(code) == 2 and code not in ("XX", "T1"):
+            return code
+
+    return country_code_from_ip(client_ip(request))

--- a/core/tests/test_telemetry.py
+++ b/core/tests/test_telemetry.py
@@ -1,0 +1,107 @@
+"""Tests for telemetry pings, country capture, and optional update subscriptions."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from api.telemetry import updates_limiter
+from main import app
+from services.country_from_request import country_code_from_ip, country_code_from_request
+from services.rate_limiter import InMemoryStorage
+
+client = TestClient(app)
+
+PING = {
+    "install_id": "550e8400-e29b-41d4-a716-446655440000",
+    "sdk": "python",
+    "sdk_version": "0.2.5",
+    "python": "3.12",
+    "os": "Linux",
+    "mode": "cloud",
+}
+
+
+class TestCountryFromRequest:
+    def test_cf_ipcountry_header(self):
+        request = MagicMock()
+        request.headers = {"cf-ipcountry": "de"}
+        request.client = MagicMock(host="203.0.113.1")
+        assert country_code_from_request(request) == "DE"
+
+    def test_private_ip_returns_none_without_geoip(self):
+        assert country_code_from_ip("127.0.0.1") is None
+        assert country_code_from_ip("192.168.1.4") is None
+
+
+class TestTelemetryPing:
+    @patch("api.telemetry.get_pool")
+    def test_ping_stores_country_from_header(self, mock_get_pool):
+        mock_pool = MagicMock()
+        mock_pool.execute = AsyncMock()
+        mock_get_pool.return_value = mock_pool
+
+        response = client.post(
+            "/v1/telemetry",
+            json=PING,
+            headers={"CF-IPCountry": "US"},
+        )
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+        args = mock_pool.execute.call_args[0]
+        assert args[7] == "US"
+
+    @patch("api.telemetry.get_pool")
+    def test_ping_always_returns_ok_on_db_error(self, mock_get_pool):
+        mock_pool = MagicMock()
+        mock_pool.execute = AsyncMock(side_effect=RuntimeError("db down"))
+        mock_get_pool.return_value = mock_pool
+
+        response = client.post("/v1/telemetry", json=PING)
+        assert response.status_code == 200
+        assert response.json() == {"ok": True}
+
+
+class TestTelemetryUpdates:
+    def setup_method(self):
+        updates_limiter.storage = InMemoryStorage()
+        asyncio.run(updates_limiter.storage.clear())
+
+    @patch("api.telemetry.get_pool")
+    @patch("api.telemetry.is_suppressed", new_callable=AsyncMock, return_value=False)
+    def test_subscribe_updates(self, _mock_suppressed, mock_get_pool):
+        mock_pool = MagicMock()
+        mock_pool.execute = AsyncMock()
+        mock_get_pool.return_value = mock_pool
+
+        response = client.post(
+            "/v1/telemetry/updates",
+            json={
+                "email": "dev@example.com",
+                "install_id": PING["install_id"],
+                "sdk": "python",
+                "source": "dashboard",
+                "botcheck": "",
+            },
+            headers={"CF-IPCountry": "DE"},
+        )
+        assert response.status_code == 201
+        assert response.json() == {"ok": True}
+
+        args = mock_pool.execute.call_args[0]
+        assert args[1] == "dev@example.com"
+        assert args[2] == PING["install_id"]
+        assert args[4] == "DE"
+
+    def test_honeypot_rejected(self):
+        response = client.post(
+            "/v1/telemetry/updates",
+            json={
+                "email": "dev@example.com",
+                "botcheck": "spam",
+            },
+        )
+        assert response.status_code == 400

--- a/dashboard/app/privacy/page.tsx
+++ b/dashboard/app/privacy/page.tsx
@@ -52,7 +52,8 @@ export default function PrivacyPolicyPage() {
         <li style={S.li}><strong>Technical data</strong> — IP address, browser type, device information, API request logs, error reports</li>
         <li style={S.li}><strong>Communications</strong> — messages you send via contact or enterprise forms</li>
         <li style={S.li}><strong>Cookie / local storage data</strong> — consent preferences and session identifiers (see Section 9)</li>
-        <li style={S.li}><strong>Optional telemetry</strong> — anonymous SDK install metrics if not disabled (<code style={{ fontFamily: 'monospace', fontSize: 13 }}>ZIZKADB_TELEMETRY=false</code>)</li>
+        <li style={S.li}><strong>Optional telemetry</strong> — anonymous SDK install metrics (SDK type, version, OS, and coarse country derived from IP at ping time; we do not store raw IP in telemetry tables) if not disabled (<code style={{ fontFamily: 'monospace', fontSize: 13 }}>ZIZKADB_TELEMETRY=false</code>)</li>
+        <li style={S.li}><strong>Optional product updates</strong> — if you choose to subscribe on the dashboard or via a future SDK prompt, we store your email solely to send release and security notices; you may unsubscribe at any time</li>
       </ul>
 
       <h2 style={S.h2}>4. Purposes and legal bases (GDPR Art. 6)</h2>

--- a/dashboard/components/dashboard/DashboardTabsShell.tsx
+++ b/dashboard/components/dashboard/DashboardTabsShell.tsx
@@ -10,6 +10,7 @@ import { useEdition } from '@/hooks/useEdition'
 import { useAgents } from '@/hooks/useAgents'
 import { useSelectedAgent } from '@/hooks/useSelectedAgent'
 import { colors } from '@/lib/design-tokens'
+import { TelemetryUpdatesPrompt } from '@/components/dashboard/TelemetryUpdatesPrompt'
 
 /** Tabs available in every edition, in display order. */
 const BASE_TABS = [
@@ -85,6 +86,7 @@ function ShellInner({ children }: { children: ReactNode }) {
       </header>
 
       <main className="flex-1 max-w-7xl mx-auto w-full px-4 sm:px-6 py-6">{children}</main>
+      <TelemetryUpdatesPrompt />
     </div>
   )
 }

--- a/dashboard/components/dashboard/TelemetryUpdatesPrompt.tsx
+++ b/dashboard/components/dashboard/TelemetryUpdatesPrompt.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { getSessionEmail } from '@/lib/auth'
+import { getOrCreateInstallId, submitTelemetryUpdates } from '@/lib/telemetry-updates'
+import { colors } from '@/lib/design-tokens'
+
+const DISMISS_KEY = 'zizkadb_telemetry_updates_dismissed_at'
+const SUBMITTED_KEY = 'zizkadb_telemetry_updates_submitted_at'
+
+function nowMs() {
+  return Date.now()
+}
+
+function parseMs(v: string | null): number | null {
+  if (!v) return null
+  const n = Number(v)
+  return Number.isFinite(n) ? n : null
+}
+
+/** Optional email opt-in for SDK/security release notes (dashboard visitors). */
+export function TelemetryUpdatesPrompt() {
+  const [open, setOpen] = useState(false)
+  const [email, setEmail] = useState('')
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState('')
+  const timer = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (getSessionEmail()) return
+
+    const dismissed = parseMs(window.localStorage.getItem(DISMISS_KEY))
+    const submitted = parseMs(window.localStorage.getItem(SUBMITTED_KEY))
+    if (submitted) return
+    if (dismissed && nowMs() - dismissed < 14 * 24 * 60 * 60 * 1000) return
+
+    timer.current = window.setTimeout(() => setOpen(true), 8000)
+    return () => {
+      if (timer.current) window.clearTimeout(timer.current)
+    }
+  }, [])
+
+  const styles = useMemo(
+    () => ({
+      wrap: {
+        position: 'fixed' as const,
+        bottom: 20,
+        right: 20,
+        zIndex: 1200,
+        width: 'min(420px, calc(100vw - 32px))',
+        background: colors.surfaceAlt,
+        border: `1px solid ${colors.border}`,
+        borderRadius: 14,
+        padding: '16px 18px',
+        boxShadow: '0 12px 40px rgba(0,0,0,0.35)',
+        display: open ? 'block' : 'none',
+      },
+      title: { fontSize: 14, fontWeight: 700, color: colors.textStrong, marginBottom: 6 },
+      body: { fontSize: 13, color: colors.textMuted, lineHeight: 1.5, marginBottom: 12 },
+      row: { display: 'flex', gap: 8, flexWrap: 'wrap' as const },
+      input: {
+        flex: '1 1 180px',
+        padding: '9px 11px',
+        background: colors.bg,
+        border: `1px solid ${colors.border}`,
+        borderRadius: 10,
+        color: colors.textStrong,
+        fontSize: 13,
+        outline: 'none',
+      },
+      primary: {
+        padding: '9px 12px',
+        borderRadius: 10,
+        border: 'none',
+        background: '#f97316',
+        color: '#111',
+        fontSize: 13,
+        fontWeight: 700,
+        cursor: 'pointer',
+        opacity: busy ? 0.7 : 1,
+      },
+      ghost: {
+        padding: '9px 12px',
+        borderRadius: 10,
+        border: `1px solid ${colors.border}`,
+        background: 'transparent',
+        color: colors.textMuted,
+        fontSize: 13,
+        cursor: 'pointer',
+      },
+      err: { marginTop: 8, fontSize: 12, color: '#f87171' },
+    }),
+    [open, busy],
+  )
+
+  const dismiss = () => {
+    try {
+      window.localStorage.setItem(DISMISS_KEY, String(nowMs()))
+    } catch {
+      // ignore
+    }
+    setOpen(false)
+  }
+
+  const submit = async () => {
+    setBusy(true)
+    setErr('')
+    try {
+      await submitTelemetryUpdates({
+        email: email.trim(),
+        install_id: getOrCreateInstallId(),
+        sdk: 'dashboard',
+      })
+      try {
+        window.localStorage.setItem(SUBMITTED_KEY, String(nowMs()))
+      } catch {
+        // ignore
+      }
+      setOpen(false)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : 'Failed to subscribe')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!open) return null
+
+  return (
+    <div style={styles.wrap} role="dialog" aria-label="Optional product updates">
+      <div style={styles.title}>Get SDK &amp; security updates?</div>
+      <div style={styles.body}>
+        Optional. We&apos;ll email release notes and breaking-change alerts. You can skip — the dashboard works either way.
+      </div>
+      <div style={styles.row}>
+        <input
+          style={styles.input}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="you@example.com"
+          inputMode="email"
+          autoComplete="email"
+          disabled={busy}
+        />
+        <button type="button" style={styles.primary} disabled={busy || email.trim().length < 3} onClick={submit}>
+          Subscribe
+        </button>
+        <button type="button" style={styles.ghost} disabled={busy} onClick={dismiss}>
+          Skip
+        </button>
+      </div>
+      {err && <div style={styles.err}>{err}</div>}
+    </div>
+  )
+}

--- a/dashboard/lib/telemetry-updates.ts
+++ b/dashboard/lib/telemetry-updates.ts
@@ -1,0 +1,38 @@
+import { API } from './api'
+
+export interface TelemetryUpdatesPayload {
+  email: string
+  install_id?: string
+  sdk?: string
+  source?: string
+}
+
+export async function submitTelemetryUpdates(payload: TelemetryUpdatesPayload) {
+  const res = await fetch(`${API}/v1/telemetry/updates`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ...payload, source: payload.source ?? 'dashboard', botcheck: '' }),
+  })
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({ detail: res.statusText }))
+    const detail = err.detail
+    throw new Error(typeof detail === 'string' ? detail : 'Request failed')
+  }
+  return res.json() as Promise<{ ok: true }>
+}
+
+const INSTALL_ID_KEY = 'zizkadb_install_id'
+
+/** Stable anonymous install id for dashboard opt-in (matches SDK telemetry shape). */
+export function getOrCreateInstallId(): string {
+  if (typeof window === 'undefined') return ''
+  try {
+    const existing = window.localStorage.getItem(INSTALL_ID_KEY)
+    if (existing) return existing
+    const id = crypto.randomUUID()
+    window.localStorage.setItem(INSTALL_ID_KEY, id)
+    return id
+  } catch {
+    return ''
+  }
+}


### PR DESCRIPTION
…hase 1).

Record ISO country on SDK telemetry pings from CDN headers or optional GeoIP DB; add POST /v1/telemetry/updates for voluntary email subscriptions and a skippable dashboard prompt.