### PR TITLE
fix(phase-12): backend hardening

### DIFF
--- a/core/api/settings.py
+++ b/core/api/settings.py
@@ -34,7 +34,7 @@ async def embeddings_catalog():
 
 
 @router.get("/embeddings")
-async def get_embeddings(tenant: dict = Depends(get_tenant)):
+async def get_embeddings(tenant: dict = Depends(require_dashboard_session)):
     config = await get_tenant_embedding_config(tenant["tenant_id"])
     return embedding_config_for_response(config)
 

--- a/core/db/connection.py
+++ b/core/db/connection.py
@@ -195,6 +195,12 @@ async def init_db():
     """)
 
     await _pg_pool.execute("""
+        CREATE INDEX IF NOT EXISTS idx_api_keys_tenant_active
+        ON api_keys (tenant_id)
+        WHERE revoked = FALSE;
+    """)
+
+    await _pg_pool.execute("""
         CREATE TABLE IF NOT EXISTS sdk_telemetry (
             install_id TEXT PRIMARY KEY,
             sdk TEXT NOT NULL DEFAULT 'unknown',

--- a/core/main.py
+++ b/core/main.py
@@ -42,6 +42,13 @@ async def lifespan(app: FastAPI):
                 "Refusing to start with ENV=production and default JWT_SECRET. "
                 "Set a strong JWT_SECRET in infra/.env."
             )
+        from services.entitlements import limits_enforced
+
+        if not limits_enforced():
+            logger.warning(
+                "API_KEY_LIMITS_ENFORCED is false in production — per-plan API key "
+                "caps are not enforced until you enable the kill switch."
+            )
     await init_db()
     # Seed dev tenant for local self-host (ENV=development) or when DEV_API_KEY is set.
     if os.getenv("ENV", "development") == "development" or os.getenv("DEV_API_KEY"):

--- a/core/tests/test_settings_auth.py
+++ b/core/tests/test_settings_auth.py
@@ -1,0 +1,25 @@
+"""Tests for GET /v1/settings/embeddings auth."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+@patch("api.settings.get_tenant_embedding_config", new_callable=AsyncMock)
+def test_embeddings_get_rejects_api_key(mock_config):
+    mock_config.return_value = {
+        "provider": "openai",
+        "model": "text-embedding-3-small",
+        "use_platform_key": True,
+        "ready": False,
+    }
+    res = client.get(
+        "/v1/settings/embeddings",
+        headers={"Authorization": "Bearer zizkadb_live_testkey1234567890123456789012"},
+    )
+    assert res.status_code == 403
+    mock_config.assert_not_called()

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -9,7 +9,7 @@ COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 ARG NEXT_PUBLIC_API_URL=http://localhost:8000
 ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
-ARG NEXT_PUBLIC_DEV_MODE=true
+ARG NEXT_PUBLIC_DEV_MODE=false
 ENV NEXT_PUBLIC_DEV_MODE=$NEXT_PUBLIC_DEV_MODE
 # Edition signal: self_hosted (4 tabs) or managed (adds Agent Fleets).
 ARG NEXT_PUBLIC_DEPLOYMENT_MODE=self_hosted

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -47,6 +47,12 @@ services:
     environment:
       QDRANT__SERVICE__GRPC_PORT: 6334
 
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:6333/healthz || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
     restart: unless-stopped
 
   redis:
@@ -116,6 +122,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      qdrant:
         condition: service_healthy
 
     volumes:


### PR DESCRIPTION
## Summary
Phase 12 (partial) — backend hardening (2 commits). More commits will follow on this branch.

- Dashboard Dockerfile default `NEXT_PUBLIC_DEV_MODE=false`
- `GET /v1/settings/embeddings` requires dashboard JWT session

## Test plan
- [ ] Core unit tests pass

Made with [Cursor](https://cursor.com)