### PR TITLE
feat(phase-7-8): Python and TypeScript SDK analytics parity

### DIFF
--- a/sdk/python/tests/test_analytics_client.py
+++ b/sdk/python/tests/test_analytics_client.py
@@ -1,0 +1,68 @@
+import asyncio
+import httpx
+import pytest
+
+from zizkadb.client import ZizkaDB
+
+
+def _prevent_telemetry(monkeypatch):
+    monkeypatch.setattr("zizkadb.client._telemetry_ping", lambda mode: None)
+    monkeypatch.setenv("ZIZKADB_TELEMETRY", "false")
+
+
+def _client(monkeypatch, handler):
+    _prevent_telemetry(monkeypatch)
+    db = ZizkaDB(api_key="zizkadb_live_test", host="https://example.test")
+    db._client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        base_url=db._base_url,
+        headers=db._headers(),
+    )
+    return db
+
+
+@pytest.mark.parametrize(
+    ("method_name", "call", "expected_path"),
+    [
+        (
+            "token_usage",
+            lambda db: db.token_usage("a1", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z"),
+            "/v1/agents/a1/token-usage",
+        ),
+        (
+            "token_optimization",
+            lambda db: db.token_optimization("a1"),
+            "/v1/agents/a1/token-optimization",
+        ),
+        (
+            "suggestions",
+            lambda db: db.suggestions("a1"),
+            "/v1/agents/a1/suggestions",
+        ),
+        (
+            "report",
+            lambda db: db.report("a1", "2026-01-01T00:00:00Z", "2026-01-02T00:00:00Z"),
+            "/v1/agents/a1/report",
+        ),
+        (
+            "behavior_change",
+            lambda db: db.behavior_change("a1"),
+            "/v1/agents/a1/behavior-change",
+        ),
+    ],
+)
+def test_analytics_methods_hit_expected_paths(monkeypatch, method_name, call, expected_path):
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["path"] = request.url.path
+        return httpx.Response(200, json={"ok": True})
+
+    db = _client(monkeypatch, handler)
+    try:
+        result = asyncio.run(call(db))
+    finally:
+        asyncio.run(db._client.aclose())
+
+    assert seen["path"] == expected_path
+    assert result == {"ok": True}

--- a/sdk/python/zizkadb/client.py
+++ b/sdk/python/zizkadb/client.py
@@ -123,6 +123,7 @@ class ZizkaDB:
         parent_id: str | None = None,
         session_id: str | None = None,
         metadata: dict[str, Any] | None = None,
+        token_usage: dict[str, Any] | None = None,
     ) -> LogResult:
         """
         Log an event.
@@ -138,12 +139,15 @@ class ZizkaDB:
         Returns:
             LogResult with event_id, timestamp, sequence_no, checksum
         """
+        payload_data = dict(data)
+        if token_usage is not None:
+            payload_data["token_usage"] = token_usage
         response = await self._post(
             "/v1/events",
             {
                 "agent": agent,
                 "event": event,
-                "data": data,
+                "data": payload_data,
                 "parent_id": parent_id,
                 "session_id": session_id,
                 "metadata": metadata,
@@ -409,7 +413,12 @@ class ZizkaDB:
     # BASELINE — behavioral baseline + drift signal
     # ─────────────────────────────────────────
 
-    async def baseline(self, agent: str, recent_window: int = 50) -> dict:
+    async def baseline(
+        self,
+        agent: str,
+        recent_window: int = 50,
+        window: str | None = None,
+    ) -> dict:
         """
         Get the behavioral baseline for an agent.
 
@@ -437,10 +446,88 @@ class ZizkaDB:
             if b["drift"]["score"] > 0.15:
                 print("Drift detected:", b["drift"]["biggest_changes"])
         """
+        params: dict[str, Any] = {"recent_window": recent_window}
+        if window:
+            params["window"] = window
         return await self._get(
             f"/v1/agents/{agent}/baseline",
-            {"recent_window": recent_window},
+            params,
         )
+
+    async def token_usage(
+        self,
+        agent: str,
+        from_: str,
+        to: str,
+        granularity: str | None = None,
+    ) -> dict:
+        """Token usage and cost report for an agent over a date range."""
+        params: dict[str, Any] = {"from": from_, "to": to}
+        if granularity:
+            params["granularity"] = granularity
+        return await self._get(f"/v1/agents/{agent}/token-usage", params)
+
+    async def token_optimization(
+        self,
+        agent: str,
+        from_: str | None = None,
+        to: str | None = None,
+        granularity: str | None = None,
+    ) -> dict:
+        """Deterministic token optimization suggestions from real usage events."""
+        params: dict[str, Any] = {}
+        if from_:
+            params["from"] = from_
+        if to:
+            params["to"] = to
+        if granularity:
+            params["granularity"] = granularity
+        return await self._get(f"/v1/agents/{agent}/token-optimization", params)
+
+    async def suggestions(
+        self,
+        agent: str,
+        from_: str | None = None,
+        to: str | None = None,
+        refresh: bool = False,
+    ) -> dict:
+        """AI-generated improvement suggestions for an agent."""
+        params: dict[str, Any] = {}
+        if from_:
+            params["from"] = from_
+        if to:
+            params["to"] = to
+        if refresh:
+            params["refresh"] = "true"
+        return await self._get(f"/v1/agents/{agent}/suggestions", params)
+
+    async def report(
+        self,
+        agent: str,
+        from_: str,
+        to: str,
+        granularity: str | None = None,
+    ) -> dict:
+        """Consolidated date-ranged report for an agent."""
+        params: dict[str, Any] = {"from": from_, "to": to}
+        if granularity:
+            params["granularity"] = granularity
+        return await self._get(f"/v1/agents/{agent}/report", params)
+
+    async def behavior_change(
+        self,
+        agent: str,
+        window: str = "7d",
+        from_ts: str | None = None,
+        to_ts: str | None = None,
+    ) -> dict:
+        """Time-windowed behavior change vs the pre-window baseline epoch."""
+        params: dict[str, Any] = {"window": window}
+        if from_ts:
+            params["from_ts"] = from_ts
+        if to_ts:
+            params["to_ts"] = to_ts
+        return await self._get(f"/v1/agents/{agent}/behavior-change", params)
 
     # ─────────────────────────────────────────
     # HTTP HELPERS

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -451,10 +451,78 @@ export class ZizkaDB {
   async baseline(options: {
     agent: string
     recentWindow?: number
+    window?: '24h' | '7d' | '30d'
   }): Promise<Record<string, unknown>> {
-    const res = await this.get(`/v1/agents/${options.agent}/baseline`, {
+    const params: Record<string, string> = {
       recent_window: String(options.recentWindow ?? 50),
-    })
+    }
+    if (options.window) params.window = options.window
+    const res = await this.get(`/v1/agents/${options.agent}/baseline`, params)
+    return res as Record<string, unknown>
+  }
+
+  async tokenUsage(options: {
+    agent: string
+    from: string
+    to: string
+    granularity?: 'hour' | 'day' | 'week'
+  }): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = { from: options.from, to: options.to }
+    if (options.granularity) params.granularity = options.granularity
+    const res = await this.get(`/v1/agents/${options.agent}/token-usage`, params)
+    return res as Record<string, unknown>
+  }
+
+  async tokenOptimization(options: {
+    agent: string
+    from?: string
+    to?: string
+    granularity?: 'day' | 'week'
+  }): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = {}
+    if (options.from) params.from = options.from
+    if (options.to) params.to = options.to
+    if (options.granularity) params.granularity = options.granularity
+    const res = await this.get(`/v1/agents/${options.agent}/token-optimization`, params)
+    return res as Record<string, unknown>
+  }
+
+  async suggestions(options: {
+    agent: string
+    from?: string
+    to?: string
+    refresh?: boolean
+  }): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = {}
+    if (options.from) params.from = options.from
+    if (options.to) params.to = options.to
+    if (options.refresh) params.refresh = 'true'
+    const res = await this.get(`/v1/agents/${options.agent}/suggestions`, params)
+    return res as Record<string, unknown>
+  }
+
+  async report(options: {
+    agent: string
+    from: string
+    to: string
+    granularity?: 'day' | 'week'
+  }): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = { from: options.from, to: options.to }
+    if (options.granularity) params.granularity = options.granularity
+    const res = await this.get(`/v1/agents/${options.agent}/report`, params)
+    return res as Record<string, unknown>
+  }
+
+  async behaviorChange(options: {
+    agent: string
+    window?: '24h' | '7d' | '30d' | 'custom'
+    fromTs?: string
+    toTs?: string
+  }): Promise<Record<string, unknown>> {
+    const params: Record<string, string> = { window: options.window ?? '7d' }
+    if (options.fromTs) params.from_ts = options.fromTs
+    if (options.toTs) params.to_ts = options.toTs
+    const res = await this.get(`/v1/agents/${options.agent}/behavior-change`, params)
     return res as Record<string, unknown>
   }
 


### PR DESCRIPTION
## Summary
Phases 7–8 — SDK analytics methods (3 commits).

- Python: `token_usage`, `token_optimization`, `suggestions`, `report`, `behavior_change`, `baseline(window=)`
- Python analytics client tests
- TypeScript: matching analytics methods + baseline window param

## Test plan
- [ ] `pytest sdk/python/tests/test_analytics_client.py -v`
- [ ] `cd sdk/typescript && npm test`

Made with [Cursor](https://cursor.com)