### PR TITLE
docs: developer experience and integration documentation audit

### DIFF
--- a/.cursor/rules/sdk-integrations-mcp.mdc
+++ b/.cursor/rules/sdk-integrations-mcp.mdc
@@ -39,7 +39,7 @@ const baseline = await db.baseline({ agent: 'my-bot' })
 
 ## Integrations (`integrations/`)
 
-Two standalone packages: `zizkadb-langchain` and `zizkadb-crewai`. **Not yet on PyPI** — install via git URL.
+Two standalone packages: `zizkadb-langchain` and `zizkadb-crewai`. **Published on PyPI** — `pip install zizkadb-langchain zizkadb-crewai`.
 
 ### Critical: code lives in two places — keep both in sync
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Summary
+
+<!-- What changed and why (1–3 bullets). -->
+
+## Test plan
+
+- [ ] `ruff check core/ sdk/python/ mcp/ integrations/` (if Python touched)
+- [ ] `pytest core/tests/ -m "not integration"` (if core touched)
+- [ ] `cd dashboard && npm run lint && npm test && npm run build` (if dashboard touched)
+- [ ] Manual: <!-- steps or "docs only" -->
+
+## Areas touched
+
+- [ ] API / schema
+- [ ] SDK (Python / TypeScript)
+- [ ] Dashboard
+- [ ] MCP / integrations
+- [ ] Docs only
+- [ ] Infra / CI
+
+## Breaking changes
+
+<!-- None, or describe migration. -->
+
+Fixes #<!-- issue number if applicable -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md — guidance for AI coding tools
+
+This file helps Cursor, Copilot, Claude Code, and other agents work on **this repository**.
+
+## Start here
+
+| Resource | Use for |
+|----------|---------|
+| [CLAUDE.md](CLAUDE.md) | Project stack, invariants, test commands |
+| [.cursor/rules/coding-standards.mdc](.cursor/rules/coding-standards.mdc) | Always-on auth, entitlements, cross-cutting rules |
+| [.cursor/rules/ai-knowledge-base.mdc](.cursor/rules/ai-knowledge-base.mdc) | Doc index + OSS scope |
+| [docs/README.md](docs/README.md) | Human + agent documentation map |
+| [dashboard/DASHBOARD_KNOWLEDGE_BASE.md](dashboard/DASHBOARD_KNOWLEDGE_BASE.md) | Dashboard flows and API contract |
+
+Area-specific rules load automatically from `.cursor/rules/*.mdc` by file path.
+
+## Critical invariants
+
+1. **Auth:** SDK routes → `get_tenant`; dashboard management → `require_dashboard_session`; per-agent routes → `assert_agent_allowed`.
+2. **Never rename `/v1/` paths** without updating `dashboard/lib/api.ts`.
+3. **Plan caps:** only in `core/services/entitlements.py::PLAN_ENTITLEMENTS`.
+4. **Schema DDL:** idempotent only (`IF NOT EXISTS`).
+5. **No admin console in OSS** — do not add `/v1/admin` or `/admin` routes here.
+
+## Tests before PR
+
+```bash
+ruff check core/ sdk/python/ mcp/ integrations/
+pytest core/tests/ -m "not integration" -v
+cd dashboard && npm run lint && npm test && npm run build
+```
+
+See [.cursor/skills/zizkadb-test/SKILL.md](.cursor/skills/zizkadb-test/SKILL.md).
+
+## Integrating ZizkaDB into user agents (product)
+
+For **using** ZizkaDB as a product (not hacking this repo), point users to:
+
+- [CONNECT.md](CONNECT.md)
+- [docs/integrate/any-agent.md](docs/integrate/any-agent.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+- Documentation hub: `docs/README.md`, `docs/integrate/`
+- `AGENTS.md` for AI coding tools
+- `wiki/Production-Deployment.md` (self-host production ops)
+
+### Fixed
+- README plan terminology (API keys vs "projects")
+- CONNECT.md dashboard verify steps (Activity tab)
+
+## [0.1.0] — 2026-08-21
+
+Production-hardening sprint merged to `main` (via stacked PRs #125–#139), including:
+
+- CI: dashboard vitest, integration workflow
+- Security: scoped-key isolation on `why()`, search, verify-otp rate limits
+- Dashboard: `apiFetch` timeout, 401 handling, `lib/plans.ts`
+- SDK: analytics methods (`baseline`, `token_usage`, `token_optimization`)
+- MCP: analytics tools
+- CLI: `why`, `baseline`, `token-usage`, `token-opt`
+- Docs: always-on Cursor coding standards, KB OSS scope updates
+
+See [GitHub releases](https://github.com/Zizka-ai/ZizkaDB/releases) for tagged artifacts.
+
+[Unreleased]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/Zizka-ai/ZizkaDB/releases

--- a/CONNECT.md
+++ b/CONNECT.md
@@ -46,7 +46,7 @@ async def main():
             data={"tool": "search"},
             parent_id=user.event_id,
         )
-        print("Logged — refresh dashboard → Agents → my-bot")
+        print("Logged — refresh dashboard → Activity → my-bot")
 
 asyncio.run(main())
 ```
@@ -179,9 +179,9 @@ Swagger: http://localhost:8000/swagger
 
 ## Verify
 
-1. Dashboard → **Agents** — `my-bot` appears within ~30s  
-2. Settings → **Send test event** (separate test agent)  
-3. Agent page → **Test agent**
+1. Dashboard → **Activity** — `my-bot` appears within ~30s  
+2. Settings → **Send test event** (logs to `dashboard-connection-test`, not your agent)  
+3. Settings with `?agent=my-bot` → **Test agent**
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,8 @@ You do **not** need a large PR to help.
 | **Improve docs** | README, wiki, `dashboard/app/docs`, integration guides |
 | **Fix issues** | Pick an open issue or ask on the [community board](https://db.zizka.ai/community) |
 | **SDKs & MCP** | Python / TypeScript SDK, `zizkadb-mcp` tools |
-| **Integrations** | LangChain, CrewAI, OpenAI Agents, new framework adapters |
-| **Dashboard** | Agent views, drift UI, admin tools |
+| **Integrations** | LangChain, CrewAI (PyPI adapters); example patterns for other frameworks (`examples/`) |
+| **Dashboard** | Agent views, drift UI, settings |
 | **Core API** | Event pipeline, search, baselines, auth |
 | **Examples** | Minimal demos under `examples/` |
 | **Discuss design** | Open an issue or community post before large architectural changes |

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@
 
 # ZizkaDB
 
-**Dont Observe - Audit your AI Agent.**
+**Don't observe — audit your AI agent.**
 
 Operational database for AI agents — replay sessions, trace decisions, detect drift.
+
+**Have an agent already? → [CONNECT.md](CONNECT.md) · [Integration guides](docs/integrate/)**
 
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/Zizka-ai/ZizkaDB?label=release&color=f97316)](https://github.com/Zizka-ai/ZizkaDB/releases)
@@ -35,13 +37,15 @@ Operational database for AI agents — replay sessions, trace decisions, detect 
 | **Best for** | Self-hosters & contributors | Solo devs & early prod | Teams with multiple agents |
 | **Price** | Free forever (AGPL) | €29 / month | €69 / month |
 | **Hosting** | Your machine / VPC | [db.zizka.ai](https://db.zizka.ai) | [db.zizka.ai](https://db.zizka.ai) |
-| **Events / month** | Unlimited (your infra) | 50k | 100k |
-| **Projects** | Unlimited | 2 | 5 |
+| **Events / month** | Unlimited (your infra) | 50k† | 100k† |
+| **Active API keys** | Unlimited | 2 | 5 |
 | **Dashboard** | Activity · Behavior · Reports · Suggestions | Same + **Fleet** (managed) | Same + **Fleet** + priority support |
 | **Support** | Community | Email | Priority |
 | **Jump to** | [4 steps ↓](#open-source-self-host) | [4 steps ↓](#pro-managed-cloud) | [4 steps ↓](#team-managed-cloud) |
 
 > **Enterprise VPC?** Single-tenant deploy, commercial license → [db.zizka.ai/enterprise](https://db.zizka.ai/enterprise)
+
+> † Event caps are **plan targets** on managed cloud; **not enforced** in the API yet. **Active API key** caps apply when `API_KEY_LIMITS_ENFORCED=true`. Details: [docs/README.md](docs/README.md#plan-limits-honest).
 
 > This repo is the **open-source product runtime** (API, dashboard, SDKs, MCP). Managed operator tools live in a private repo; all product links point here.
 
@@ -55,7 +59,7 @@ Operational database for AI agents — replay sessions, trace decisions, detect 
 | :---: | :--- |
 | **① What it is** | ZizkaDB stores every agent step as a **linked event** — not scattered logs. Trace decisions with **`why()`**, rewind with **`at()`**, search history in plain English, and catch **behavioral drift** before users notice. You run the full stack: API + dashboard + SDKs. |
 | **② How to integrate** | Run locally in ~2 min: `curl -fsSL …/quickstart-remote.sh \| bash` then `pip install zizkadb-sdk` (or TS / MCP / REST). Link events with `parent_id` so `why()` can walk the chain. → **[Full connect guide](CONNECT.md)** |
-| **③ Documentation** | [CONNECT.md](CONNECT.md) · [Docs](https://db.zizka.ai/docs) · [Self-hosting](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) · [Examples](examples/) · [Architecture](https://github.com/Zizka-ai/ZizkaDB/wiki/Architecture) |
+| **③ Documentation** | [CONNECT.md](CONNECT.md) · [docs/](docs/) · [Self-hosting](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) · [Examples](examples/) · [Architecture](https://github.com/Zizka-ai/ZizkaDB/wiki/Architecture) |
 | **④ Live dashboard** | **[localhost:3001/login](http://localhost:3001/login)** → **Open my dashboard** (no signup). Log from SDK → refresh → see sessions live. |
 
 **Quickstart**
@@ -87,7 +91,7 @@ async with ZizkaDB(host="http://localhost:8000") as db:
 | :---: | :--- |
 | **① What it is** | Same engine, **hosted on [db.zizka.ai](https://db.zizka.ai)**. Replay sessions and trace causal chains without running your own databases. **vs OSS:** zero infra · instant API keys · **Fleet** tab on managed cloud. |
 | **② How to integrate** | [Sign up →](https://db.zizka.ai/signup?plan=pro) · create agent · copy API key · `pip install zizkadb-sdk` · log with `api_key="zizkadb_live_..."`. Also: npm, MCP, REST. → **[CONNECT.md](CONNECT.md)** |
-| **③ Documentation** | [db.zizka.ai/docs](https://db.zizka.ai/docs) · [Swagger](https://db.zizka.ai/swagger) · [Community](https://db.zizka.ai/community) · **50k events/mo · 2 projects · email support** |
+| **③ Documentation** | [db.zizka.ai/docs](https://db.zizka.ai/docs) · [Swagger](https://db.zizka.ai/swagger) · [Community](https://db.zizka.ai/community) · **50k events/mo† · 2 API keys · email support** |
 | **④ Live dashboard** | **[db.zizka.ai/dashboard](https://db.zizka.ai/dashboard)** — sign up, log from SDK, sessions appear in seconds. Same UI as self-host, always online. |
 
 ```python
@@ -107,13 +111,13 @@ async with ZizkaDB(api_key="zizkadb_live_...") as db:
 
 ## Team (managed cloud)
 
-**Multiple agents & projects in production**
+**Multiple agents in production**
 
 | Step | What you get |
 | :---: | :--- |
-| **① What it is** | Everything in **Pro**, with room to grow. **vs Pro:** 100k events (vs 50k) · 5 projects (vs 2) · **priority support** · built for multi-agent ops with **Fleet** ranking. |
+| **① What it is** | Everything in **Pro**, with room to grow. **vs Pro:** 100k events† (vs 50k) · 5 active API keys (vs 2) · **priority support** · built for multi-agent ops with **Fleet** ranking. |
 | **② How to integrate** | [Sign up for Team →](https://db.zizka.ai/signup?plan=team) · one agent per service · consistent `session_id` per conversation. → **[Multi-agent wiki](https://github.com/Zizka-ai/ZizkaDB/wiki/Multi-Agent-Apps)** |
-| **③ Documentation** | [Plan picker](https://db.zizka.ai/signup/plan) · [Docs](https://db.zizka.ai/docs) · [Production wiki](https://github.com/Zizka-ai/ZizkaDB/wiki/Production-Deployment) · **100k events/mo · 5 projects · priority support** |
+| **③ Documentation** | [Plan picker](https://db.zizka.ai/signup/plan) · [Docs](https://db.zizka.ai/docs) · [Production wiki](https://github.com/Zizka-ai/ZizkaDB/wiki/Production-Deployment) · **100k events/mo† · 5 API keys · priority support** |
 | **④ Live dashboard** | **[db.zizka.ai/dashboard](https://db.zizka.ai/dashboard)** — switch agents, compare baselines, Fleet ranking across your workspace. |
 
 ```typescript
@@ -159,10 +163,10 @@ Core unit tests plus the SDK and MCP package tests do not require a running Zizk
 | **Fleet** tab (managed cloud) | — | ✓ | ✓ |
 | Self-host / AGPL | ✓ | — | — |
 | Managed hosting | — | ✓ | ✓ |
-| 50k events / month | — | ✓ | — |
-| 100k events / month | — | — | ✓ |
-| 2 projects | — | ✓ | — |
-| 5 projects | — | — | ✓ |
+| 50k events / month† | — | ✓ | — |
+| 100k events / month† | — | — | ✓ |
+| 2 active API keys | — | ✓ | — |
+| 5 active API keys | — | — | ✓ |
 | Priority support | — | — | ✓ |
 | Enterprise VPC | [Contact →](https://db.zizka.ai/enterprise) | | |
 
@@ -173,6 +177,8 @@ Core unit tests plus the SDK and MCP package tests do not require a running Zizk
 | Python | TypeScript | LangChain | CrewAI | MCP (Cursor) | REST |
 | :---: | :---: | :---: | :---: | :---: | :---: |
 | [`pip install zizkadb-sdk`](https://pypi.org/project/zizkadb-sdk/) | [`npm i zizkadb-sdk`](https://www.npmjs.com/package/zizkadb-sdk) | [Guide →](CONNECT.md#langchain) | [Guide →](CONNECT.md#crewai) | `uvx zizkadb-mcp` | [Swagger →](https://db.zizka.ai/swagger) |
+
+**Any framework:** [docs/integrate/any-agent.md](docs/integrate/any-agent.md) · **LangGraph / others:** [docs/integrate/frameworks.md](docs/integrate/frameworks.md)
 
 <p align="center">
   <img src="docs/assets/gallery-mcp.png" alt="ZizkaDB MCP in Cursor" width="45%"/>
@@ -214,6 +220,8 @@ zizkadb init my-agent --template basic
 
 | Resource | Link |
 | --- | --- |
+| Documentation index | [docs/README.md](docs/README.md) |
+| Integrate any agent | [docs/integrate/](docs/integrate/) |
 | Issues | [GitHub Issues](https://github.com/Zizka-ai/ZizkaDB/issues) |
 | Discussions | [GitHub Discussions](https://github.com/Zizka-ai/ZizkaDB/discussions) |
 | Forum | [db.zizka.ai/community](https://db.zizka.ai/community) |

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -687,7 +687,7 @@ The logic that drives every dashboard gate and funnel branch. Routers are thin; 
 
 **No payment provider.** Billing endpoints exist for plan persistence and informational status only.
 
-**Plans** (`PLAN_CATALOG`, `billing.py`): `pro` = €29/mo (50k events/mo, 2 projects), `team` = €69/mo (100k events/mo, 5 projects). Trial length = `TRIAL_DAYS` env (default **30**).
+**Plans** (`PLAN_CATALOG`, `billing.py`): `pro` = €29/mo (50k events/mo target†, 2 active API keys), `team` = €69/mo (100k events/mo target†, 5 active API keys). Trial length = `TRIAL_DAYS` env (default **30**). †Event caps are marketing copy — not enforced in API yet.
 
 **Access:** `billing_status_payload` always returns `has_access: true`, `enforced: false`, `requires_plan_selection: false`, `requires_checkout: false`. Used by `TenantPlanBanner` and verify-otp response for compatibility.
 
@@ -947,7 +947,7 @@ These live in the same Next app but are separate from the tenant `/dashboard/*` 
 - **Client Component**, static marketing. Sections: `SiteNav` → Hero (+ `CalendlyBookModal`, `IntegrationStrip`) → `ThreeWaysConnectSection` → `ConversationCompare` → engineering cards → `TrustBar` → **Pricing grid** (Self-Hosted / Pro / Team / Enterprise via `PricingCard` + `LANDING_PRICING_PLANS`) → `CompetitorCompare` → final CTA → footer.
 - **State:** `copied` (which copy button, 2s reset) and `demoOpen` (Calendly modal). **No `useEffect`, no API calls.**
 - **CTAs / nav:** `/signup` (hero, cards, final, footer), `/signup?plan=pro`, `/signup?plan=team`, `/enterprise#contact` (Enterprise pricing card), `/docs`, `/trust`, `/login`, `#pricing`, GitHub. "Book demo" opens `CalendlyBookModal` (`demoOpen`); "Copy MCP config" copies `MCP_CONFIG` JSON.
-- **Rules:** `plan.highlight` → "POPULAR" badge; `ctaPrimary` → filled orange CTA (Pro, Enterprise). **Pro** €29/mo (50k events, 2 projects); **Team** €69/mo (100k events, 5 projects); both include 30-day free trial. Enterprise card: **Annual License / 1 Year**, four VPC features (Install + integration workshop; no audit/commercial bullets on landing). Pricing grid: 4-col desktop, 2-col tablet (≤1024px), 1-col mobile (≤768px); cards use flex column so CTAs align at bottom. `SiteNav` Enterprise link uses premium outlined style (`enterpriseNavLinkStyle` in `brand.ts`).
+- **Rules:** `plan.highlight` → "POPULAR" badge; `ctaPrimary` → filled orange CTA (Pro, Enterprise). **Pro** €29/mo (50k events†, 2 active API keys); **Team** €69/mo (100k events†, 5 active API keys); both include 30-day free trial. †Event caps not enforced in API. Enterprise card: **Annual License / 1 Year**, four VPC features (Install + integration workshop; no audit/commercial bullets on landing). Pricing grid: 4-col desktop, 2-col tablet (≤1024px), 1-col mobile (≤768px); cards use flex column so CTAs align at bottom. `SiteNav` Enterprise link uses premium outlined style (`enterpriseNavLinkStyle` in `brand.ts`).
 
 ### 20.2 Community — `app/community/page.tsx` + `app/community/[id]/page.tsx`
 

--- a/dashboard/app/docs/sections.tsx
+++ b/dashboard/app/docs/sections.tsx
@@ -673,7 +673,7 @@ asyncio.run(run_turn("Hello", "sess_001"))`}</Code>
           },
           {
             q: "401 Invalid API key",
-            a: "Copy the full key from Dashboard → Agents (no spaces). Use ZIZKADB_API_KEY or AGENTDB_API_KEY in your env.",
+            a: "Copy the full key from Dashboard → Settings → API keys (no spaces). Use ZIZKADB_API_KEY or AGENTDB_API_KEY in your env.",
           },
           {
             q: "403 Agent mismatch",
@@ -681,7 +681,7 @@ asyncio.run(run_turn("Hello", "sess_001"))`}</Code>
           },
           {
             q: "Dashboard empty but SDK works",
-            a: "Check you are viewing the same agent name your code logs to. Click Test agent on the agent page. Settings test event goes to dashboard-connection-test, not your app agent.",
+            a: "Check you are viewing the same agent name your code logs to. Use Test agent in Settings with ?agent= set. Settings → Send test event logs to dashboard-connection-test, not your app agent.",
           },
           {
             q: "Search returns nothing",

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,43 @@
+# ZizkaDB documentation index
+
+Start here if you are not sure which file to read.
+
+## I want to…
+
+| Goal | Start here |
+|------|------------|
+| **Understand the product in 2 minutes** | [README](../README.md) |
+| **Connect my existing agent** | [CONNECT.md](../CONNECT.md) → [integrate/](integrate/) |
+| **Run locally (Docker)** | `bash scripts/setup-local.sh` · [Getting Started wiki](../wiki/Getting-Started.md) |
+| **Self-host production** | [wiki/Self-Hosting](../wiki/Self-Hosting.md) · [Production deployment](../wiki/Production-Deployment.md) |
+| **Use managed cloud** | [db.zizka.ai/signup](https://db.zizka.ai/signup) |
+| **Browse API** | [Swagger](https://db.zizka.ai/swagger) · [REST API wiki](../wiki/REST-API.md) |
+| **Product docs (hosted site)** | [db.zizka.ai/docs](https://db.zizka.ai/docs) |
+| **Examples** | [examples/](../examples/) · `zizkadb init my-agent --template basic` |
+| **Contribute** | [CONTRIBUTING.md](../CONTRIBUTING.md) · [CLAUDE.md](../CLAUDE.md) |
+| **Troubleshoot** | [wiki/Troubleshooting](../wiki/Troubleshooting.md) |
+| **Architecture / why** | [docs/adr/](adr/) · [wiki/Architecture](../wiki/Architecture.md) |
+
+## Integration guides (in this repo)
+
+| Guide | Status |
+|-------|--------|
+| [Any agent (framework-agnostic)](integrate/any-agent.md) | **Start here** for custom stacks |
+| [Supported vs generic frameworks](integrate/frameworks.md) | LangChain, CrewAI, LangGraph, etc. |
+| [CONNECT.md](../CONNECT.md) | Copy-paste: Python, TS, LangChain, CrewAI, MCP, REST |
+
+## Source of truth
+
+| Topic | Canonical location |
+|-------|-------------------|
+| HTTP API routes | FastAPI `/swagger` (runtime) |
+| Dashboard API client | `dashboard/lib/api.ts` |
+| Dashboard behavior | `dashboard/DASHBOARD_KNOWLEDGE_BASE.md` |
+| Plan API key caps | `core/services/entitlements.py` |
+| Auth rules | `docs/adr/004-auth-dependency-split.md` |
+| AI coding in this repo | [AGENTS.md](../AGENTS.md) · `.cursor/rules/` |
+
+## Plan limits (honest)
+
+- **Enforced today (when `API_KEY_LIMITS_ENFORCED=true`):** active API keys per plan (Self-Hosted 1, Pro 2, Team 5, Enterprise 50).
+- **Marketing targets, not enforced in API yet:** monthly event caps (50k / 100k on Pro/Team copy).

--- a/docs/integrate/README.md
+++ b/docs/integrate/README.md
@@ -1,0 +1,44 @@
+# Integrate ZizkaDB
+
+**Already have an agent?** You only need three things:
+
+1. A running ZizkaDB (local, self-host, or [db.zizka.ai](https://db.zizka.ai))
+2. An **agent id** string (same name in code and dashboard)
+3. Calls to `log()` (SDK or REST) with optional `parent_id` and `session_id`
+
+## Choose your path
+
+| Stack | Guide |
+|-------|-------|
+| **Any framework / custom code** | [any-agent.md](any-agent.md) |
+| **What's officially supported** | [frameworks.md](frameworks.md) |
+| **Copy-paste quickstart** | [CONNECT.md](../../CONNECT.md) |
+
+## Minimal Python (local)
+
+```bash
+bash scripts/setup-local.sh   # or quickstart-remote.sh
+pip install zizkadb-sdk
+```
+
+```python
+import asyncio
+from zizkadb import ZizkaDB
+
+async def main():
+    async with ZizkaDB(host="http://localhost:8000") as db:
+        turn = await db.log(agent="my-bot", event="user_message", data={"text": "Hi"})
+        await db.log(agent="my-bot", event="assistant_response", data={"text": "Hello"}, parent_id=turn.event_id)
+
+asyncio.run(main())
+```
+
+Open http://localhost:3001/login → **Open my dashboard** → **Activity** tab → select `my-bot`.
+
+## Verify
+
+1. Dashboard → **Activity** → agent appears in the header selector (~30s poll)
+2. **Settings** → connection test (uses a separate test agent name)
+3. Run `await db.why(event_id)` in the SDK to confirm causal links
+
+See [wiki/Troubleshooting](../../wiki/Troubleshooting.md) if events do not appear.

--- a/docs/integrate/any-agent.md
+++ b/docs/integrate/any-agent.md
@@ -1,0 +1,119 @@
+# Integrate ZizkaDB with any AI agent
+
+Framework-agnostic guide. Works with Python, TypeScript, Node, Go, or any HTTP client.
+
+## Mental model
+
+```
+Your agent (LLM, tools, workflow)
+        ↓  log each meaningful step
+ZizkaDB SDK or POST /v1/events
+        ↓
+Postgres (source of truth) + Qdrant (semantic search)
+        ↓
+Dashboard: Activity · Behavior · Reports · Suggestions
+```
+
+ZizkaDB is **not** your LLM or orchestrator. It is the **operational record** of what the agent did and why.
+
+---
+
+## What to log
+
+Log **decisions and actions**, not every token.
+
+| Event type (string) | When | Example `data` |
+|---------------------|------|----------------|
+| `user_message` | User input received | `{"text": "..."}` |
+| `assistant_response` | Model reply | `{"text": "..."}` |
+| `tool_call` | Before/after tool execution | `{"tool": "search", "args": {...}}` |
+| `tool_result` | Tool output | `{"result": {...}}` |
+| `error` | Failure you want to debug later | `{"message": "...", "code": "..."}` |
+| `decision` | Routing / policy choice | `{"route": "billing", "reason": "..."}` |
+
+Use consistent `event` type strings within your agent so baselines and reports stay meaningful.
+
+---
+
+## Required fields
+
+Every write includes:
+
+| Field | Purpose |
+|-------|---------|
+| `agent` | Stable agent id — **must match** dashboard agent name (or use tenant-wide key) |
+| `event` | Type string (see above) |
+| `data` | JSON payload (your schema) |
+
+Strongly recommended:
+
+| Field | Purpose |
+|-------|---------|
+| `parent_id` | UUID of the causing event → powers `why()` |
+| `session_id` | Groups one conversation/run → sessions, baselines, reports |
+
+---
+
+## Causal lineage (`parent_id`)
+
+Link child → parent so `db.why(event_id)` walks backward:
+
+```python
+user = await db.log(agent="bot", event="user_message", data={"text": q}, session_id=sid)
+plan = await db.log(agent="bot", event="decision", data={"action": "search"}, parent_id=user.event_id, session_id=sid)
+tool = await db.log(agent="bot", event="tool_call", data={"tool": "search"}, parent_id=plan.event_id, session_id=sid)
+await db.why(tool.event_id)  # tool → plan → user
+```
+
+---
+
+## Authentication
+
+| Environment | Auth |
+|-------------|------|
+| Local dev (`localhost:8000`) | Dev key auto-injected: `zizkadb_dev_local` |
+| Self-host production | API key from dashboard Settings |
+| Managed cloud | `zizkadb_live_...` from dashboard |
+
+Set `ZIZKADB_HOST` when not using cloud default. Set `ZIZKADB_API_KEY` for non-localhost.
+
+**403 agent mismatch:** per-agent keys only work for that agent name. Multi-user SaaS apps often need a **tenant-wide key** (Settings) and per-user agent ids like `conv-{userId}`.
+
+---
+
+## REST (any language)
+
+```bash
+curl -s -H "Authorization: Bearer $ZIZKADB_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"agent":"my-bot","event":"started","data":{"ok":true},"session_id":"run-1"}' \
+  https://db.zizka.ai/v1/events
+```
+
+See [wiki/REST-API.md](../../wiki/REST-API.md) and Swagger.
+
+---
+
+## Errors and retries
+
+- Log **`error`** events with `parent_id` pointing at the step that failed.
+- Retries: either new events with a new `session_id` or same session with `parent_id` linking to the failed attempt — pick one convention per agent and stay consistent.
+- SDK raises `AuthError`, `AgentScopeError`, `NotFoundError` — see [wiki/Troubleshooting](../../wiki/Troubleshooting.md).
+
+---
+
+## Production checklist
+
+- [ ] Same `agent` string in code and dashboard
+- [ ] `session_id` on every event in a conversation
+- [ ] `parent_id` on tool calls and responses
+- [ ] `ENV=production` + no dev keys on public deployments
+- [ ] Embeddings configured if you need search / `context_for()` (Settings → Embeddings)
+
+---
+
+## Next steps
+
+- [frameworks.md](frameworks.md) — LangChain, CrewAI, LangGraph, etc.
+- [CONNECT.md](../../CONNECT.md) — full SDK examples
+- [examples/](../../examples/) — runnable agents

--- a/docs/integrate/frameworks.md
+++ b/docs/integrate/frameworks.md
@@ -1,0 +1,42 @@
+# Framework integration status
+
+Only list **SUPPORTED** when an adapter or official example exists in this repository.
+
+| Framework | Status | How to integrate |
+|-----------|--------|------------------|
+| **Python (custom)** | Supported | `zizkadb-sdk` — [any-agent.md](any-agent.md) |
+| **TypeScript / Node** | Supported | `zizkadb-sdk` (npm) — [CONNECT.md](../../CONNECT.md#typescript-sdk) |
+| **REST / any HTTP client** | Supported | `POST /v1/events` — [wiki/REST-API](../../wiki/REST-API.md) |
+| **LangChain (Python)** | Supported | `zizkadb-langchain` — `ZizkaDBCallbackHandler` · [examples/langchain-agent](../../examples/langchain-agent/) |
+| **CrewAI (Python)** | Supported | `zizkadb-crewai` — `ZizkaDBCrewLogger` · [examples/crewai-agent](../../examples/crewai-agent/) |
+| **MCP (Cursor, Claude Desktop)** | Supported | `uvx zizkadb-mcp` · [mcp/README.md](../../mcp/README.md) |
+| **OpenAI / Anthropic SDKs** | Example pattern | Manual `log()` around API calls · [examples/openai-agent](../../examples/openai-agent/) |
+| **LangGraph** | Generic only | No official adapter — call `db.log()` inside graph nodes · [any-agent.md](any-agent.md) |
+| **LlamaIndex** | Generic only | Log at retrieval/tool boundaries via SDK or REST |
+| **AutoGen** | Generic only | Log agent messages and tool calls via SDK or REST |
+| **OpenAI Agents SDK** | Generic only | Wrap tool/run lifecycle with `log()` + `parent_id` |
+
+## LangGraph (generic pattern)
+
+There is no `zizkadb-langgraph` package. In each node:
+
+```python
+from zizkadb import ZizkaDB
+
+async with ZizkaDB(api_key="...") as db:
+    state_event = await db.log(
+        agent="my-graph",
+        event="graph_node",
+        data={"node": "research", "input": state},
+        session_id=thread_id,
+        parent_id=last_event_id,  # from prior node if tracked
+    )
+    # ... run node logic ...
+    await db.log(agent="my-graph", event="graph_node_done", data={"output": out}, parent_id=state_event.event_id, session_id=thread_id)
+```
+
+Track `last_event_id` in graph state if you need full chains across nodes.
+
+## Adding official support
+
+Open an issue or PR under `integrations/` — see [CONTRIBUTING.md](../../CONTRIBUTING.md).

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -36,7 +36,7 @@ Templates: `basic`, `openai`, `langchain`, `crewai`, `mcp-cursor`.
 ```python
 from zizkadb import ZizkaDB
 
-# Key from Dashboard → Agents → create "my-bot" → copy key
+# Key from Dashboard → Settings → API keys → create "my-bot" → copy key
 db = ZizkaDB("zizkadb_live_xxxx")
 
 async with db:

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -48,7 +48,7 @@ bash scripts/setup-local.sh
 1. **Taste lineage** — `bash scripts/quickstart.sh` or `zizkadb demo`
 2. **Connect your code** — [CONNECT.md](../CONNECT.md) or `zizkadb init my-agent --template basic`
 3. **Go deeper** — [examples/](../examples/), [integrations/](../integrations/)
-4. **Production** — [[Self-Hosting]], [[Production Deployment]]
+4. **Production** — [[Self-Hosting]], [[Production-Deployment]]
 
 ---
 
@@ -72,10 +72,11 @@ Go to [db.zizka.ai/signup](https://db.zizka.ai/signup) → enter email → verif
 
 ### 2. Create an agent + API key
 
-1. Open [Dashboard → Agents](https://db.zizka.ai/dashboard)
-2. Enter an agent id (e.g. `support-bot`)
-3. Click **Create**
-4. **Copy the full API key** — shown once only (`zizkadb_live_...`)
+1. Open [Dashboard → Fleet](https://db.zizka.ai/dashboard/fleet) (managed cloud)
+2. Click **Create agent**, enter an id (e.g. `support-bot`)
+3. **Copy the full API key** — shown once only (`zizkadb_live_...`)
+
+Alternative: **Settings → Tenant-wide API key** if your app uses dynamic agent names per session (see [[Multi-Agent Apps]]).
 
 ### 3. Configure your environment
 
@@ -108,7 +109,7 @@ asyncio.run(main())
 
 ### 5. Verify in dashboard
 
-Open your agent on the dashboard → **Events** tab.
+Dashboard → **Activity** — select `support-bot` to see events.
 
 ---
 

--- a/wiki/Production-Deployment.md
+++ b/wiki/Production-Deployment.md
@@ -1,0 +1,107 @@
+# Production deployment (self-hosted)
+
+This page covers **running your own ZizkaDB instance in production** (VPS, private cloud, on-prem). For managed hosting, use [db.zizka.ai](https://db.zizka.ai/signup) — same SDK, no Docker ops.
+
+For local dev, see [[Getting Started]] and [[Self-Hosting]].
+
+---
+
+## Before you go live
+
+Run the config validator after editing `infra/.env`:
+
+```bash
+bash scripts/validate-selfhost-config.sh --production
+```
+
+Minimum checklist:
+
+| Setting | Why |
+|---------|-----|
+| `ENV=production` | Disables dev API keys (`zizkadb_dev_local`) |
+| Unset or empty `DEV_API_KEY` | No bypass auth in production |
+| `NEXT_PUBLIC_DEV_MODE=false` | Dashboard requires OTP login (build arg + env) |
+| `JWT_SECRET` | Generate with `openssl rand -hex 32` — not the default |
+| `DEPLOYMENT_MODE=self_hosted` | Resolves self-host plan entitlements (1 API key cap when enforced) |
+| `EMAIL_*` SMTP vars | OTP login for team members |
+| TLS in front of API + dashboard | nginx or your load balancer |
+
+See [[Self-Hosting]] for the full Docker Compose flow and `bash infra/deploy-selfhost.sh`.
+
+---
+
+## Deploy / upgrade
+
+On the server (from a git clone):
+
+```bash
+git pull origin main
+bash infra/backup-postgres.sh    # always before upgrade
+docker compose -f infra/docker-compose.yml up -d --build
+bash scripts/smoke-test.sh
+```
+
+**Never** run `docker compose down -v` on a server with real data — it wipes Postgres volumes.
+
+---
+
+## Backups
+
+```bash
+bash infra/backup-postgres.sh   # → infra/backups/zizkadb_<timestamp>.sql.gz
+bash infra/backup-qdrant.sh     # vector index snapshot
+```
+
+Retention defaults to 14 days (`BACKUP_KEEP_DAYS`). Schedule both via cron before deploys.
+
+### Restore Postgres (disaster recovery)
+
+1. Stop the API (avoid writes during restore):
+
+   ```bash
+   docker compose -f infra/docker-compose.yml stop api dashboard
+   ```
+
+2. Restore from the latest `.sql.gz`:
+
+   ```bash
+   gunzip -c infra/backups/zizkadb_YYYYMMDDTHHMMSSZ.sql.gz | \
+     docker compose -f infra/docker-compose.yml exec -T postgres \
+     psql -U zizkadb -d zizkadb
+   ```
+
+   For a **full replace**, drop and recreate the database first (destructive — only on empty/failed installs).
+
+3. Restart the stack:
+
+   ```bash
+   docker compose -f infra/docker-compose.yml up -d
+   bash scripts/smoke-test.sh
+   ```
+
+4. Re-index Qdrant if needed — events remain in Postgres `events.embedding`; Qdrant can be rebuilt from Postgres in a future maintenance script. After restore, verify search and `why()` against Postgres-backed routes first.
+
+---
+
+## Health checks
+
+| Endpoint | Expected |
+|----------|----------|
+| `GET /health` | `{"status":"ok",...}` |
+| `GET /health/deep` | Postgres, Redis, Qdrant status |
+
+Use these for load balancer probes and post-deploy smoke tests.
+
+---
+
+## Managed cloud (db.zizka.ai)
+
+The public managed service runs the same open-source runtime from this repository. Operator runbooks (EC2, nginx, PM2 dashboard) are maintained separately — OSS users only need the self-host steps above.
+
+---
+
+## Related
+
+- [[Self-Hosting]] — first install, embeddings, suggestions API key
+- [[Troubleshooting]] — auth, empty dashboard, search
+- [SECURITY.md](https://github.com/Zizka-ai/ZizkaDB/blob/main/SECURITY.md) — vulnerability reporting

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -16,7 +16,12 @@
 
 ### Operations
 - [Self-Hosting](Self-Hosting)
+- [Production deployment](Production-Deployment)
 - [Architecture](Architecture)
+
+### Docs (repo)
+- [Documentation index](https://github.com/Zizka-ai/ZizkaDB/tree/main/docs)
+- [Integration guides](https://github.com/Zizka-ai/ZizkaDB/tree/main/docs/integrate)
 
 ### External
 - [Managed cloud](https://db.zizka.ai)

--- a/worked/01-support-order-delay/demo.py
+++ b/worked/01-support-order-delay/demo.py
@@ -40,7 +40,7 @@ async def main() -> None:
     print("  tool_call (lookup_order, ORD-8842)")
     print("    └── llm_response")
     print("          └── user_message")
-    print("\nDashboard: http://localhost:3001/login → Agents → support-bot")
+    print("\nDashboard: http://localhost:3001/login → Activity → support-bot")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Add missing **Production-Deployment** wiki page and **docs/** hub with framework-agnostic integration guides
- Fix plan terminology across README, KB, and hosted docs (**active API keys** vs "projects"; event caps marked as targets)
- Align dashboard navigation copy (**Activity** / **Settings** instead of removed **Agents** page)
- Add **AGENTS.md**, **CHANGELOG.md**, and PR template for contributor DX

## Commits (9)

1. `docs(wiki): add Production-Deployment page`
2. `docs: add documentation hub and integration guides`
3. `docs: add AGENTS.md and CHANGELOG`
4. `chore(github): add pull request template`
5. `docs(readme): fix plan terminology and doc links`
6. `docs(connect): fix dashboard verify steps`
7. `docs: clarify integration scope and PyPI status`
8. `docs(dashboard): align plan copy with API key entitlements`
9. `docs(wiki): update navigation and Activity tab references`

## Test plan

- [x] Docs-only change — no runtime code paths modified (except hosted docs copy in `sections.tsx`)
- [ ] `cd dashboard && npm run lint && npm run build` (optional — copy-only TSX edit)
- [ ] Manual: verify README links resolve (`docs/README.md`, `wiki/Production-Deployment.md`)


Made with [Cursor](https://cursor.com)