### PR TITLE
refactor(phase-5): dashboard plan metadata single source

### DIFF
--- a/core/tests/test_community.py
+++ b/core/tests/test_community.py
@@ -1,0 +1,97 @@
+"""Unit tests for public community board routes."""
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import UUID
+
+import pytest
+from fastapi.testclient import TestClient
+
+from api.community import community_limiter
+from main import app
+from services.rate_limiter import InMemoryStorage
+
+client = TestClient(app)
+
+POST_BODY = {
+    "author_name": "Ada",
+    "author_email": "ada@example.com",
+    "category": "question",
+    "title": "How do I log events?",
+    "body": "I am trying to connect the Python SDK to my local stack.",
+    "image_urls": [],
+    "website": "",
+}
+
+
+def _mock_pool(fetch_return=None, fetchrow_return=None):
+    pool = MagicMock()
+    pool.fetch = AsyncMock(return_value=fetch_return or [])
+    pool.fetchrow = AsyncMock(return_value=fetchrow_return)
+    pool.execute = AsyncMock()
+    return pool
+
+
+class TestCommunityPosts:
+    def setup_method(self):
+        community_limiter.storage = InMemoryStorage()
+        asyncio.run(community_limiter.storage.clear())
+
+    @patch("api.community.get_pool")
+    def test_list_posts_empty(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool(fetch_return=[])
+        res = client.get("/v1/community/posts")
+        assert res.status_code == 200
+        assert res.json()["posts"] == []
+
+    @patch("api.community.get_pool")
+    def test_create_post_happy_path(self, mock_get_pool):
+        post_id = "11111111-1111-1111-1111-111111111111"
+        now = datetime(2026, 7, 1, tzinfo=timezone.utc)
+        mock_get_pool.return_value = _mock_pool(
+            fetchrow_return={
+                "post_id": UUID(post_id),
+                "created_at": now,
+                "category": "question",
+                "title": POST_BODY["title"],
+                "body": POST_BODY["body"],
+                "author_name": POST_BODY["author_name"],
+                "reply_count": 0,
+                "image_urls": [],
+            }
+        )
+        res = client.post("/v1/community/posts", json=POST_BODY)
+        assert res.status_code == 201
+        data = res.json()
+        assert data["post_id"] == post_id
+        assert data["title"] == POST_BODY["title"]
+
+    @patch("api.community.get_pool")
+    def test_create_post_honeypot_rejects_bot(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool()
+        res = client.post(
+            "/v1/community/posts",
+            json={**POST_BODY, "website": "http://spam.bot"},
+        )
+        assert res.status_code == 400
+        mock_get_pool.return_value.execute.assert_not_called()
+
+    @patch("api.community.get_pool")
+    def test_create_post_rate_limit(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool(
+            fetchrow_return={
+                "post_id": UUID("11111111-1111-1111-1111-111111111111"),
+                "created_at": datetime(2026, 7, 1, tzinfo=timezone.utc),
+                "category": "question",
+                "title": POST_BODY["title"],
+                "body": POST_BODY["body"],
+                "author_name": POST_BODY["author_name"],
+                "reply_count": 0,
+                "image_urls": [],
+            }
+        )
+        for _ in range(10):
+            assert client.post("/v1/community/posts", json=POST_BODY).status_code == 201
+        res = client.post("/v1/community/posts", json=POST_BODY)
+        assert res.status_code == 429

--- a/core/tests/test_deep_health.py
+++ b/core/tests/test_deep_health.py
@@ -1,0 +1,21 @@
+"""Unit tests for GET /health/deep."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from main import app
+
+client = TestClient(app)
+
+
+@patch("main.check_postgres", new_callable=AsyncMock, return_value={"ok": True})
+@patch("main.check_redis", new_callable=AsyncMock, return_value={"ok": True})
+@patch("main.check_qdrant", new_callable=AsyncMock, return_value={"ok": True})
+def test_deep_health_returns_dependency_status(_q, _r, _p):
+    res = client.get("/health/deep")
+    assert res.status_code == 200
+    body = res.json()
+    assert body["status"] == "ok"
+    assert "checks" in body
+    assert body["checks"]["postgres"]["ok"] is True

--- a/core/tests/test_marketing_subscriptions.py
+++ b/core/tests/test_marketing_subscriptions.py
@@ -32,6 +32,25 @@ class TestMarketingSubscribe:
         assert res.json() == {"ok": True}
         pool.execute.assert_awaited_once()
 
+    @patch("api.marketing_subscriptions.is_suppressed", new_callable=AsyncMock, return_value=False)
+    @patch("api.marketing_subscriptions.get_pool")
+    def test_subscribe_rate_limit(self, mock_get_pool, _mock_suppressed):
+        pool = MagicMock()
+        pool.execute = AsyncMock()
+        mock_get_pool.return_value = pool
+
+        for _ in range(20):
+            assert client.post(
+                "/v1/marketing/subscribe",
+                json={"email": f"u{_}@example.com", "source": "popup", "botcheck": ""},
+            ).status_code == 201
+
+        res = client.post(
+            "/v1/marketing/subscribe",
+            json={"email": "one-more@example.com", "source": "popup", "botcheck": ""},
+        )
+        assert res.status_code == 429
+
     def test_subscribe_honeypot(self):
         res = client.post(
             "/v1/marketing/subscribe",

--- a/core/tests/test_marketing_subscriptions.py
+++ b/core/tests/test_marketing_subscriptions.py
@@ -1,0 +1,40 @@
+"""Tests for POST /v1/marketing/subscribe."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from api.marketing_subscriptions import subscribe_limiter
+from main import app
+from services.rate_limiter import InMemoryStorage
+
+client = TestClient(app)
+
+
+class TestMarketingSubscribe:
+    def setup_method(self):
+        subscribe_limiter.storage = InMemoryStorage()
+        asyncio.run(subscribe_limiter.storage.clear())
+
+    @patch("api.marketing_subscriptions.is_suppressed", new_callable=AsyncMock, return_value=False)
+    @patch("api.marketing_subscriptions.get_pool")
+    def test_subscribe_create(self, mock_get_pool, _mock_suppressed):
+        pool = MagicMock()
+        pool.execute = AsyncMock()
+        mock_get_pool.return_value = pool
+
+        res = client.post(
+            "/v1/marketing/subscribe",
+            json={"email": "lead@example.com", "source": "popup", "botcheck": ""},
+        )
+        assert res.status_code == 201
+        assert res.json() == {"ok": True}
+        pool.execute.assert_awaited_once()
+
+    def test_subscribe_honeypot(self):
+        res = client.post(
+            "/v1/marketing/subscribe",
+            json={"email": "lead@example.com", "botcheck": "spam"},
+        )
+        assert res.status_code == 400

--- a/dashboard/app/signup/plan/page.tsx
+++ b/dashboard/app/signup/plan/page.tsx
@@ -7,37 +7,20 @@ import { BRAND, BRAND_DARK } from "@/components/brand";
 import { SIGNUP_PLAN_KEY } from "@/lib/signup-funnel";
 import { M } from "@/components/marketing/marketing-theme";
 import { authPage, authSubtitle, authTitle, authMutedLink, authSubmitBtn, authCard } from "@/components/marketing/auth-styles";
+import { MANAGED_PLANS, type ManagedPlanId } from "@/lib/plans";
 
-const PLANS = [
-  {
-    id: "pro" as const,
-    name: "Pro",
-    price: "€29",
-    price_sub: "/ month",
-    highlight: true,
-    features: [
-      "50k events / month",
-      "2 active API keys",
-      "Email support",
-    ],
-  },
-  {
-    id: "team" as const,
-    name: "Team",
-    price: "€69",
-    price_sub: "/ month",
-    highlight: false,
-    features: [
-      "100k events / month",
-      "5 active API keys",
-      "Priority support",
-    ],
-  },
-];
+const PLANS = MANAGED_PLANS.map((p) => ({
+  id: p.id,
+  name: p.name,
+  price: p.price,
+  price_sub: p.priceSub,
+  highlight: p.highlight,
+  features: [...p.features],
+}));
 
 export default function SignupPlanPage() {
   const router = useRouter();
-  const [selected, setSelected] = useState<"pro" | "team">("pro");
+  const [selected, setSelected] = useState<ManagedPlanId>("pro");
 
   function handleContinue() {
     if (typeof window !== "undefined") {

--- a/dashboard/components/marketing/pricing-plans.ts
+++ b/dashboard/components/marketing/pricing-plans.ts
@@ -10,6 +10,21 @@ export interface PricingPlan {
   note?: string
 }
 
+import { MANAGED_PLANS } from "@/lib/plans";
+
+const managedPricing = MANAGED_PLANS.map(
+  (p): PricingPlan => ({
+    name: p.name,
+    price: p.price,
+    sub: p.priceSub,
+    features: p.features,
+    cta: "Get started",
+    href: `/signup?plan=${p.id}`,
+    highlight: p.highlight,
+    ctaPrimary: p.id === "pro",
+  }),
+);
+
 export const LANDING_PRICING_PLANS: readonly PricingPlan[] = [
   {
     name: 'Self-Hosted',
@@ -21,26 +36,7 @@ export const LANDING_PRICING_PLANS: readonly PricingPlan[] = [
     highlight: false,
     ctaPrimary: false,
   },
-  {
-    name: 'Pro',
-    price: '\u20ac29',
-    sub: '/ month',
-    features: ['50k events / month', '2 active API keys', 'Email support'],
-    cta: 'Get started',
-    href: '/signup?plan=pro',
-    highlight: true,
-    ctaPrimary: true,
-  },
-  {
-    name: 'Team',
-    price: '\u20ac69',
-    sub: '/ month',
-    features: ['100k events / month', '5 active API keys', 'Priority support'],
-    cta: 'Get started',
-    href: '/signup?plan=team',
-    highlight: false,
-    ctaPrimary: false,
-  },
+  ...managedPricing,
   {
     name: 'Enterprise',
     price: 'Annual License',

--- a/dashboard/lib/plans.ts
+++ b/dashboard/lib/plans.ts
@@ -1,0 +1,36 @@
+/** Single source for managed-cloud plan metadata shown in signup and marketing. */
+
+export type ManagedPlanId = 'pro' | 'team'
+
+export interface ManagedPlanMeta {
+  id: ManagedPlanId
+  name: string
+  price: string
+  priceSub: string
+  highlight: boolean
+  features: readonly string[]
+}
+
+/** API key caps must match core/services/entitlements.py PLAN_ENTITLEMENTS. */
+export const MANAGED_PLANS: readonly ManagedPlanMeta[] = [
+  {
+    id: 'pro',
+    name: 'Pro',
+    price: '€29',
+    priceSub: '/ month',
+    highlight: true,
+    features: ['50k events / month', '2 active API keys', 'Email support'],
+  },
+  {
+    id: 'team',
+    name: 'Team',
+    price: '€69',
+    priceSub: '/ month',
+    highlight: false,
+    features: ['100k events / month', '5 active API keys', 'Priority support'],
+  },
+] as const
+
+export function managedPlanById(id: ManagedPlanId): ManagedPlanMeta {
+  return MANAGED_PLANS.find((p) => p.id === id) ?? MANAGED_PLANS[0]
+}


### PR DESCRIPTION
## Summary
- Extract `dashboard/lib/plans.ts` as single source for Pro/Team plan metadata
- Update landing pricing and signup plan page to import from `lib/plans`

## Test plan
- [x] `cd dashboard && npm run lint && npm run build`
- [x] Verify signup plan page shows Pro (2 keys) and Team (5 keys)


Made with [Cursor](https://cursor.com)