### PR TITLE
docs: show SDK 0.2.7 versions under README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Open-source **audit trail for AI agents** — causal lineage, session replay, an
 [![CrewAI](https://img.shields.io/pypi/v/zizkadb-crewai?label=CrewAI)](https://pypi.org/project/zizkadb-crewai/)
 [![MCP](https://img.shields.io/pypi/v/zizkadb-mcp?label=MCP)](https://pypi.org/project/zizkadb-mcp/)
 
+<sub>Current packages: SDK <strong>0.2.7</strong> · MCP <strong>0.1.6</strong> · LangChain/CrewAI <strong>0.1.2</strong></sub>
+
 **[Try free ↓](#open-source-self-host)** · **[START_HERE.md](START_HERE.md)** · **[CONNECT.md](CONNECT.md)** · **[Pro ↓](#pro-managed-cloud)** · **[Docs](https://db.zizka.ai/docs)**
 
 </div>


### PR DESCRIPTION
## Summary
- Add static version line under README header badges: SDK **0.2.7**, MCP **0.1.6**, LangChain/CrewAI **0.1.2**
- PyPI/npm badges are dynamic and may cache; this makes current releases visible immediately

## Note
The orange **release** badge stays at v0.2.6 until a GitHub Release `v0.2.7` is published.

## Test plan
- [ ] README renders the new sub line under badges