### PR TITLE
docs: GitHub release versions 0.2.7 / 0.1.6 / 0.1.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     attributes:
       label: Version
       description: GitHub release tag, or `pip show zizkadb-sdk`
-      placeholder: v0.2.6 / zizkadb-sdk 0.2.6
+      placeholder: v0.2.7 / zizkadb-sdk 0.2.7
 
   - type: textarea
     id: env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.2.7] — 2026-08-22
+
+### Python SDK (`zizkadb-sdk` 0.2.7, PyPI)
+
+- Restore telemetry ping on client construct (process start), including self-hosted localhost
+
+### TypeScript SDK (`zizkadb-sdk` 0.2.7, npm)
+
+- Restore telemetry ping on client construct (process start), including self-hosted localhost
+
+### MCP (`zizkadb-mcp` 0.1.6)
+
+- Restore telemetry ping on MCP server startup (not first tool call only)
+
+### Integrations
+
+- `zizkadb-langchain` **0.1.2** — requires `zizkadb-sdk>=0.2.7`
+- `zizkadb-crewai` **0.1.2** — requires `zizkadb-sdk>=0.2.7`
+
 ## [0.2.6] — 2026-08-21
 
 ### Python SDK (`zizkadb-sdk` 0.2.6, PyPI)
@@ -48,6 +67,7 @@ Production-hardening sprint merged to `main` (via stacked PRs #125–#139), incl
 
 See [GitHub releases](https://github.com/Zizka-ai/ZizkaDB/releases) for tagged artifacts.
 
-[Unreleased]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.2.6...HEAD
+[Unreleased]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.2.7...HEAD
+[0.2.7]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.1.0...v0.2.6
 [0.1.0]: https://github.com/Zizka-ai/ZizkaDB/releases

--- a/CONNECT.md
+++ b/CONNECT.md
@@ -1,14 +1,6 @@
 # Connect your agent (self-host / OSS)
 
-**Current releases:** PyPI/npm `zizkadb-sdk` **0.2.6** · `zizkadb-mcp` **0.1.5** · `zizkadb-langchain` **0.1.1** · `zizkadb-crewai` **0.1.1**
-
-**Fastest win:** run the stack + demo, then paste the Python snippet below.
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
-# stack already up?
-pip install zizkadb-sdk && zizkadb demo
-```
+**Current PyPI releases:** `zizkadb-sdk` **0.2.7** · `zizkadb-mcp` **0.1.6** · `zizkadb-langchain` **0.1.2** · `zizkadb-crewai` **0.1.2**
 
 ## Start the stack (pick one)
 
@@ -36,7 +28,7 @@ Pick your stack below. Use the **same agent name** in code and dashboard.
 ## Python SDK
 
 ```bash
-pip install "zizkadb-sdk>=0.2.6"
+pip install "zizkadb-sdk>=0.2.7"
 ```
 
 ```python
@@ -73,7 +65,7 @@ export ZIZKADB_AGENT=my-bot
 ## TypeScript SDK
 
 ```bash
-npm install zizkadb-sdk@0.2.6
+npm install zizkadb-sdk
 ```
 
 ```typescript
@@ -99,7 +91,7 @@ await db.log({
 ## LangChain
 
 ```bash
-pip install "zizkadb-sdk>=0.2.6" "zizkadb-langchain>=0.1.1"
+pip install "zizkadb-sdk>=0.2.7" "zizkadb-langchain>=0.1.2"
 ```
 
 ```python
@@ -124,7 +116,7 @@ Or scaffold: `zizkadb init my-agent --template langchain`
 ## CrewAI
 
 ```bash
-pip install "zizkadb-sdk>=0.2.6" "zizkadb-crewai>=0.1.1"
+pip install "zizkadb-sdk>=0.2.7" "zizkadb-crewai>=0.1.2"
 ```
 
 ```python
@@ -146,7 +138,7 @@ Or scaffold: `zizkadb init my-agent --template crewai`
 ## MCP (Cursor, Claude Desktop, Windsurf)
 
 ```bash
-pip install "zizkadb-mcp>=0.1.5"
+pip install "zizkadb-mcp>=0.1.6"
 # or: uvx zizkadb-mcp
 ```
 

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ Core unit tests plus the SDK and MCP package tests do not require a running Zizk
 
 ## Integrations
 
-**Current releases:** PyPI `zizkadb-sdk` **0.2.6** · npm `zizkadb-sdk` **0.2.6** · `zizkadb-mcp` **0.1.5** · `zizkadb-langchain` **0.1.1** · `zizkadb-crewai` **0.1.1**
+**Current releases:** PyPI `zizkadb-sdk` **0.2.7** · npm `zizkadb-sdk` **0.2.7** · `zizkadb-mcp` **0.1.6** · `zizkadb-langchain` **0.1.2** · `zizkadb-crewai` **0.1.2**
 
 | Python | TypeScript | LangChain | CrewAI | MCP (Cursor) | REST |
 | :---: | :---: | :---: | :---: | :---: | :---: |

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -86,7 +86,7 @@ observability baseline).
 | R10 | **No CD + out-of-tree deploy assets** — `deploy-production.sh` and prod `nginx.conf` are referenced but absent from the repo → DR/reproducibility risk | **Medium** | referenced in `infra/docker-compose.yml:12,99`, `dashboard/ecosystem.config.js:8` |
 | R11 | **Datastore SPOFs** — single Postgres/Qdrant/Redis, no replication/HA | **Medium** | single containers, local volumes |
 | R12 | **Stale docs / dead references** — largely reconciled this cycle (router map 14→9; absent `admin`/`stats`/`community`/`demo`/`marketing`) | **Low** | fixed in `CLAUDE.md`, KB, wiki |
-| R13 | **Version drift** — `core/main.py` 0.1.0, SDKs 0.2.6, MCP 0.1.5; version hardcoded twice in `main.py` | **Low** | vs the "bump together" doc rule |
+| R13 | **Version drift** — `core/main.py` 0.1.0, SDKs 0.2.7, MCP 0.1.6; version hardcoded twice in `main.py` | **Low** | vs the "bump together" doc rule |
 
 ---
 

--- a/docs/integrate/frameworks.md
+++ b/docs/integrate/frameworks.md
@@ -4,12 +4,12 @@ Only list **SUPPORTED** when an adapter or official example exists in this repos
 
 | Framework | Status | Package (version) |
 |-----------|--------|-------------------|
-| **Python (custom)** | Supported | `zizkadb-sdk` **0.2.6** — [any-agent.md](any-agent.md) |
-| **TypeScript / Node** | Supported | `zizkadb-sdk` **0.2.6** (npm) — [CONNECT.md](../../CONNECT.md#typescript-sdk) |
+| **Python (custom)** | Supported | `zizkadb-sdk` **0.2.7** — [any-agent.md](any-agent.md) |
+| **TypeScript / Node** | Supported | `zizkadb-sdk` **0.2.7** (npm) — [CONNECT.md](../../CONNECT.md#typescript-sdk) |
 | **REST / any HTTP client** | Supported | `POST /v1/events` — [wiki/REST-API](../../wiki/REST-API.md) |
-| **LangChain (Python)** | Supported | `zizkadb-langchain` **0.1.1** — [examples/langchain-agent](../../examples/langchain-agent/) |
-| **CrewAI (Python)** | Supported | `zizkadb-crewai` **0.1.1** — [examples/crewai-agent](../../examples/crewai-agent/) |
-| **MCP (Cursor, Claude Desktop)** | Supported | `zizkadb-mcp` **0.1.5** · [mcp/README.md](../../mcp/README.md) |
+| **LangChain (Python)** | Supported | `zizkadb-langchain` **0.1.2** — [examples/langchain-agent](../../examples/langchain-agent/) |
+| **CrewAI (Python)** | Supported | `zizkadb-crewai` **0.1.2** — [examples/crewai-agent](../../examples/crewai-agent/) |
+| **MCP (Cursor, Claude Desktop)** | Supported | `zizkadb-mcp` **0.1.6** · [mcp/README.md](../../mcp/README.md) |
 | **OpenAI / Anthropic SDKs** | Example pattern | Manual `log()` around API calls · [examples/openai-agent](../../examples/openai-agent/) |
 | **LangGraph** | Generic only | No official adapter — call `db.log()` inside graph nodes · [any-agent.md](any-agent.md) |
 | **LlamaIndex** | Generic only | Log at retrieval/tool boundaries via SDK or REST |

--- a/examples/crewai-agent/requirements.txt
+++ b/examples/crewai-agent/requirements.txt
@@ -1,4 +1,4 @@
-zizkadb-sdk>=0.2.6
-zizkadb-crewai>=0.1.1
+zizkadb-sdk>=0.2.7
+zizkadb-crewai>=0.1.2
 crewai>=0.80.0
 langchain-openai>=0.2.0

--- a/examples/langchain-agent/requirements.txt
+++ b/examples/langchain-agent/requirements.txt
@@ -1,3 +1,3 @@
-zizkadb-sdk>=0.2.6
-zizkadb-langchain>=0.1.1
+zizkadb-sdk>=0.2.7
+zizkadb-langchain>=0.1.2
 langchain-openai>=0.2.0

--- a/examples/minimal-python/requirements.txt
+++ b/examples/minimal-python/requirements.txt
@@ -1,1 +1,1 @@
-zizkadb-sdk>=0.2.6
+zizkadb-sdk>=0.2.7

--- a/examples/openai-agent/requirements.txt
+++ b/examples/openai-agent/requirements.txt
@@ -1,1 +1,1 @@
-zizkadb-sdk>=0.2.6
+zizkadb-sdk>=0.2.7

--- a/integrations/CLAUDE.md
+++ b/integrations/CLAUDE.md
@@ -8,16 +8,16 @@ Two standalone adapter packages: **`zizkadb-langchain`** and **`zizkadb-crewai`*
 
 ## Packages
 
-Both adapters are **published on PyPI** (`zizkadb-sdk` **0.2.6**, integrations **0.1.1**), so users install directly — no git URLs.
+Both adapters are **published on PyPI** (`zizkadb-sdk` **0.2.7**, integrations **0.1.2**), so users install directly — no git URLs.
 
 | Package | Directory | Class | PyPI (current) |
 |---|---|---|---|
-| `zizkadb-langchain` | `integrations/langchain/` | `ZizkaDBCallbackHandler` (auto callback handler) | `0.1.1` |
-| `zizkadb-crewai` | `integrations/crewai/` | `ZizkaDBCrewLogger` (kickoff/task/output logger) | `0.1.1` |
+| `zizkadb-langchain` | `integrations/langchain/` | `ZizkaDBCallbackHandler` (auto callback handler) | `0.1.2` |
+| `zizkadb-crewai` | `integrations/crewai/` | `ZizkaDBCrewLogger` (kickoff/task/output logger) | `0.1.2` |
 
 Install for users:
 ```bash
-pip install "zizkadb-sdk>=0.2.6" "zizkadb-langchain>=0.1.1"    # or zizkadb-crewai>=0.1.1
+pip install "zizkadb-sdk>=0.2.7" "zizkadb-langchain>=0.1.2"    # or zizkadb-crewai>=0.1.2
 ```
 
 ---

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4,11 +4,10 @@ Official adapters for agent frameworks. Each package is optional — core SDK is
 
 | Package | PyPI version | Install | Use case |
 |---------|--------------|---------|----------|
-| `zizkadb-sdk` | **0.2.6** | `pip install zizkadb-sdk` | Core Python client |
-| `zizkadb-sdk` (npm) | **0.2.6** | `npm install zizkadb-sdk` | TypeScript / Node client |
-| [langchain](langchain/) | **0.1.1** | `pip install zizkadb-langchain` | `ZizkaDBCallbackHandler` on LangChain runnables |
-| [crewai](crewai/) | **0.1.1** | `pip install zizkadb-crewai` | `ZizkaDBCrewLogger` for crew kickoff / output |
-| [mcp](../mcp/) | **0.1.5** | `uvx zizkadb-mcp` | Cursor, Claude Desktop, Windsurf tools |
+| `zizkadb-sdk` | **0.2.7** | `pip install zizkadb-sdk` | Core Python client |
+| [langchain](langchain/) | **0.1.2** | `pip install zizkadb-langchain` | `ZizkaDBCallbackHandler` on LangChain runnables |
+| [crewai](crewai/) | **0.1.2** | `pip install zizkadb-crewai` | `ZizkaDBCrewLogger` for crew kickoff / output |
+| [mcp](../mcp/) | **0.1.6** | `uvx zizkadb-mcp` | Cursor, Claude Desktop, Windsurf tools |
 
 **Configure once (all packages):**
 

--- a/integrations/crewai/README.md
+++ b/integrations/crewai/README.md
@@ -1,6 +1,6 @@
 # zizkadb-crewai
 
-**PyPI:** [zizkadb-crewai 0.1.1](https://pypi.org/project/zizkadb-crewai/0.1.1/) · requires `zizkadb-sdk>=0.2.6`
+**PyPI:** [zizkadb-crewai 0.1.2](https://pypi.org/project/zizkadb-crewai/0.1.2/) · requires `zizkadb-sdk>=0.2.7`
 
 Self-hosted, open-source **observability and causal debugging** for [CrewAI](https://crewai.com).
 

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -1,6 +1,6 @@
 # zizkadb-langchain
 
-**PyPI:** [zizkadb-langchain 0.1.1](https://pypi.org/project/zizkadb-langchain/0.1.1/)
+**PyPI:** [zizkadb-langchain 0.1.2](https://pypi.org/project/zizkadb-langchain/0.1.2/)
 
 LangChain `AsyncCallbackHandler` that logs LLM and tool steps to ZizkaDB with `parent_id` lineage.
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,10 +8,10 @@ ZizkaDB is open-source (AGPL-3.0, except MCP server which is MIT). It runs as a 
 
 - [Core API](core/) — FastAPI + asyncpg + PostgreSQL 16/pgvector + Qdrant + Redis. 14 routers at `/v1/`.
 - [Dashboard](dashboard/) — Next.js 14 App Router. Marketing + authenticated agent fleet view.
-- [Python SDK](sdk/python/) — `zizkadb-sdk` **0.2.6** on PyPI. Async client, `zizkadb init` CLI.
-- [TypeScript SDK](sdk/typescript/) — `zizkadb-sdk` **0.2.6** on npm. Sync constructor, camelCase fields.
-- [Integrations](integrations/) — `zizkadb-langchain` **0.1.1**, `zizkadb-crewai` **0.1.1** on PyPI. `db.why()` causal debugging.
-- [MCP Server](mcp/) — `zizkadb-mcp` **0.1.5** on PyPI. MIT license. `uvx zizkadb-mcp`.
+- [Python SDK](sdk/python/) — `zizkadb-sdk` **0.2.7** on PyPI. Async client, `zizkadb init` CLI.
+- [TypeScript SDK](sdk/typescript/) — `zizkadb-sdk` **0.2.7** on npm. Sync constructor, camelCase fields.
+- [Integrations](integrations/) — `zizkadb-langchain` **0.1.2**, `zizkadb-crewai` **0.1.2** on PyPI. `db.why()` causal debugging.
+- [MCP Server](mcp/) — `zizkadb-mcp` **0.1.6** on PyPI. MIT license. `uvx zizkadb-mcp`.
 - [Infra](infra/) — Docker Compose. Production: `docker-compose.yml`. Dev overlay: `docker-compose.dev.yml`.
 
 ## Key context files

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # zizkadb-mcp
 
-**PyPI:** [zizkadb-mcp 0.1.5](https://pypi.org/project/zizkadb-mcp/0.1.5/)
+**PyPI:** [zizkadb-mcp 0.1.6](https://pypi.org/project/zizkadb-mcp/0.1.6/)
 
 MCP server for [ZizkaDB](https://db.zizka.ai). Gives any MCP-compatible AI agent persistent memory, semantic search, causal debugging, and time travel.
 
@@ -73,7 +73,7 @@ On localhost, the dev key (`zizkadb_dev_local`) is auto-injected — no API key 
 | `ZIZKADB_API_KEY` | — | **Required on cloud.** Your key from db.zizka.ai Settings |
 | `AGENTDB_API_KEY` | — | Legacy alias for `ZIZKADB_API_KEY` |
 | `AGENTDB_HOST` | — | Legacy alias for `ZIZKADB_HOST` |
-| `ZIZKADB_TELEMETRY` | on | Set `false` to opt out (ping after first successful tool call) |
+| `ZIZKADB_TELEMETRY` | on | Set `false` to opt out (ping on MCP server startup) |
 
 If `ZIZKADB_API_KEY` is missing on cloud, MCP tools return a clear error instead of silently failing.
 

--- a/mcp/zizkadb_mcp/__init__.py
+++ b/mcp/zizkadb_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ZizkaDB MCP Server — give any AI agent persistent memory and observability."""
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,91 +1,85 @@
 # zizkadb-sdk
 
-Python SDK for [ZizkaDB](https://github.com/Zizka-ai/ZizkaDB) — audit trails, causal lineage, and drift baselines for AI agents.
+**PyPI:** [zizkadb-sdk 0.2.7](https://pypi.org/project/zizkadb-sdk/0.2.7/)
 
-**PyPI:** [zizkadb-sdk 0.2.6](https://pypi.org/project/zizkadb-sdk/)
+Python SDK for [ZizkaDB](https://db.zizka.ai) — the operational database for AI agents.
 
-## Try free (local — no signup)
+## Setup (managed cloud)
 
-Start the OSS stack + demo (requires Docker):
+1. [Sign up](https://db.zizka.ai/signup) at db.zizka.ai  
+2. **Dashboard → Create agent** (e.g. `my-bot`) — you get an API key for that agent  
+3. Use the **same agent name** in every `db.log()` call  
+4. Set `ZIZKADB_API_KEY` (or pass the key to the constructor)
 
-```bash
-curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
-```
-
-Or, if the stack is already running:
-
-```bash
-pip install zizkadb-sdk
-zizkadb demo
-```
-
-Dashboard: http://localhost:3001/login → **Open my dashboard →**
+> **Important:** The `agent` in `db.log(agent="...", ...)` must match the agent you created in the dashboard. A mismatch returns **403 AgentScopeError**.
 
 ## Install
 
 ```bash
-pip install "zizkadb-sdk>=0.2.6"
+pip install zizkadb-sdk
 ```
 
-> Install **`zizkadb-sdk`**, not the unrelated `agentdb` package on PyPI.
-
-## Quickstart (local)
-
-```python
-import asyncio
-from zizkadb import ZizkaDB
-
-async def main():
-    async with ZizkaDB(host="http://localhost:8000") as db:
-        user = await db.log(agent="my-bot", event="user_message", data={"text": "Hello"})
-        tool = await db.log(agent="my-bot", event="tool_call", data={"tool": "search"}, parent_id=user.event_id)
-        (await db.why(tool.event_id)).print()
-
-asyncio.run(main())
-```
-
-No API key on localhost — the local stack uses a built-in dev key.
+> **Note:** There is an unrelated package called `agentdb` on PyPI. Install **`zizkadb-sdk`**. Import: `from zizkadb import ZizkaDB`.
 
 ## Scaffold a project
 
 ```bash
+pip install zizkadb-sdk
 zizkadb init my-agent --template basic
-cd my-agent
-cp .env.example .env   # ZIZKADB_HOST=http://localhost:8000
+cd my-agent && cp .env.example .env   # paste your key into ZIZKADB_API_KEY
 pip install -r requirements.txt
 python agent.py
 ```
 
 Templates: `basic`, `openai`, `langchain`, `crewai`, `mcp-cursor`.
 
-## Managed cloud (optional)
-
-[Sign up](https://db.zizka.ai/signup) → create an agent → use the same agent name in every `db.log()`:
+## Quickstart
 
 ```python
-async with ZizkaDB(api_key="zizkadb_live_...") as db:
-    await db.log(agent="my-bot", event="tool_call", data={...})
+from zizkadb import ZizkaDB
+
+# Key from Dashboard → Settings → API keys → create "my-bot" → copy key
+db = ZizkaDB("zizkadb_live_xxxx")
+
+async with db:
+    result = await db.log(
+        agent="my-bot",  # must match dashboard agent name
+        event="tool_call",
+        data={"tool": "search", "query": "billing"},
+    )
+    chain = await db.why(result.event_id)
+    chain.print()
 ```
 
-## CLI
+## Multi-agent apps (one key, many agent names)
 
-| Command | Description |
-|---------|-------------|
-| `zizkadb demo` | Run the support-bot lineage demo |
-| `zizkadb init NAME -t basic` | Scaffold from a template |
-| `zizkadb why EVENT_ID` | Print causal chain as JSON |
+If your app logs to **different agent ids** per user (e.g. `conv-alice`, `conv-bob`), create a **tenant-wide key** in **Settings → Tenant-wide API key**. Per-agent keys only work for that one agent name.
+
+## Errors
+
+| Exception | Meaning |
+|-----------|---------|
+| `AuthError` | Invalid or revoked API key |
+| `AgentScopeError` | Key is for agent A but you logged to agent B |
+| `NotFoundError` | Event or agent not found |
 
 ## Environment variables
 
 | Variable | Purpose |
 |----------|---------|
-| `ZIZKADB_HOST` | Local/self-hosted API (default stack: `http://localhost:8000`) |
-| `ZIZKADB_API_KEY` | Managed cloud API key |
-| `ZIZKADB_AGENT` | Default agent name in templates |
-| `ZIZKADB_TELEMETRY` | Set `false` to opt out |
+| `ZIZKADB_API_KEY` | Your cloud API key (preferred) |
+| `AGENTDB_API_KEY` | Legacy alias for `ZIZKADB_API_KEY` |
+| `ZIZKADB_AGENT` | Default agent name (used in templates/examples) |
+| `ZIZKADB_HOST` | Self-hosted API URL |
+| `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping on client construct) |
+
+## Self-host dashboard
+
+1. `bash scripts/setup-local.sh` (API + dashboard on port **3001**)
+2. Open http://localhost:3001/login → **Open my dashboard →**
 
 ## Links
 
-- [GitHub README](https://github.com/Zizka-ai/ZizkaDB#readme)
-- [CONNECT.md](https://github.com/Zizka-ai/ZizkaDB/blob/main/CONNECT.md)
 - [Docs](https://db.zizka.ai/docs)
+- [API explorer](https://db.zizka.ai/swagger)
+- [GitHub](https://github.com/Zizka-ai/ZizkaDB)

--- a/sdk/python/zizkadb/templates/basic/requirements.txt
+++ b/sdk/python/zizkadb/templates/basic/requirements.txt
@@ -1,1 +1,1 @@
-zizkadb-sdk>=0.2.6
+zizkadb-sdk>=0.2.7

--- a/sdk/python/zizkadb/templates/crewai/requirements.txt
+++ b/sdk/python/zizkadb/templates/crewai/requirements.txt
@@ -1,4 +1,4 @@
-zizkadb-sdk>=0.2.6
-zizkadb-crewai>=0.1.1
+zizkadb-sdk>=0.2.7
+zizkadb-crewai>=0.1.2
 crewai>=0.80.0
 langchain-openai>=0.2.0

--- a/sdk/python/zizkadb/templates/langchain/requirements.txt
+++ b/sdk/python/zizkadb/templates/langchain/requirements.txt
@@ -1,3 +1,3 @@
-zizkadb-sdk>=0.2.6
-zizkadb-langchain>=0.1.1
+zizkadb-sdk>=0.2.7
+zizkadb-langchain>=0.1.2
 langchain-openai>=0.2.0

--- a/sdk/python/zizkadb/templates/openai/requirements.txt
+++ b/sdk/python/zizkadb/templates/openai/requirements.txt
@@ -1,1 +1,1 @@
-zizkadb-sdk>=0.2.6
+zizkadb-sdk>=0.2.7

--- a/sdk/typescript/CLAUDE.md
+++ b/sdk/typescript/CLAUDE.md
@@ -2,7 +2,7 @@
 
 See root [`CLAUDE.md`](../../CLAUDE.md) for full project context.
 
-Package: **`zizkadb-sdk` 0.2.6** on npm. Import: `import { ZizkaDB } from 'zizkadb-sdk'`.
+Package: **`zizkadb-sdk` 0.2.7** on npm. Import: `import { ZizkaDB } from 'zizkadb-sdk'`.
 
 ---
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,6 +1,6 @@
 # zizkadb-sdk
 
-**npm:** [zizkadb-sdk 0.2.6](https://www.npmjs.com/package/zizkadb-sdk)
+**npm:** [zizkadb-sdk 0.2.7](https://www.npmjs.com/package/zizkadb-sdk)
 
 TypeScript SDK for [ZizkaDB](https://db.zizka.ai) — causal lineage, time travel, and semantic search for AI agents.
 
@@ -16,7 +16,7 @@ TypeScript SDK for [ZizkaDB](https://db.zizka.ai) — causal lineage, time trave
 ## Install
 
 ```bash
-npm install zizkadb-sdk@0.2.6
+npm install zizkadb-sdk
 ```
 
 ## Quickstart
@@ -54,7 +54,7 @@ If your app logs to **different agent ids** per user (e.g. `conv-alice`, `conv-b
 | `ZIZKADB_API_KEY` | Your cloud API key (preferred) |
 | `AGENTDB_API_KEY` | Legacy alias for `ZIZKADB_API_KEY` |
 | `ZIZKADB_HOST` | Self-hosted API URL |
-| `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping after first `log()`) |
+| `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping on client construct) |
 
 Core HTTP client only — LangChain and CrewAI adapters are Python packages (`zizkadb-langchain`, `zizkadb-crewai`).
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,11 +7,11 @@
 | GitHub | [Zizka-ai/ZizkaDB](https://github.com/Zizka-ai/ZizkaDB) |
 | OSS quickstart (no clone) | `curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh \| bash` |
 | Connect guide | [CONNECT.md](https://github.com/Zizka-ai/ZizkaDB/blob/main/CONNECT.md) |
-| PyPI SDK | [zizkadb-sdk](https://pypi.org/project/zizkadb-sdk/) **0.2.6** |
-| PyPI MCP | [zizkadb-mcp](https://pypi.org/project/zizkadb-mcp/) **0.1.5** |
-| PyPI LangChain | [zizkadb-langchain](https://pypi.org/project/zizkadb-langchain/) **0.1.1** |
-| PyPI CrewAI | [zizkadb-crewai](https://pypi.org/project/zizkadb-crewai/) **0.1.1** |
-| npm SDK | [zizkadb-sdk](https://www.npmjs.com/package/zizkadb-sdk) **0.2.6** |
+| PyPI SDK | [zizkadb-sdk](https://pypi.org/project/zizkadb-sdk/) **0.2.7** |
+| PyPI MCP | [zizkadb-mcp](https://pypi.org/project/zizkadb-mcp/) **0.1.6** |
+| PyPI LangChain | [zizkadb-langchain](https://pypi.org/project/zizkadb-langchain/) **0.1.2** |
+| PyPI CrewAI | [zizkadb-crewai](https://pypi.org/project/zizkadb-crewai/) **0.1.2** |
+| npm SDK | [zizkadb-sdk](https://www.npmjs.com/package/zizkadb-sdk) **0.2.5** |
 | Docs site | [db.zizka.ai/docs](https://db.zizka.ai/docs) |
 | Managed cloud (optional) | [db.zizka.ai/signup](https://db.zizka.ai/signup) |
 

--- a/wiki/MCP-and-Cursor.md
+++ b/wiki/MCP-and-Cursor.md
@@ -1,6 +1,6 @@
 # MCP and Cursor
 
-**Package:** `zizkadb-mcp` on PyPI (**0.1.5**)  
+**Package:** `zizkadb-mcp` on PyPI (**0.1.6**)  
 **Run:** `uvx zizkadb-mcp`
 
 ## Install uv (for uvx)

--- a/wiki/Python-SDK.md
+++ b/wiki/Python-SDK.md
@@ -1,6 +1,6 @@
 # Python SDK
 
-**Package:** `zizkadb-sdk` on PyPI (**0.2.6**)  
+**Package:** `zizkadb-sdk` on PyPI (**0.2.7**)  
 **Import:** `from zizkadb import ZizkaDB`
 
 ```bash

--- a/wiki/TypeScript-SDK.md
+++ b/wiki/TypeScript-SDK.md
@@ -1,9 +1,9 @@
 # TypeScript SDK
 
-**Package:** `zizkadb-sdk` on npm (**0.2.6**)
+**Package:** `zizkadb-sdk` on npm (**0.2.7**)
 
 ```bash
-npm install zizkadb-sdk@0.2.6
+npm install zizkadb-sdk
 ```
 
 ## Quickstart
@@ -30,7 +30,7 @@ chain.print()
 | `ZIZKADB_API_KEY` | Cloud API key |
 | `AGENTDB_API_KEY` | Legacy alias |
 | `ZIZKADB_HOST` | Self-hosted URL |
-| `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping after first `log()`) |
+| `ZIZKADB_TELEMETRY` | Set `false` to opt out |
 
 Core HTTP client only — LangChain and CrewAI adapters are Python packages (`zizkadb-langchain`, `zizkadb-crewai`).
 


### PR DESCRIPTION
## Summary
- Update **GitHub-facing docs only** for published packages: SDK **0.2.7**, MCP **0.1.6**, LangChain/CrewAI **0.1.2**
- README, CHANGELOG, wiki, CONNECT, examples, templates, integration READMEs
- **No site/dashboard changes** (`/docs`, trust page, marketing strip) — those go on zizkadb-cloud

## Test plan
- [ ] Review README and wiki version pins
- [ ] Confirm CHANGELOG 0.2.7 entry matches PyPI/npm
