### PR TITLE
Improve GitHub funnel: local-first README, START_HERE, and PyPI docs.

### DIFF
--- a/CONNECT.md
+++ b/CONNECT.md
@@ -2,6 +2,14 @@
 
 **Current releases:** PyPI/npm `zizkadb-sdk` **0.2.6** · `zizkadb-mcp` **0.1.5** · `zizkadb-langchain` **0.1.1** · `zizkadb-crewai` **0.1.1**
 
+**Fastest win:** run the stack + demo, then paste the Python snippet below.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
+# stack already up?
+pip install zizkadb-sdk && zizkadb demo
+```
+
 ## Start the stack (pick one)
 
 **No repo clone** (recommended for new users):

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@
 
 **Don't observe — audit your AI agent.**
 
-Operational database for AI agents — replay sessions, trace decisions, detect drift.
+Open-source **audit trail for AI agents** — causal lineage, session replay, and drift detection for **LangChain**, **CrewAI**, **Cursor**, and any agent stack. Trace **why** a decision happened instead of grepping scattered logs.
 
 **Free · self-host · no signup required**
 
+[![CI](https://github.com/Zizka-ai/ZizkaDB/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Zizka-ai/ZizkaDB/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/Zizka-ai/ZizkaDB?label=release&color=f97316)](https://github.com/Zizka-ai/ZizkaDB/releases)
 [![Python](https://img.shields.io/pypi/v/zizkadb-sdk?label=Python)](https://pypi.org/project/zizkadb-sdk/)
@@ -18,26 +19,73 @@ Operational database for AI agents — replay sessions, trace decisions, detect 
 
 </div>
 
-<p align="center">
-  <img src="docs/assets/why-demo.gif" alt="Terminal demo — trace why an agent called a tool with db.why()" width="100%"/>
-</p>
+- **Causal chains, not log dumps.** Link steps with `parent_id`, then walk backward with `why()` — root cause in one call, not manual correlation.
+- **Not a trace UI.** Built to **audit** production agents: replay sessions, compare baselines, prove what changed after a deploy.
+- **Local-first & free.** OSS stack on your machine — Docker quickstart, no signup, no API key on `localhost`.
 
 <p align="center">
-  <sub>Causal chain replay with <code>db.why()</code> — run <code>quickstart</code> below to reproduce this in your terminal</sub>
+  <img src="docs/assets/why-demo.gif" alt="ZizkaDB agent debugging demo — db.why() walks a causal chain from tool call to user message" width="100%"/>
 </p>
+
+## See it in action
+
+**Get started (2 minutes)** — requires [Docker](https://docs.docker.com/get-docker/):
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
+```
+
+Real output from `zizkadb demo` (support-bot order delay):
+
+```text
+$ zizkadb demo
+→ ZizkaDB @ http://localhost:8000
+
+Logged chain. Walking back with db.why():
+
+tool_call · lookup_order · ORD-8842
+  └── llm_response · gpt-4o
+        └── user_message · Why was my order delayed?
+
+✓ Done — open the dashboard to explore this agent:
+  http://localhost:3001/login → Open my dashboard →
+```
+
+**Works with:** Python · TypeScript · LangChain · CrewAI · Cursor / Claude MCP · REST · any HTTP client
+
+---
+
+## What you get
+
+| Capability | What you get |
+|---|---|
+| **Causal lineage** | `db.why(event_id)` walks from any step back to the user message |
+| **Session replay** | Full agent run in the dashboard — Activity, Behavior, Reports |
+| **Drift baselines** | `db.baseline(agent)` flags when answers change vs past sessions |
+| **Time travel** | `db.at(agent, timestamp)` — what the agent knew at decision time |
+| **Semantic search** | Plain-English search over agent history (`db.search()`) |
+| **Editor integration** | MCP tools in Cursor — audit from chat without rewriting your app |
+
+## Observe vs audit
+
+| | Typical observability / logs | ZizkaDB |
+|---|---|---|
+| **Question** | What lines mention `lookup_order`? | **Why** did the agent call `lookup_order`? |
+| **Structure** | Flat, unrelated events | Linked chain via `parent_id` |
+| **After a bad answer** | Grep and guess | Replay session + walk `why()` |
+| **After prompt deploy** | Hope someone notices | Baseline / drift alert |
+| **Proof for teams** | Screenshots of log noise | Shareable audit trail in dashboard |
+
+```mermaid
+flowchart BT
+  U[user_message] --> L[llm_response]
+  L --> T[tool_call]
+  T -.->|db.why| U
+```
 
 > **New here?** You do **not** need to understand this whole repo.  
-> Copy one command → see an audit trail in your terminal → open the dashboard.  
-> Managed cloud (Pro / Team) is optional — **[jump to OSS ↓](#open-source-self-host)**
-
-<table align="center">
-<tr>
-<td align="center"><strong>Replay</strong><br/>any session end-to-end</td>
-<td align="center"><strong>Lineage</strong><br/><code>db.why()</code> — decision trail</td>
-<td align="center"><strong>Drift</strong><br/>baseline when behavior shifts</td>
-<td align="center"><strong>Search</strong><br/>plain-English history</td>
-</tr>
-</table>
+> Copy the command above → see an audit trail in your terminal → open the dashboard.  
+> Managed cloud (Pro / Team) is optional — **[jump to OSS details ↓](#open-source-self-host)**
 
 <br/>
 
@@ -75,19 +123,20 @@ Operational database for AI agents — replay sessions, trace decisions, detect 
 | **③ Documentation** | [START_HERE.md](START_HERE.md) · [CONNECT.md](CONNECT.md) · [worked example](worked/01-support-order-delay/) · [Examples](examples/) · [Self-hosting](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) |
 | **④ Live dashboard** | **[localhost:3001/login](http://localhost:3001/login)** → **Open my dashboard** (no signup). Log from SDK → refresh → see sessions live. |
 
-**Quickstart** — requires [Docker](https://docs.docker.com/get-docker/) · ~2 min cached · ~5–10 min first image pull
+**Quickstart** — ~2 min cached · ~5–10 min first Docker image pull
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
-```
+Already ran the command above? Skip to **[Connect your agent](#connect-your-agent-3-lines)**.
 
-**You should see:**
+<details>
+<summary>Prerequisites</summary>
 
-```
-tool_call · lookup_order · ORD-8842
-  └── llm_response · gpt-4o
-        └── user_message · Why was my order delayed?
-```
+| Requirement | Minimum | Check |
+|---|---|---|
+| Docker | Desktop or Engine | `docker info` |
+| Python | 3.10+ (for demo CLI) | `python3 --version` |
+| Disk | ~2 GB for images | first pull only |
+
+</details>
 
 **Run the demo again anytime:**
 
@@ -95,6 +144,10 @@ tool_call · lookup_order · ORD-8842
 pip install zizkadb-sdk
 zizkadb demo
 ```
+
+**Story behind the demo:** [worked/01-support-order-delay](worked/01-support-order-delay/) — support-bot, order delay, full `parent_id` chain.
+
+<a id="connect-your-agent-3-lines"></a>
 
 **Connect your agent (3 lines):**
 
@@ -273,6 +326,49 @@ zizkadb init my-agent --template basic
 | `db.baseline()` | Detect behavioral drift |
 | `db.context_for()` | Inject relevant past events into prompts |
 | `db.forget()` | GDPR erasure by metadata filter |
+
+---
+
+## Worked examples
+
+| Scenario | Command / link | What you prove |
+|---|---|---|
+| Support-bot order delay | `zizkadb demo` | 3-step causal chain + dashboard session |
+| Step-by-step walkthrough | [worked/01-support-order-delay](worked/01-support-order-delay/) | Same story with source code |
+| LangChain agent | [examples/langchain-agent](examples/langchain-agent/) | Auto-log every chain step |
+| Cursor MCP | [examples/mcp-cursor](examples/mcp-cursor/) | Audit from the editor |
+
+---
+
+## FAQ
+
+<details>
+<summary><strong>Do I need to clone this repo?</strong></summary>
+
+No. `curl … quickstart-remote.sh | bash` downloads a few config files and pulls Docker images — no full clone required.
+
+</details>
+
+<details>
+<summary><strong>Do I need an API key for local dev?</strong></summary>
+
+No. The local stack uses a built-in dev key on `http://localhost:8000`. Open the dashboard at [localhost:3001/login](http://localhost:3001/login) with no signup.
+
+</details>
+
+<details>
+<summary><strong>How is this different from LangSmith / Langfuse?</strong></summary>
+
+Those tools **observe** traces and spans. ZizkaDB is built to **audit** agent behavior: causal `parent_id` chains, session replay, drift baselines, and time-travel state — optimized for *why did production behavior change?* See [wiki comparisons](https://github.com/Zizka-ai/ZizkaDB/wiki).
+
+</details>
+
+<details>
+<summary><strong><code>zizkadb demo</code> fails — connection refused?</strong></summary>
+
+Start the stack first: `curl -fsSL …/quickstart-remote.sh | bash` or `bash scripts/setup-local.sh`. Check API health: `curl http://localhost:8000/health`.
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Operational database for AI agents — replay sessions, trace decisions, detect drift.
 
-**Have an agent already? → [CONNECT.md](CONNECT.md) · [Integration guides](docs/integrate/)**
+**Free · self-host · no signup required**
 
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/github/v/release/Zizka-ai/ZizkaDB?label=release&color=f97316)](https://github.com/Zizka-ai/ZizkaDB/releases)
@@ -14,19 +14,32 @@ Operational database for AI agents — replay sessions, trace decisions, detect 
 [![npm](https://img.shields.io/npm/v/zizkadb-sdk?label=npm)](https://www.npmjs.com/package/zizkadb-sdk)
 [![MCP](https://img.shields.io/pypi/v/zizkadb-mcp?label=MCP)](https://pypi.org/project/zizkadb-mcp/)
 
-**[Open Source ↓](#open-source-self-host)** · **[Pro ↓](#pro-managed-cloud)** · **[Team ↓](#team-managed-cloud)** · **[Docs](https://db.zizka.ai/docs)** · **[Live site](https://db.zizka.ai)**
+**[Try free ↓](#open-source-self-host)** · **[START_HERE.md](START_HERE.md)** · **[CONNECT.md](CONNECT.md)** · **[Pro ↓](#pro-managed-cloud)** · **[Docs](https://db.zizka.ai/docs)**
 
 </div>
 
 <p align="center">
-  <a href="https://db.zizka.ai/dashboard">
-    <img src="docs/assets/readme-hero-dashboard.png" alt="ZizkaDB dashboard — Activity, Agent Behavior, Reports, and AI suggestions" width="100%"/>
-  </a>
+  <img src="docs/assets/why-demo.gif" alt="Terminal demo — trace why an agent called a tool with db.why()" width="100%"/>
 </p>
 
 <p align="center">
-  <sub>↑ Activity · Behavior · Reports · Suggestions — same dashboard on <a href="https://db.zizka.ai">managed cloud</a> and after <code>quickstart</code></sub>
+  <sub>Causal chain replay with <code>db.why()</code> — run <code>quickstart</code> below to reproduce this in your terminal</sub>
 </p>
+
+> **New here?** You do **not** need to understand this whole repo.  
+> Copy one command → see an audit trail in your terminal → open the dashboard.  
+> Managed cloud (Pro / Team) is optional — **[jump to OSS ↓](#open-source-self-host)**
+
+<table align="center">
+<tr>
+<td align="center"><strong>Replay</strong><br/>any session end-to-end</td>
+<td align="center"><strong>Lineage</strong><br/><code>db.why()</code> — decision trail</td>
+<td align="center"><strong>Drift</strong><br/>baseline when behavior shifts</td>
+<td align="center"><strong>Search</strong><br/>plain-English history</td>
+</tr>
+</table>
+
+<br/>
 
 ---
 
@@ -35,13 +48,13 @@ Operational database for AI agents — replay sessions, trace decisions, detect 
 | | **Open Source** | **Pro** | **Team** |
 | :--- | :--- | :--- | :--- |
 | **Best for** | Self-hosters & contributors | Solo devs & early prod | Teams with multiple agents |
-| **Price** | Free forever (AGPL) | €29 / month | €69 / month |
+| **Price** | **Free forever (AGPL)** | €29 / month | €69 / month |
 | **Hosting** | Your machine / VPC | [db.zizka.ai](https://db.zizka.ai) | [db.zizka.ai](https://db.zizka.ai) |
 | **Events / month** | Unlimited (your infra) | 50k† | 100k† |
 | **Active API keys** | Unlimited | 2 | 5 |
 | **Dashboard** | Activity · Behavior · Reports · Suggestions | Same + **Fleet** (managed) | Same + **Fleet** + priority support |
 | **Support** | Community | Email | Priority |
-| **Jump to** | [4 steps ↓](#open-source-self-host) | [4 steps ↓](#pro-managed-cloud) | [4 steps ↓](#team-managed-cloud) |
+| **Jump to** | **[Start free ↓](#open-source-self-host)** | [4 steps ↓](#pro-managed-cloud) | [4 steps ↓](#team-managed-cloud) |
 
 > **Enterprise VPC?** Single-tenant deploy, commercial license → [db.zizka.ai/enterprise](https://db.zizka.ai/enterprise)
 
@@ -53,39 +66,84 @@ Operational database for AI agents — replay sessions, trace decisions, detect 
 
 ## Open Source (self-host)
 
-**Free · AGPL-3.0 · Your infrastructure**
+**Free · AGPL-3.0 · No signup · Your infrastructure**
 
 | Step | What you get |
 | :---: | :--- |
 | **① What it is** | ZizkaDB stores every agent step as a **linked event** — not scattered logs. Trace decisions with **`why()`**, rewind with **`at()`**, search history in plain English, and catch **behavioral drift** before users notice. You run the full stack: API + dashboard + SDKs. |
-| **② How to integrate** | Run locally in ~2 min: `curl -fsSL …/quickstart-remote.sh \| bash` then `pip install zizkadb-sdk` (or TS / MCP / REST). Link events with `parent_id` so `why()` can walk the chain. → **[Full connect guide](CONNECT.md)** |
-| **③ Documentation** | [CONNECT.md](CONNECT.md) · [docs/](docs/) · [Self-hosting](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) · [Examples](examples/) · [Architecture](https://github.com/Zizka-ai/ZizkaDB/wiki/Architecture) |
+| **② How to integrate** | Run locally: `curl -fsSL …/quickstart-remote.sh \| bash` then `pip install zizkadb-sdk` (or TS / MCP / REST). Link events with `parent_id` so `why()` can walk the chain. → **[Full connect guide](CONNECT.md)** |
+| **③ Documentation** | [START_HERE.md](START_HERE.md) · [CONNECT.md](CONNECT.md) · [worked example](worked/01-support-order-delay/) · [Examples](examples/) · [Self-hosting](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) |
 | **④ Live dashboard** | **[localhost:3001/login](http://localhost:3001/login)** → **Open my dashboard** (no signup). Log from SDK → refresh → see sessions live. |
 
-**Quickstart**
+**Quickstart** — requires [Docker](https://docs.docker.com/get-docker/) · ~2 min cached · ~5–10 min first image pull
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
 ```
 
+**You should see:**
+
+```
+tool_call · lookup_order · ORD-8842
+  └── llm_response · gpt-4o
+        └── user_message · Why was my order delayed?
+```
+
+**Run the demo again anytime:**
+
+```bash
+pip install zizkadb-sdk
+zizkadb demo
+```
+
+**Connect your agent (3 lines):**
+
 ```python
-async with ZizkaDB(host="http://localhost:8000") as db:
-    user = await db.log(agent="my-bot", event="user_message", data={"text": "Why is my order late?"})
-    tool = await db.log(agent="my-bot", event="tool_call", data={"tool": "lookup_order"}, parent_id=user.event_id)
-    await db.why(tool.event_id).print()
+import asyncio
+from zizkadb import ZizkaDB
+
+async def main():
+    async with ZizkaDB(host="http://localhost:8000") as db:
+        user = await db.log(agent="my-bot", event="user_message", data={"text": "Why is my order late?"})
+        tool = await db.log(agent="my-bot", event="tool_call", data={"tool": "lookup_order"}, parent_id=user.event_id)
+        (await db.why(tool.event_id)).print()
+
+asyncio.run(main())
 ```
 
 <p align="center">
-  <img src="docs/assets/why-demo.gif" alt="Terminal demo — trace why an agent called a tool with db.why()" width="640"/>
-  <br/>
-  <sub>Causal chain replay with <code>db.why()</code> after <code>quickstart</code></sub>
+  <img src="docs/assets/gallery-why.png" alt="Causal chain in the ZizkaDB dashboard" width="48%"/>
+  <img src="docs/assets/readme-hero-dashboard.png" alt="ZizkaDB dashboard — Activity, Behavior, Reports, and Suggestions" width="48%"/>
 </p>
+
+<p align="center">
+  <sub>↑ Same UI locally and on <a href="https://db.zizka.ai">managed cloud</a> — story behind the demo: <a href="worked/01-support-order-delay/">worked/01-support-order-delay</a></sub>
+</p>
+
+<details>
+<summary>Other local install options</summary>
+
+**Already cloned this repo:**
+
+```bash
+bash scripts/quickstart.sh
+```
+
+**Stack only (no demo):**
+
+```bash
+bash scripts/setup-local.sh
+```
+
+**No Docker?** See [Self-hosting wiki](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) or [Pro (managed cloud)](#pro-managed-cloud) below.
+
+</details>
 
 ---
 
 ## Pro (managed cloud)
 
-**Hosted for you · No Docker to maintain**
+**Optional · Hosted for you · No Docker to maintain**
 
 | Step | What you get |
 | :---: | :--- |
@@ -111,7 +169,7 @@ async with ZizkaDB(api_key="zizkadb_live_...") as db:
 
 ## Team (managed cloud)
 
-**Multiple agents in production**
+**Optional · Multiple agents in production**
 
 | Step | What you get |
 | :---: | :--- |
@@ -222,6 +280,9 @@ zizkadb init my-agent --template basic
 
 | Resource | Link |
 | --- | --- |
+| **Start here (60s path)** | [START_HERE.md](START_HERE.md) |
+| Connect guide | [CONNECT.md](CONNECT.md) |
+| Worked example | [worked/01-support-order-delay](worked/01-support-order-delay/) |
 | Documentation index | [docs/README.md](docs/README.md) |
 | Integrate any agent | [docs/integrate/](docs/integrate/) |
 | Issues | [GitHub Issues](https://github.com/Zizka-ai/ZizkaDB/issues) |

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,6 +1,8 @@
 # Start here
 
-**Free, local, no signup.** Audit your first agent in a few minutes.
+**Free, local, no signup.** Audit your first AI agent in a few minutes.
+
+Open-source agent debugging: causal lineage, session replay, drift baselines — works with **LangChain**, **CrewAI**, **Cursor MCP**, Python, and TypeScript.
 
 ## 1. Run the demo
 
@@ -8,19 +10,30 @@
 curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
 ```
 
+Requires Docker. First image pull may take 5–10 minutes.
+
 ## 2. Check the terminal
 
 You should see a causal chain ending in `user_message · Why was my order delayed?`
 
+```text
+$ zizkadb demo
+tool_call · lookup_order · ORD-8842
+  └── llm_response · gpt-4o
+        └── user_message · Why was my order delayed?
+```
+
 ## 3. Open the dashboard
 
-http://localhost:3001/login → **Open my dashboard →**
+http://localhost:3001/login → **Open my dashboard →** (no account, no API key)
 
 ## 4. Connect your code
 
 ```python
 async with ZizkaDB(host="http://localhost:8000") as db:
-    ...
+    user = await db.log(agent="my-bot", event="user_message", data={"text": "Hello"})
+    tool = await db.log(agent="my-bot", event="tool_call", data={"tool": "search"}, parent_id=user.event_id)
+    (await db.why(tool.event_id)).print()
 ```
 
 Full guide: [CONNECT.md](CONNECT.md)

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -1,0 +1,40 @@
+# Start here
+
+**Free, local, no signup.** Audit your first agent in a few minutes.
+
+## 1. Run the demo
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
+```
+
+## 2. Check the terminal
+
+You should see a causal chain ending in `user_message · Why was my order delayed?`
+
+## 3. Open the dashboard
+
+http://localhost:3001/login → **Open my dashboard →**
+
+## 4. Connect your code
+
+```python
+async with ZizkaDB(host="http://localhost:8000") as db:
+    ...
+```
+
+Full guide: [CONNECT.md](CONNECT.md)
+
+## Run again
+
+```bash
+pip install zizkadb-sdk && zizkadb demo
+```
+
+## Next
+
+- [worked/01-support-order-delay](worked/01-support-order-delay/) — the demo scenario
+- [examples/](examples/) — LangChain, CrewAI, OpenAI, MCP
+- [wiki/Getting-Started](https://github.com/Zizka-ai/ZizkaDB/wiki/Getting-Started)
+
+**Managed cloud (optional, no Docker):** [db.zizka.ai/signup](https://db.zizka.ai/signup)

--- a/scripts/quickstart-remote.sh
+++ b/scripts/quickstart-remote.sh
@@ -91,13 +91,13 @@ curl -fsSL "${BASE}/infra/docker-compose.quickstart.yml" -o "${INFRA}/docker-com
 curl -fsSL "${BASE}/core/db/schema.sql" -o "${INFRA}/schema.sql"
 curl -fsSL "${BASE}/infra/.env.quickstart" -o "${INFRA}/.env"
 
-echo "→ Pulling pre-built images from ghcr.io/zizka-ai/..."
+echo "→ Pulling pre-built images from ghcr.io/zizka-ai/ (first run may take 5–10 min)..."
 cd "${INFRA}"
 if ! docker compose -f docker-compose.quickstart.yml pull; then
   fallback_shallow_clone
 fi
 
-echo "→ Starting stack..."
+echo "→ Starting stack (postgres, qdrant, redis, api, dashboard)..."
 docker compose -f docker-compose.quickstart.yml up -d
 
 echo "→ Waiting for API..."

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,85 +1,91 @@
 # zizkadb-sdk
 
-**PyPI:** [zizkadb-sdk 0.2.6](https://pypi.org/project/zizkadb-sdk/0.2.6/)
+Python SDK for [ZizkaDB](https://github.com/Zizka-ai/ZizkaDB) — audit trails, causal lineage, and drift baselines for AI agents.
 
-Python SDK for [ZizkaDB](https://db.zizka.ai) — the operational database for AI agents.
+**PyPI:** [zizkadb-sdk 0.2.6](https://pypi.org/project/zizkadb-sdk/)
 
-## Setup (managed cloud)
+## Try free (local — no signup)
 
-1. [Sign up](https://db.zizka.ai/signup) at db.zizka.ai  
-2. **Dashboard → Create agent** (e.g. `my-bot`) — you get an API key for that agent  
-3. Use the **same agent name** in every `db.log()` call  
-4. Set `ZIZKADB_API_KEY` (or pass the key to the constructor)
+Start the OSS stack + demo (requires Docker):
 
-> **Important:** The `agent` in `db.log(agent="...", ...)` must match the agent you created in the dashboard. A mismatch returns **403 AgentScopeError**.
+```bash
+curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
+```
+
+Or, if the stack is already running:
+
+```bash
+pip install zizkadb-sdk
+zizkadb demo
+```
+
+Dashboard: http://localhost:3001/login → **Open my dashboard →**
 
 ## Install
 
 ```bash
-pip install zizkadb-sdk
+pip install "zizkadb-sdk>=0.2.6"
 ```
 
-> **Note:** There is an unrelated package called `agentdb` on PyPI. Install **`zizkadb-sdk`**. Import: `from zizkadb import ZizkaDB`.
+> Install **`zizkadb-sdk`**, not the unrelated `agentdb` package on PyPI.
+
+## Quickstart (local)
+
+```python
+import asyncio
+from zizkadb import ZizkaDB
+
+async def main():
+    async with ZizkaDB(host="http://localhost:8000") as db:
+        user = await db.log(agent="my-bot", event="user_message", data={"text": "Hello"})
+        tool = await db.log(agent="my-bot", event="tool_call", data={"tool": "search"}, parent_id=user.event_id)
+        (await db.why(tool.event_id)).print()
+
+asyncio.run(main())
+```
+
+No API key on localhost — the local stack uses a built-in dev key.
 
 ## Scaffold a project
 
 ```bash
-pip install zizkadb-sdk
 zizkadb init my-agent --template basic
-cd my-agent && cp .env.example .env   # paste your key into ZIZKADB_API_KEY
+cd my-agent
+cp .env.example .env   # ZIZKADB_HOST=http://localhost:8000
 pip install -r requirements.txt
 python agent.py
 ```
 
 Templates: `basic`, `openai`, `langchain`, `crewai`, `mcp-cursor`.
 
-## Quickstart
+## Managed cloud (optional)
+
+[Sign up](https://db.zizka.ai/signup) → create an agent → use the same agent name in every `db.log()`:
 
 ```python
-from zizkadb import ZizkaDB
-
-# Key from Dashboard → Settings → API keys → create "my-bot" → copy key
-db = ZizkaDB("zizkadb_live_xxxx")
-
-async with db:
-    result = await db.log(
-        agent="my-bot",  # must match dashboard agent name
-        event="tool_call",
-        data={"tool": "search", "query": "billing"},
-    )
-    chain = await db.why(result.event_id)
-    chain.print()
+async with ZizkaDB(api_key="zizkadb_live_...") as db:
+    await db.log(agent="my-bot", event="tool_call", data={...})
 ```
 
-## Multi-agent apps (one key, many agent names)
+## CLI
 
-If your app logs to **different agent ids** per user (e.g. `conv-alice`, `conv-bob`), create a **tenant-wide key** in **Settings → Tenant-wide API key**. Per-agent keys only work for that one agent name.
-
-## Errors
-
-| Exception | Meaning |
-|-----------|---------|
-| `AuthError` | Invalid or revoked API key |
-| `AgentScopeError` | Key is for agent A but you logged to agent B |
-| `NotFoundError` | Event or agent not found |
+| Command | Description |
+|---------|-------------|
+| `zizkadb demo` | Run the support-bot lineage demo |
+| `zizkadb init NAME -t basic` | Scaffold from a template |
+| `zizkadb why EVENT_ID` | Print causal chain as JSON |
 
 ## Environment variables
 
 | Variable | Purpose |
 |----------|---------|
-| `ZIZKADB_API_KEY` | Your cloud API key (preferred) |
-| `AGENTDB_API_KEY` | Legacy alias for `ZIZKADB_API_KEY` |
-| `ZIZKADB_AGENT` | Default agent name (used in templates/examples) |
-| `ZIZKADB_HOST` | Self-hosted API URL |
-| `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping after first `log()`) |
-
-## Self-host dashboard
-
-1. `bash scripts/setup-local.sh` (API + dashboard on port **3001**)
-2. Open http://localhost:3001/login → **Open my dashboard →**
+| `ZIZKADB_HOST` | Local/self-hosted API (default stack: `http://localhost:8000`) |
+| `ZIZKADB_API_KEY` | Managed cloud API key |
+| `ZIZKADB_AGENT` | Default agent name in templates |
+| `ZIZKADB_TELEMETRY` | Set `false` to opt out |
 
 ## Links
 
+- [GitHub README](https://github.com/Zizka-ai/ZizkaDB#readme)
+- [CONNECT.md](https://github.com/Zizka-ai/ZizkaDB/blob/main/CONNECT.md)
 - [Docs](https://db.zizka.ai/docs)
-- [API explorer](https://db.zizka.ai/swagger)
-- [GitHub](https://github.com/Zizka-ai/ZizkaDB)


### PR DESCRIPTION
Lead with free OSS quickstart and zizkadb demo, add expected terminal output and worked example links, keep Pro/Team secondary, and align CONNECT and PyPI README with localhost-first onboarding.

## Summary

<!-- What changed and why (1–3 bullets). -->

## Test plan

- [ ] `ruff check core/ sdk/python/ mcp/ integrations/` (if Python touched)
- [ ] `pytest core/tests/ -m "not integration"` (if core touched)
- [ ] `cd dashboard && npm run lint && npm test && npm run build` (if dashboard touched)
- [ ] Manual: <!-- steps or "docs only" -->

## Areas touched

- [ ] API / schema
- [ ] SDK (Python / TypeScript)
- [ ] Dashboard
- [ ] MCP / integrations
- [ ] Docs only
- [ ] Infra / CI

## Breaking changes

<!-- None, or describe migration. -->

Fixes #<!-- issue number if applicable -->
