### PR TITLE
test(phase-14): dashboard vitest billing and plans

### DIFF
--- a/dashboard/lib/api.test.ts
+++ b/dashboard/lib/api.test.ts
@@ -70,3 +70,31 @@ describe('getToken cookie fallback', () => {
     expect(getToken()).toBe('cookie-token')
   })
 })
+
+describe('selectBillingPlan', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.unstubAllGlobals()
+  })
+
+  it('POSTs plan to /v1/billing/select-plan', async () => {
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => ({
+      ok: true,
+      status: 200,
+      json: async () => ({ plan: 'pro', has_access: true }),
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { selectBillingPlan } = await import('./api')
+    const result = await selectBillingPlan('tok', 'pro')
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining('/v1/billing/select-plan'),
+      expect.objectContaining({
+        method: 'POST',
+        body: JSON.stringify({ plan: 'pro' }),
+      }),
+    )
+    expect(result.plan).toBe('pro')
+  })
+})

--- a/dashboard/lib/plans.test.ts
+++ b/dashboard/lib/plans.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { MANAGED_PLANS, managedPlanById } from './plans'
+
+describe('MANAGED_PLANS', () => {
+  it('defines pro and team with matching API key caps', () => {
+    const pro = MANAGED_PLANS.find((p) => p.id === 'pro')
+    const team = MANAGED_PLANS.find((p) => p.id === 'team')
+    expect(pro?.features).toContain('2 active API keys')
+    expect(team?.features).toContain('5 active API keys')
+  })
+
+  it('managedPlanById returns pro for unknown ids', () => {
+    expect(managedPlanById('pro').id).toBe('pro')
+    // @ts-expect-error exercising fallback for invalid runtime input
+    expect(managedPlanById('unknown').id).toBe('pro')
+  })
+})


### PR DESCRIPTION
## Summary
- Add lib/plans.test.ts for Pro/Team key cap metadata
- Add selectBillingPlan contract test in lib/api.test.ts

## Test plan
- [ ] cd dashboard && npm test

Made with [Cursor](https://cursor.com)