### PR TITLE
Release SDK 0.2.6: usage-based telemetry

### DIFF
--- a/dashboard/app/trust/page.tsx
+++ b/dashboard/app/trust/page.tsx
@@ -534,8 +534,8 @@ docker compose -f infra/docker-compose.yml up -d`}</Code>
                 and vectors.
               </li>
               <li>
-                <strong>Telemetry:</strong> one anonymous SDK/MCP startup ping —
-                opt out with{" "}
+                <strong>Telemetry:</strong> one anonymous SDK/MCP ping per process
+                after first use (log or tool call) — opt out with{" "}
                 <code style={codeInline}>ZIZKADB_TELEMETRY=false</code>.
               </li>
             </ul>
@@ -659,8 +659,8 @@ chain = await db.why(tool.event_id)`}</Code>
               for config.
             </p>
             <p style={p}>
-              Telemetry: one anonymous SDK startup ping (name, version, OS,
-              cloud vs self-host). Opt out:{" "}
+              Telemetry: one anonymous SDK ping per process after first log (name,
+              version, OS, cloud vs self-host). Opt out:{" "}
               <code style={codeInline}>ZIZKADB_TELEMETRY=false</code>.
             </p>
           </Section>

--- a/docs/DEVELOPER_TECHNICAL_BRIEF.md
+++ b/docs/DEVELOPER_TECHNICAL_BRIEF.md
@@ -268,7 +268,7 @@ Stack: postgres (pgvector), qdrant, redis, api. Dashboard optional (`npm run dev
 
 **Embeddings:** Without `OPENAI_API_KEY`, **logging still works**; semantic search and context injection that rely on embeddings will not.
 
-**Telemetry:** SDK/MCP send **one anonymous ping** on startup (SDK name, version, OS, cloud vs self-host). No event payloads, no API keys. Opt out: `ZIZKADB_TELEMETRY=false`.
+**Telemetry:** SDK/MCP send **one anonymous ping per process** after the first successful log or MCP tool use (SDK name, version, OS, cloud vs self-host). No event payloads, no API keys. Opt out: `ZIZKADB_TELEMETRY=false`.
 
 ---
 

--- a/integrations/crewai/pyproject.toml
+++ b/integrations/crewai/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zizkadb-crewai"
-version = "0.1.0"
+version = "0.1.1"
 description = "CrewAI logging helpers for ZizkaDB causal agent memory"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"
 dependencies = [
-    "zizkadb-sdk>=0.2.5",
+    "zizkadb-sdk>=0.2.6",
 ]
 
 [project.urls]

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zizkadb-langchain"
-version = "0.1.0"
+version = "0.1.1"
 description = "LangChain callbacks for ZizkaDB causal agent logging"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"
 dependencies = [
-    "zizkadb-sdk>=0.2.5",
+    "zizkadb-sdk>=0.2.6",
     "langchain-core>=0.3.0",
 ]
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -71,7 +71,7 @@ On localhost, the dev key (`zizkadb_dev_local`) is auto-injected — no API key 
 | `ZIZKADB_API_KEY` | — | **Required on cloud.** Your key from db.zizka.ai Settings |
 | `AGENTDB_API_KEY` | — | Legacy alias for `ZIZKADB_API_KEY` |
 | `AGENTDB_HOST` | — | Legacy alias for `ZIZKADB_HOST` |
-| `ZIZKADB_TELEMETRY` | on | Set `false` to opt out |
+| `ZIZKADB_TELEMETRY` | on | Set `false` to opt out (ping after first successful tool call) |
 
 If `ZIZKADB_API_KEY` is missing on cloud, MCP tools return a clear error instead of silently failing.
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zizkadb-mcp"
-version = "0.1.4"
+version = "0.1.5"
 description = "MCP server for ZizkaDB — give any AI agent persistent memory and observability"
 readme = "README.md"
 license = "MIT"

--- a/mcp/zizkadb_mcp/server.py
+++ b/mcp/zizkadb_mcp/server.py
@@ -36,7 +36,7 @@ try:
 
     __version__ = _pkg_version("zizkadb-mcp")
 except Exception:
-    __version__ = "0.1.4"
+    __version__ = "0.1.5"
 
 DEFAULT_DEV_API_KEY = "zizkadb_dev_local"
 _HOST = (
@@ -57,6 +57,21 @@ if not _KEY and _HOST and _is_local_host(_HOST):
 
 # ── Anonymous telemetry (opt-out: ZIZKADB_TELEMETRY=false) ────────────────────
 
+_telemetry_sent = False
+
+
+def _machine_stable_uuid() -> str:
+    for path in (Path("/etc/machine-id"), Path("/var/lib/dbus/machine-id")):
+        try:
+            raw = path.read_text().strip()
+            if raw:
+                return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"zizkadb:{raw}"))
+        except OSError:
+            continue
+    seed = f"{platform.node()}:{platform.system()}:{platform.machine()}"
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"zizkadb:{seed}"))
+
+
 def _get_install_id() -> str:
     try:
         path = Path.home() / ".zizkadb" / "install_id"
@@ -69,35 +84,40 @@ def _get_install_id() -> str:
         path.write_text(iid)
         return iid
     except Exception:
-        return str(uuid.uuid4())
+        return _machine_stable_uuid()
 
 
-def _telemetry_ping() -> None:
+def _telemetry_ping_on_use() -> None:
+    global _telemetry_sent
+    if _telemetry_sent:
+        return
     if os.getenv("ZIZKADB_TELEMETRY", "").lower() in ("false", "0", "no", "off"):
         return
-    try:
-        import urllib.request, json
-        mode = "self-hosted" if os.getenv("ZIZKADB_HOST") else "cloud"
-        payload = json.dumps({
-            "install_id":  _get_install_id(),
-            "sdk":         "mcp",
-            "sdk_version": __version__,
-            "python":      f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-            "os":          platform.system(),
-            "mode":        mode,
-        }).encode()
-        req = urllib.request.Request(
-            "https://db.zizka.ai/v1/telemetry",
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        urllib.request.urlopen(req, timeout=3)
-    except Exception:
-        pass
+    _telemetry_sent = True
 
+    def _run() -> None:
+        try:
+            import urllib.request, json
+            mode = "self-hosted" if os.getenv("ZIZKADB_HOST") else "cloud"
+            payload = json.dumps({
+                "install_id":  _get_install_id(),
+                "sdk":         "mcp",
+                "sdk_version": __version__,
+                "python":      f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+                "os":          platform.system(),
+                "mode":        mode,
+            }).encode()
+            req = urllib.request.Request(
+                "https://db.zizka.ai/v1/telemetry",
+                data=payload,
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            urllib.request.urlopen(req, timeout=3)
+        except Exception:
+            pass
 
-threading.Thread(target=_telemetry_ping, daemon=True).start()
+    threading.Thread(target=_run, daemon=True).start()
 
 
 async def _api(method: str, path: str, body: dict | None = None) -> dict:
@@ -125,6 +145,7 @@ async def _api(method: str, path: str, body: dict | None = None) -> dict:
 
     if not r.is_success:
         return {"error": r.text, "status": r.status_code}
+    _telemetry_ping_on_use()
     return r.json()
 
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -69,7 +69,7 @@ If your app logs to **different agent ids** per user (e.g. `conv-alice`, `conv-b
 | `AGENTDB_API_KEY` | Legacy alias for `ZIZKADB_API_KEY` |
 | `ZIZKADB_AGENT` | Default agent name (used in templates/examples) |
 | `ZIZKADB_HOST` | Self-hosted API URL |
-| `ZIZKADB_TELEMETRY` | Set `false` to opt out |
+| `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping after first `log()`) |
 
 ## Self-host dashboard
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zizkadb-sdk"
-version = "0.2.5"
+version = "0.2.6"
 description = "ZizkaDB tells you when your agent stops behaving like itself. Causal lineage, time travel and behavioral baselines for any AI agent."
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/sdk/python/tests/test_telemetry.py
+++ b/sdk/python/tests/test_telemetry.py
@@ -1,0 +1,52 @@
+"""Telemetry ping behavior."""
+
+from __future__ import annotations
+
+import zizkadb.telemetry as telemetry
+
+
+def test_ping_on_use_skips_self_hosted(monkeypatch):
+    telemetry._sent = False
+    called: list[str] = []
+
+    monkeypatch.setattr(telemetry, "_send", lambda mode: called.append(mode))
+    monkeypatch.delenv("ZIZKADB_TELEMETRY", raising=False)
+
+    telemetry.ping_on_use(mode="self-hosted")
+    assert called == []
+
+
+def test_ping_on_use_cloud(monkeypatch):
+    telemetry._sent = False
+    called: list[str] = []
+
+    monkeypatch.setattr(telemetry, "_send", lambda mode: called.append(mode))
+    monkeypatch.delenv("ZIZKADB_TELEMETRY", raising=False)
+    monkeypatch.delenv("ZIZKADB_HOST", raising=False)
+
+    telemetry.ping_on_use(mode="cloud")
+    assert called == ["cloud"]
+
+
+def test_ping_respects_opt_out(monkeypatch):
+    telemetry._sent = False
+    called: list[str] = []
+
+    monkeypatch.setattr(telemetry, "_send", lambda mode: called.append(mode))
+    monkeypatch.setenv("ZIZKADB_TELEMETRY", "false")
+
+    telemetry.ping_on_use(mode="cloud")
+    assert called == []
+
+
+def test_ping_once_per_process(monkeypatch):
+    telemetry._sent = False
+    called: list[str] = []
+
+    monkeypatch.setattr(telemetry, "_send", lambda mode: called.append(mode))
+    monkeypatch.delenv("ZIZKADB_TELEMETRY", raising=False)
+    monkeypatch.delenv("ZIZKADB_HOST", raising=False)
+
+    telemetry.ping_on_use(mode="cloud")
+    telemetry.ping_on_use(mode="cloud")
+    assert called == ["cloud"]

--- a/sdk/python/zizkadb/__init__.py
+++ b/sdk/python/zizkadb/__init__.py
@@ -6,7 +6,7 @@ try:
 
     __version__ = _pkg_version("zizkadb-sdk")
 except Exception:
-    __version__ = "0.2.5"
+    __version__ = "0.2.6"
 
 __all__ = [
     "ZizkaDB",

--- a/sdk/python/zizkadb/client.py
+++ b/sdk/python/zizkadb/client.py
@@ -31,7 +31,7 @@ from typing import Any
 
 from .models import Event, LogResult, CausalChain, AgentState, AgentInfo
 from .exceptions import ZizkaDBError, AuthError, NotFoundError, RateLimitError, AgentScopeError
-from .telemetry import ping as _telemetry_ping
+from .telemetry import ping_on_use as _telemetry_ping
 
 CLOUD_HOST = "https://db.zizka.ai"
 DEFAULT_DEV_API_KEY = "zizkadb_dev_local"
@@ -92,8 +92,7 @@ class ZizkaDB:
         self._base_url = host.rstrip("/") if host else CLOUD_HOST
         self._timeout = timeout
         self._client: httpx.AsyncClient | None = None
-
-        _telemetry_ping(mode="self-hosted" if host else "cloud")
+        self._telemetry_mode = "self-hosted" if host else "cloud"
 
     # ─────────────────────────────────────────
     # CONTEXT MANAGER
@@ -149,6 +148,7 @@ class ZizkaDB:
                 "metadata": metadata,
             },
         )
+        _telemetry_ping(mode=self._telemetry_mode)
         return LogResult.from_dict(response)
 
     # ─────────────────────────────────────────

--- a/sdk/python/zizkadb/install_id.py
+++ b/sdk/python/zizkadb/install_id.py
@@ -1,0 +1,37 @@
+"""Stable anonymous install_id — one UUID per machine when possible."""
+
+from __future__ import annotations
+
+import platform
+import uuid
+from pathlib import Path
+
+_INSTALL_DIR = Path.home() / ".zizkadb"
+_INSTALL_ID_PATH = _INSTALL_DIR / "install_id"
+
+
+def _machine_stable_uuid() -> str:
+    """Deterministic id when ~/.zizkadb is not writable (CI/Docker)."""
+    for path in (Path("/etc/machine-id"), Path("/var/lib/dbus/machine-id")):
+        try:
+            raw = path.read_text().strip()
+            if raw:
+                return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"zizkadb:{raw}"))
+        except OSError:
+            continue
+    seed = f"{platform.node()}:{platform.system()}:{platform.machine()}"
+    return str(uuid.uuid5(uuid.NAMESPACE_DNS, f"zizkadb:{seed}"))
+
+
+def get_or_create_install_id() -> str:
+    try:
+        _INSTALL_DIR.mkdir(parents=True, exist_ok=True)
+        if _INSTALL_ID_PATH.exists():
+            iid = _INSTALL_ID_PATH.read_text().strip()
+            if iid:
+                return iid
+        iid = str(uuid.uuid4())
+        _INSTALL_ID_PATH.write_text(iid)
+        return iid
+    except OSError:
+        return _machine_stable_uuid()

--- a/sdk/python/zizkadb/telemetry.py
+++ b/sdk/python/zizkadb/telemetry.py
@@ -1,76 +1,33 @@
 """
 Anonymous usage telemetry for the ZizkaDB Python SDK.
 
-What is sent (once per install, fire-and-forget):
-  install_id  — random UUID stored in ~/.zizkadb/install_id (never changes)
-  sdk_version — e.g. "0.1.0"
-  python      — e.g. "3.12.3"
-  os          — e.g. "Linux", "Darwin", "Windows"
-  mode        — "cloud" or "self-hosted"
+One ping per process after the first successful log() — usage, not import.
+install_id is stable per machine (~/.zizkadb/install_id).
 
 What is NOT sent: API keys, agent names, event data, IP address, hostname.
 
-Opt out at any time:
-  export ZIZKADB_TELEMETRY=false   # shell
-  ZIZKADB_TELEMETRY=false          # .env
+Opt out: export ZIZKADB_TELEMETRY=false
 """
 
 from __future__ import annotations
 
+import json
 import os
-import sys
 import platform
+import sys
 import threading
-import uuid
-from pathlib import Path
+import urllib.request
+
+from .install_id import get_or_create_install_id
 
 _TELEMETRY_URL = "https://db.zizka.ai/v1/telemetry"
-_INSTALL_ID_PATH = Path.home() / ".zizkadb" / "install_id"
-_sent = False  # only fire once per process
-
-
-def _get_or_create_install_id() -> str:
-    try:
-        _INSTALL_ID_PATH.parent.mkdir(parents=True, exist_ok=True)
-        if _INSTALL_ID_PATH.exists():
-            iid = _INSTALL_ID_PATH.read_text().strip()
-            if iid:
-                return iid
-        iid = str(uuid.uuid4())
-        _INSTALL_ID_PATH.write_text(iid)
-        return iid
-    except Exception:
-        return str(uuid.uuid4())  # ephemeral fallback
-
-
-def _send(mode: str) -> None:
-    try:
-        import urllib.request
-        import json
-
-        payload = json.dumps({
-            "install_id":   _get_or_create_install_id(),
-            "sdk":          "python",
-            "sdk_version":  _sdk_version(),
-            "python":       f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
-            "os":           platform.system(),
-            "mode":         mode,
-        }).encode()
-
-        req = urllib.request.Request(
-            _TELEMETRY_URL,
-            data=payload,
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        urllib.request.urlopen(req, timeout=1)
-    except Exception:
-        pass  # never surface telemetry errors
+_sent = False  # once per process
 
 
 def _sdk_version() -> str:
     try:
         from zizkadb import __version__
+
         return __version__
     except Exception:
         return "unknown"
@@ -83,17 +40,47 @@ def _is_local_self_host() -> bool:
     return host.startswith("http://0.0.0.0")
 
 
-def ping(mode: str = "cloud") -> None:
-    """Fire a single anonymous telemetry ping in a background thread."""
-    global _sent
+def _send(mode: str) -> None:
+    payload = json.dumps(
+        {
+            "install_id": get_or_create_install_id(),
+            "sdk": "python",
+            "sdk_version": _sdk_version(),
+            "python": f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}",
+            "os": platform.system(),
+            "mode": mode,
+        }
+    ).encode()
 
+    req = urllib.request.Request(
+        _TELEMETRY_URL,
+        data=payload,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    urllib.request.urlopen(req, timeout=2)
+
+
+def ping_on_use(mode: str = "cloud") -> None:
+    """Fire-and-forget: one ping per process after first successful log()."""
+    global _sent
     if _sent:
         return
     if os.getenv("ZIZKADB_TELEMETRY", "").lower() in ("false", "0", "no", "off"):
         return
     if mode == "self-hosted" or _is_local_self_host():
         return
-
     _sent = True
-    t = threading.Thread(target=_send, args=(mode,), daemon=True)
-    t.start()
+
+    def _run() -> None:
+        try:
+            _send(mode)
+        except Exception:
+            pass
+
+    threading.Thread(target=_run, daemon=True).start()
+
+
+def ping(mode: str = "cloud") -> None:
+    """Back-compat alias for ping_on_use."""
+    ping_on_use(mode)


### PR DESCRIPTION
## Summary
- **zizkadb-sdk 0.2.6** — ping after first successful `log()` (not import); stable `install_id` via `~/.zizkadb` + machine-id fallback
- **zizkadb-mcp 0.1.5** — ping after first successful tool call (not server startup)
- **zizkadb-crewai / zizkadb-langchain 0.1.1** — pin `zizkadb-sdk>=0.2.6`
- Doc copy updates for telemetry timing (trust page, technical brief, READMEs)

## After merge — publish to PyPI
```bash
export TWINE_USERNAME=__token__
export TWINE_PASSWORD=pypi-...

bash scripts/publish-packages.sh      # SDK + MCP
bash scripts/publish-integrations.sh  # CrewAI + LangChain
```

## Test plan
- [ ] `pytest sdk/python/tests/test_telemetry.py` passes
- [ ] `pip install` new versions from PyPI after publish
- [ ] Two separate Python processes with same machine → same install_id, ping_count increments on server
