### PR TITLE
Docs: npm zizkadb-sdk 0.2.6

### DIFF
--- a/CONNECT.md
+++ b/CONNECT.md
@@ -1,6 +1,6 @@
 # Connect your agent (self-host / OSS)
 
-**Current PyPI releases:** `zizkadb-sdk` **0.2.6** · `zizkadb-mcp` **0.1.5** · `zizkadb-langchain` **0.1.1** · `zizkadb-crewai` **0.1.1**
+**Current releases:** PyPI/npm `zizkadb-sdk` **0.2.6** · `zizkadb-mcp` **0.1.5** · `zizkadb-langchain` **0.1.1** · `zizkadb-crewai` **0.1.1**
 
 ## Start the stack (pick one)
 
@@ -65,7 +65,7 @@ export ZIZKADB_AGENT=my-bot
 ## TypeScript SDK
 
 ```bash
-npm install zizkadb-sdk
+npm install zizkadb-sdk@0.2.6
 ```
 
 ```typescript

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Core unit tests plus the SDK and MCP package tests do not require a running Zizk
 
 ## Integrations
 
-**Current PyPI releases:** `zizkadb-sdk` **0.2.6** · `zizkadb-mcp` **0.1.5** · `zizkadb-langchain` **0.1.1** · `zizkadb-crewai` **0.1.1** · npm `zizkadb-sdk` **0.2.5**
+**Current releases:** PyPI `zizkadb-sdk` **0.2.6** · npm `zizkadb-sdk` **0.2.6** · `zizkadb-mcp` **0.1.5** · `zizkadb-langchain` **0.1.1** · `zizkadb-crewai` **0.1.1**
 
 | Python | TypeScript | LangChain | CrewAI | MCP (Cursor) | REST |
 | :---: | :---: | :---: | :---: | :---: | :---: |

--- a/docs/integrate/frameworks.md
+++ b/docs/integrate/frameworks.md
@@ -5,7 +5,7 @@ Only list **SUPPORTED** when an adapter or official example exists in this repos
 | Framework | Status | Package (version) |
 |-----------|--------|-------------------|
 | **Python (custom)** | Supported | `zizkadb-sdk` **0.2.6** — [any-agent.md](any-agent.md) |
-| **TypeScript / Node** | Supported | `zizkadb-sdk` **0.2.5** (npm) — [CONNECT.md](../../CONNECT.md#typescript-sdk) |
+| **TypeScript / Node** | Supported | `zizkadb-sdk` **0.2.6** (npm) — [CONNECT.md](../../CONNECT.md#typescript-sdk) |
 | **REST / any HTTP client** | Supported | `POST /v1/events` — [wiki/REST-API](../../wiki/REST-API.md) |
 | **LangChain (Python)** | Supported | `zizkadb-langchain` **0.1.1** — [examples/langchain-agent](../../examples/langchain-agent/) |
 | **CrewAI (Python)** | Supported | `zizkadb-crewai` **0.1.1** — [examples/crewai-agent](../../examples/crewai-agent/) |

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -5,6 +5,7 @@ Official adapters for agent frameworks. Each package is optional — core SDK is
 | Package | PyPI version | Install | Use case |
 |---------|--------------|---------|----------|
 | `zizkadb-sdk` | **0.2.6** | `pip install zizkadb-sdk` | Core Python client |
+| `zizkadb-sdk` (npm) | **0.2.6** | `npm install zizkadb-sdk` | TypeScript / Node client |
 | [langchain](langchain/) | **0.1.1** | `pip install zizkadb-langchain` | `ZizkaDBCallbackHandler` on LangChain runnables |
 | [crewai](crewai/) | **0.1.1** | `pip install zizkadb-crewai` | `ZizkaDBCrewLogger` for crew kickoff / output |
 | [mcp](../mcp/) | **0.1.5** | `uvx zizkadb-mcp` | Cursor, Claude Desktop, Windsurf tools |

--- a/llms.txt
+++ b/llms.txt
@@ -9,7 +9,7 @@ ZizkaDB is open-source (AGPL-3.0, except MCP server which is MIT). It runs as a 
 - [Core API](core/) — FastAPI + asyncpg + PostgreSQL 16/pgvector + Qdrant + Redis. 14 routers at `/v1/`.
 - [Dashboard](dashboard/) — Next.js 14 App Router. Marketing + authenticated agent fleet view.
 - [Python SDK](sdk/python/) — `zizkadb-sdk` **0.2.6** on PyPI. Async client, `zizkadb init` CLI.
-- [TypeScript SDK](sdk/typescript/) — `zizkadb-sdk` **0.2.5** on npm. Sync constructor, camelCase fields.
+- [TypeScript SDK](sdk/typescript/) — `zizkadb-sdk` **0.2.6** on npm. Sync constructor, camelCase fields.
 - [Integrations](integrations/) — `zizkadb-langchain` **0.1.1**, `zizkadb-crewai` **0.1.1** on PyPI. `db.why()` causal debugging.
 - [MCP Server](mcp/) — `zizkadb-mcp` **0.1.5** on PyPI. MIT license. `uvx zizkadb-mcp`.
 - [Infra](infra/) — Docker Compose. Production: `docker-compose.yml`. Dev overlay: `docker-compose.dev.yml`.

--- a/sdk/typescript/CLAUDE.md
+++ b/sdk/typescript/CLAUDE.md
@@ -2,7 +2,7 @@
 
 See root [`CLAUDE.md`](../../CLAUDE.md) for full project context.
 
-Package: **`zizkadb-sdk`** on npm. Import: `import { ZizkaDB } from 'zizkadb-sdk'`.
+Package: **`zizkadb-sdk` 0.2.6** on npm. Import: `import { ZizkaDB } from 'zizkadb-sdk'`.
 
 ---
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -16,7 +16,7 @@ TypeScript SDK for [ZizkaDB](https://db.zizka.ai) — causal lineage, time trave
 ## Install
 
 ```bash
-npm install zizkadb-sdk
+npm install zizkadb-sdk@0.2.6
 ```
 
 ## Quickstart

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -11,7 +11,7 @@
 | PyPI MCP | [zizkadb-mcp](https://pypi.org/project/zizkadb-mcp/) **0.1.5** |
 | PyPI LangChain | [zizkadb-langchain](https://pypi.org/project/zizkadb-langchain/) **0.1.1** |
 | PyPI CrewAI | [zizkadb-crewai](https://pypi.org/project/zizkadb-crewai/) **0.1.1** |
-| npm SDK | [zizkadb-sdk](https://www.npmjs.com/package/zizkadb-sdk) **0.2.5** |
+| npm SDK | [zizkadb-sdk](https://www.npmjs.com/package/zizkadb-sdk) **0.2.6** |
 | Docs site | [db.zizka.ai/docs](https://db.zizka.ai/docs) |
 | Managed cloud (optional) | [db.zizka.ai/signup](https://db.zizka.ai/signup) |
 

--- a/wiki/TypeScript-SDK.md
+++ b/wiki/TypeScript-SDK.md
@@ -3,7 +3,7 @@
 **Package:** `zizkadb-sdk` on npm (**0.2.6**)
 
 ```bash
-npm install zizkadb-sdk
+npm install zizkadb-sdk@0.2.6
 ```
 
 ## Quickstart
@@ -30,7 +30,7 @@ chain.print()
 | `ZIZKADB_API_KEY` | Cloud API key |
 | `AGENTDB_API_KEY` | Legacy alias |
 | `ZIZKADB_HOST` | Self-hosted URL |
-| `ZIZKADB_TELEMETRY` | Set `false` to opt out |
+| `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping after first `log()`) |
 
 Core HTTP client only — LangChain and CrewAI adapters are Python packages (`zizkadb-langchain`, `zizkadb-crewai`).
 


### PR DESCRIPTION
## Summary
- Update GitHub docs to reflect npm **zizkadb-sdk 0.2.6** (README, CONNECT, wiki, frameworks, integrations index)

## Test plan
- [ ] Merge to main