### PR TITLE
fix(phase-4): dashboard reliability and UX

### DIFF
--- a/dashboard/app/dashboard/activity/page.tsx
+++ b/dashboard/app/dashboard/activity/page.tsx
@@ -72,7 +72,7 @@ function ActivityContent() {
 
   // Hooks must run unconditionally; they no-op on a null agent.
   const events = useAgentEvents(agentId)
-  const { stats } = useAgentStats(agentId)
+  const { stats, pollError } = useAgentStats(agentId)
 
   if (agentsLoading) return <Skeleton rows={6} />
 
@@ -122,6 +122,11 @@ function ActivityContent() {
           <h1 className="text-lg font-semibold leading-tight" style={{ color: colors.textStrong }}>
             Activity
           </h1>
+          {pollError && (
+            <p className="text-xs mt-1" style={{ color: colors.warning }}>
+              Live stats temporarily unavailable — showing last known counts.
+            </p>
+          )}
           {stats && (
             <p className="text-xs mt-1 flex flex-wrap items-center gap-x-3 gap-y-0.5" style={{ color: colors.textMuted }}>
               <span><span style={{ color: colors.text }}>{stats.total_events.toLocaleString()}</span> events</span>

--- a/dashboard/app/dashboard/behavior/page.tsx
+++ b/dashboard/app/dashboard/behavior/page.tsx
@@ -97,7 +97,12 @@ function BehaviorContent() {
           window={window}
           onRecompute={recompute}
         />
-      ) : null}
+      ) : (
+        <EmptyState
+          title="Not enough sessions yet"
+          description="Behavior baselines need recorded sessions. Log events with this agent, then check back."
+        />
+      )}
     </>
   )
 }

--- a/dashboard/app/dashboard/fleet/page.tsx
+++ b/dashboard/app/dashboard/fleet/page.tsx
@@ -167,8 +167,9 @@ function FleetContent() {
     [refresh],
   )
 
-  if (editionLoading || loading) return <Skeleton rows={5} />
-  if (edition === 'oss') return <Skeleton rows={5} />
+  if (editionLoading) return <Skeleton rows={5} />
+  if (edition === 'oss') return null
+  if (loading) return <Skeleton rows={5} />
 
   return (
     <>

--- a/dashboard/app/dashboard/reports/page.tsx
+++ b/dashboard/app/dashboard/reports/page.tsx
@@ -137,9 +137,19 @@ function ReportsContent() {
         <Skeleton rows={8} />
       ) : error ? (
         <ErrorState message={error} />
+      ) : !range && period === 'custom' ? (
+        <EmptyState
+          title="Choose a custom date range"
+          description="Pick a start and end date, then click Generate to build the report."
+        />
       ) : report ? (
         <ReportView report={report} periodLabel={periodLabel} />
-      ) : null}
+      ) : (
+        <EmptyState
+          title="No report data"
+          description="Try a different period or wait for this agent to record more events."
+        />
+      )}
     </>
   )
 }

--- a/dashboard/app/dashboard/settings/page.tsx
+++ b/dashboard/app/dashboard/settings/page.tsx
@@ -50,6 +50,7 @@ export default function SettingsPage() {
   const { copied, copy } = useCopyToClipboard();
   const router = useRouter();
   const [accountOpts, setAccountOpts] = useState<AccountOptions | null>(null);
+  const [accountOptsErr, setAccountOptsErr] = useState("");
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteConfirm, setDeleteConfirm] = useState("");
   const [accountBusy, setAccountBusy] = useState(false);
@@ -75,7 +76,7 @@ export default function SettingsPage() {
       .finally(() => setLoading(false));
     getEmbeddingCatalog()
       .then((c) => setCatalog(c.providers ?? []))
-      .catch(() => {});
+      .catch(() => setEmbErr("Could not load embedding provider catalog"));
     getEmbeddingSettings(token)
       .then((s) => {
         if (s.provider) setEmbProvider(s.provider);
@@ -88,7 +89,7 @@ export default function SettingsPage() {
       .finally(() => setEmbLoading(false));
     getAccountOptions(token)
       .then(setAccountOpts)
-      .catch(() => {});
+      .catch(() => setAccountOptsErr("Could not load account options"));
   }, []);
 
   async function handleRevoke(key: ApiKey) {
@@ -526,6 +527,12 @@ export default function SettingsPage() {
           </div>
         )}
       </div>
+      )}
+
+      {accountOptsErr && (
+        <p className="text-xs mt-4" style={{ color: '#f87171' }}>
+          {accountOptsErr}
+        </p>
       )}
 
       {accountOpts?.managed_cloud && (

--- a/dashboard/app/dashboard/suggestions/page.tsx
+++ b/dashboard/app/dashboard/suggestions/page.tsx
@@ -128,9 +128,19 @@ function SuggestionsContent() {
         <Skeleton rows={8} />
       ) : error ? (
         <ErrorState message={error} />
+      ) : !range && period === 'custom' ? (
+        <EmptyState
+          title="Choose a custom date range"
+          description="Pick a start and end date, then click Analyze to generate suggestions."
+        />
       ) : result ? (
         <ResultBody result={result} refreshing={refreshing} />
-      ) : null}
+      ) : (
+        <EmptyState
+          title="No suggestions yet"
+          description="Try a different period or check back after this agent records more activity."
+        />
+      )}
     </>
   )
 }

--- a/dashboard/app/login/page.tsx
+++ b/dashboard/app/login/page.tsx
@@ -213,7 +213,7 @@ function LoginForm() {
           >
             Your account was deleted.{" "}
             <Link
-              href="https://db.zizka.ai/signup"
+              href="/signup"
               style={{ color: "#111", fontWeight: 600 }}
             >
               Create a new account →
@@ -366,7 +366,7 @@ function LoginForm() {
                     <p style={{ margin: 0 }}>{error}</p>
                     {noAccount && (
                       <Link
-                        href="https://db.zizka.ai/signup"
+                        href="/signup"
                         style={{
                           display: "inline-block",
                           marginTop: 10,
@@ -475,7 +475,7 @@ function LoginForm() {
                     <p style={{ margin: 0 }}>{error}</p>
                     {noAccount && (
                       <Link
-                        href="https://db.zizka.ai/signup"
+                        href="/signup"
                         style={{
                           display: "inline-block",
                           marginTop: 10,
@@ -559,7 +559,7 @@ function LoginForm() {
           >
             No account yet?{" "}
             <Link
-              href="https://db.zizka.ai/signup"
+              href="/signup"
               style={{ color: "#555", textDecoration: "none", fontWeight: 500 }}
             >
               Create one free →

--- a/dashboard/components/dashboard/token-optimization/TokenOptimizationSummary.tsx
+++ b/dashboard/components/dashboard/token-optimization/TokenOptimizationSummary.tsx
@@ -15,6 +15,9 @@ import { KpiCard } from '@/components/dashboard/report/KpiCard'
 export function TokenOptimizationSummary({ result }: { result: TokenOptimizationResult }) {
   const a = result.aggregates
   const hasUnpriced = result.unpriced_models.length > 0
+  const skipped = Array.isArray(result.meta?.skipped_categories)
+    ? (result.meta.skipped_categories as string[])
+    : []
 
   // "Optimization score" is easy to misread without context — higher means
   // already well-optimized (less room to improve), lower means more savings
@@ -45,6 +48,18 @@ export function TokenOptimizationSummary({ result }: { result: TokenOptimization
 
   return (
     <section>
+      {skipped.length > 0 && (
+        <div
+          className="flex items-start gap-2 mb-3 px-3 py-2 text-xs"
+          role="status"
+          style={{ background: colors.surfaceHover, border: `1px solid ${colors.border}`, borderRadius: 8 }}
+        >
+          <Info size={14} className="mt-0.5 shrink-0" style={{ color: colors.textMuted }} />
+          <span style={{ color: colors.textMuted }}>
+            Categories not evaluated in v1: {skipped.map((c) => c.replace(/_/g, ' ')).join(', ')}.
+          </span>
+        </div>
+      )}
       {hasUnpriced && (
         <div
           className="flex items-start gap-2 mb-3 px-3 py-2 text-xs"

--- a/dashboard/hooks/useAgentStats.ts
+++ b/dashboard/hooks/useAgentStats.ts
@@ -13,6 +13,7 @@ import { POLL_INTERVAL_MS } from '@/lib/constants'
 export function useAgentStats(agentId: string | null) {
   const [stats, setStats] = useState<AgentStats | null>(null)
   const [loading, setLoading] = useState(true)
+  const [pollError, setPollError] = useState(false)
 
   const load = useCallback(async (): Promise<AgentStats | null> => {
     if (!agentId) return null
@@ -20,8 +21,10 @@ export function useAgentStats(agentId: string | null) {
     if (!token) return null
     try {
       const res = await getAgentStats(token, agentId)
+      setPollError(false)
       return res
     } catch {
+      setPollError(true)
       return null
     }
   }, [agentId])
@@ -53,5 +56,5 @@ export function useAgentStats(agentId: string | null) {
     }
   }, [agentId, load])
 
-  return { stats, loading }
+  return { stats, loading, pollError }
 }

--- a/dashboard/lib/api.test.ts
+++ b/dashboard/lib/api.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { API_FETCH_TIMEOUT_MS } from './api'
+
+describe('apiFetch behavior', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.useRealTimers()
+  })
+
+  it('exports a 30 second timeout constant', () => {
+    expect(API_FETCH_TIMEOUT_MS).toBe(30_000)
+  })
+
+  it('throws on abort timeout', async () => {
+    vi.useFakeTimers()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn((_url: string, init?: RequestInit) => {
+        return new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('Aborted')
+            err.name = 'AbortError'
+            reject(err)
+          })
+        })
+      }),
+    )
+
+    const { getAgents } = await import('./api')
+    const pending = getAgents('tok')
+    await vi.advanceTimersByTimeAsync(API_FETCH_TIMEOUT_MS + 1)
+    await expect(pending).rejects.toThrow(/timed out/i)
+  })
+
+  it('clears auth and redirects on 401', async () => {
+    vi.stubGlobal('location', { href: '' } as Location)
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: false,
+        status: 401,
+        json: async () => ({ detail: 'Invalid token' }),
+      })),
+    )
+
+    localStorage.clear()
+    localStorage.setItem('zizkadb_token', 'old')
+
+    const { getAgents } = await import('./api')
+    await expect(getAgents('old')).rejects.toThrow(/session expired/i)
+    expect(localStorage.getItem('zizkadb_token')).toBeNull()
+    expect(window.location.href).toBe('/login')
+  })
+})
+
+describe('getToken cookie fallback', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    localStorage.clear()
+    document.cookie = ''
+  })
+
+  it('reads token from cookie when localStorage is empty', async () => {
+    document.cookie = 'zizkadb_token=cookie-token'
+    const { getToken } = await import('./auth')
+    expect(getToken()).toBe('cookie-token')
+  })
+})

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -23,6 +23,8 @@ function formatApiError(detail: unknown, fallback: string): string {
 
 // Default `T = any` preserves the exact pre-existing untyped behavior for any
 // call site that doesn't opt into an explicit type — this is additive only.
+export const API_FETCH_TIMEOUT_MS = 30_000
+
 async function apiFetch<T = any>(path: string, token: string, options: RequestInit = {}): Promise<T> {
   const headers: Record<string, string> = {
     'Content-Type': 'application/json',
@@ -31,10 +33,35 @@ async function apiFetch<T = any>(path: string, token: string, options: RequestIn
   if (token) {
     headers.Authorization = `Bearer ${token}`
   }
-  const res = await fetch(`${API}${path}`, {
-    ...options,
-    headers,
-  })
+
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), API_FETCH_TIMEOUT_MS)
+
+  let res: Response
+  try {
+    res = await fetch(`${API}${path}`, {
+      ...options,
+      headers,
+      signal: options.signal ?? controller.signal,
+    })
+  } catch (e) {
+    if (e instanceof Error && e.name === 'AbortError') {
+      throw new Error('Request timed out. Check your connection and try again.')
+    }
+    throw e
+  } finally {
+    clearTimeout(timeout)
+  }
+
+  if (res.status === 401) {
+    if (typeof window !== 'undefined') {
+      const { clearToken } = await import('./auth')
+      clearToken()
+      window.location.href = '/login'
+    }
+    throw new Error('Session expired. Please sign in again.')
+  }
+
   if (!res.ok) {
     const err = await res.json().catch(() => ({ detail: res.statusText }))
     throw new Error(formatApiError(err.detail, res.statusText || 'API error'))

--- a/dashboard/lib/auth.ts
+++ b/dashboard/lib/auth.ts
@@ -19,9 +19,15 @@ function eraseCookie(name: string) {
   document.cookie = `${name}=; path=/; max-age=0`
 }
 
+function readCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null
+  const match = document.cookie.match(new RegExp(`(?:^|; )${name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}=([^;]*)`))
+  return match ? decodeURIComponent(match[1]) : null
+}
+
 export function getToken(): string | null {
   if (typeof window === 'undefined') return null
-  return localStorage.getItem(USER_TOKEN_COOKIE)
+  return localStorage.getItem(USER_TOKEN_COOKIE) ?? readCookie(USER_TOKEN_COOKIE)
 }
 
 export function setToken(token: string) {


### PR DESCRIPTION
## Summary
Phase 4 — dashboard reliability (7 commits).

- `apiFetch` 30s timeout + 401 session cleanup
- Token fallback from cookie when localStorage empty
- Settings embedding/account load errors surfaced
- Activity stats poll error indicator
- Relative signup URLs on login
- Fleet OSS redirect without skeleton flash

## Test plan
- [ ] `cd dashboard && npm test && npm run lint && npm run build`

Made with [Cursor](https://cursor.com)