### PR TITLE
Release TypeScript SDK 0.2.6 on npm.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-### Added
-- Documentation hub: `docs/README.md`, `docs/integrate/`
-- `AGENTS.md` for AI coding tools
-- `wiki/Production-Deployment.md` (self-host production ops)
+## [0.2.6] — 2026-08-21
 
-### Fixed
-- README plan terminology (API keys vs "projects")
-- CONNECT.md dashboard verify steps (Activity tab)
+### TypeScript SDK (`zizkadb-sdk` 0.2.6, npm)
+
+- Telemetry pings after the first successful `log()` (usage, not constructor)
+- Stable anonymous `install_id` per machine (`~/.zizkadb` + machine-id fallback)
+- Self-hosted / local installs skip telemetry (matches Python SDK)
+
+See Python SDK **0.2.6**, MCP **0.1.5**, and integrations **0.1.1** on PyPI (released separately).
 
 ## [0.1.0] — 2026-08-21
 
@@ -29,5 +30,6 @@ Production-hardening sprint merged to `main` (via stacked PRs #125–#139), incl
 
 See [GitHub releases](https://github.com/Zizka-ai/ZizkaDB/releases) for tagged artifacts.
 
-[Unreleased]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.2.6...HEAD
+[0.2.6]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.1.0...v0.2.6
 [0.1.0]: https://github.com/Zizka-ai/ZizkaDB/releases

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,5 +1,7 @@
 # zizkadb-sdk
 
+**npm:** [zizkadb-sdk 0.2.6](https://www.npmjs.com/package/zizkadb-sdk)
+
 TypeScript SDK for [ZizkaDB](https://db.zizka.ai) — causal lineage, time travel, and semantic search for AI agents.
 
 ## Setup (managed cloud)
@@ -52,7 +54,7 @@ If your app logs to **different agent ids** per user (e.g. `conv-alice`, `conv-b
 | `ZIZKADB_API_KEY` | Your cloud API key (preferred) |
 | `AGENTDB_API_KEY` | Legacy alias for `ZIZKADB_API_KEY` |
 | `ZIZKADB_HOST` | Self-hosted API URL |
-| `ZIZKADB_TELEMETRY` | Set `false` to opt out |
+| `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping after first `log()`) |
 
 Core HTTP client only — LangChain and CrewAI adapters are Python packages (`zizkadb-langchain`, `zizkadb-crewai`).
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zizkadb-sdk",
-  "version": "0.2.4",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zizkadb-sdk",
-      "version": "0.2.4",
+      "version": "0.2.6",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zizkadb-sdk",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "ZizkaDB tells you when your agent stops behaving like itself. Causal lineage, time travel and behavioral baselines for any AI agent.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -40,7 +40,7 @@ export * from './types'
 
 const CLOUD_HOST = 'https://db.zizka.ai'
 const TELEMETRY_URL = 'https://db.zizka.ai/v1/telemetry'
-const SDK_VERSION = '0.2.5'
+const SDK_VERSION = '0.2.6'
 const DEFAULT_DEV_API_KEY = 'zizkadb_dev_local'
 
 function isLocalHost(host: string): boolean {
@@ -55,12 +55,22 @@ function apiKeyFromEnv(): string | undefined {
 
 let _telemetrySent = false
 
+function _isLocalSelfHost(): boolean {
+  const host = process.env.ZIZKADB_HOST ?? ''
+  return (
+    host.startsWith('http://localhost') ||
+    host.startsWith('http://127.0.0.1') ||
+    host.startsWith('http://0.0.0.0')
+  )
+}
+
 function _sendTelemetry(mode: 'cloud' | 'self-hosted'): void {
   if (_telemetrySent) return
   if (
     typeof process !== 'undefined' &&
     /^(false|0|no|off)$/i.test(process.env.ZIZKADB_TELEMETRY ?? '')
   ) return
+  if (mode === 'self-hosted' || _isLocalSelfHost()) return
 
   _telemetrySent = true
 
@@ -103,6 +113,32 @@ function _getInstallId(): string {
     writeFileSync(file, id)
     return id
   } catch {
+    return _stableMachineId()
+  }
+}
+
+function _stableMachineId(): string {
+  try {
+    const { readFileSync, existsSync } = require('fs') as typeof import('fs')
+    const { createHash } = require('crypto') as typeof import('crypto')
+    const { hostname, platform, arch } = require('os') as typeof import('os')
+    for (const p of ['/etc/machine-id', '/var/lib/dbus/machine-id']) {
+      if (existsSync(p)) {
+        const raw = readFileSync(p, 'utf8').trim()
+        if (raw) {
+          return createHash('sha256').update(`zizkadb:${raw}`).digest('hex').replace(
+            /^(.{8})(.{4})(.{4})(.{4})(.{12}).*$/,
+            '$1-$2-$3-$4-$5',
+          )
+        }
+      }
+    }
+    const seed = `${hostname()}:${platform()}:${arch()}`
+    return createHash('sha256').update(`zizkadb:${seed}`).digest('hex').replace(
+      /^(.{8})(.{4})(.{4})(.{4})(.{12}).*$/,
+      '$1-$2-$3-$4-$5',
+    )
+  } catch {
     return _uuid()
   }
 }
@@ -136,6 +172,7 @@ export class ZizkaDB {
   private readonly baseUrl: string
   private readonly headers: Record<string, string>
   private readonly timeout: number
+  private readonly telemetryMode: 'cloud' | 'self-hosted'
 
   constructor(config: ZizkaDBConfig) {
     if (!config.apiKey && !config.host) {
@@ -171,7 +208,7 @@ export class ZizkaDB {
       ...(apiKey ? { Authorization: `Bearer ${apiKey}` } : {}),
     }
 
-    _sendTelemetry(config.host ? 'self-hosted' : 'cloud')
+    this.telemetryMode = config.host ? 'self-hosted' : 'cloud'
   }
 
   // ─────────────────────────────────────────
@@ -192,6 +229,7 @@ export class ZizkaDB {
       sequence_no: number
       checksum: string
     }
+    _sendTelemetry(this.telemetryMode)
     return {
       eventId: res.event_id,
       timestamp: new Date(res.timestamp),

--- a/sdk/typescript/tests/client.test.mjs
+++ b/sdk/typescript/tests/client.test.mjs
@@ -12,7 +12,7 @@ import { afterAll, expect, it } from 'vitest'
 // Save the original fetch so we can restore it after all tests finish.
 const _originalFetch = globalThis.fetch
 
-// Disable telemetry before loading the SDK so the constructor doesn't fire it.
+// Disable telemetry before loading the SDK.
 process.env.ZIZKADB_TELEMETRY = 'false'
 
 import { AgentScopeError, AuthError, ZizkaDB, ZizkaDBError } from '../src/index.ts'

--- a/wiki/TypeScript-SDK.md
+++ b/wiki/TypeScript-SDK.md
@@ -1,6 +1,6 @@
 # TypeScript SDK
 
-**Package:** `zizkadb-sdk` on npm
+**Package:** `zizkadb-sdk` on npm (**0.2.6**)
 
 ```bash
 npm install zizkadb-sdk


### PR DESCRIPTION
Ping after first log(), stable install_id, skip telemetry on self-hosted. Matches Python SDK 0.2.6 telemetry semantics.

## Summary

<!-- What changed and why (1–3 bullets). -->

## Test plan

- [ ] `ruff check core/ sdk/python/ mcp/ integrations/` (if Python touched)
- [ ] `pytest core/tests/ -m "not integration"` (if core touched)
- [ ] `cd dashboard && npm run lint && npm test && npm run build` (if dashboard touched)
- [ ] Manual: <!-- steps or "docs only" -->

## Areas touched

- [ ] API / schema
- [ ] SDK (Python / TypeScript)
- [ ] Dashboard
- [ ] MCP / integrations
- [ ] Docs only
- [ ] Infra / CI

## Breaking changes

<!-- None, or describe migration. -->

Fixes #<!-- issue number if applicable -->
