### PR TITLE
docs+test: wiki DX accuracy and missing helper coverage

### DIFF
--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -51,7 +51,17 @@ ZIZKADB_RUN_INTEGRATION=1 pytest core/tests/test_integration_selfhost.py -v
 | `test_community.py` | Community posts, honeypot, rate limit |
 | `test_marketing_subscriptions.py` | Marketing subscription create + honeypot |
 | `test_settings_auth.py` | Settings embeddings requires dashboard session |
-| `test_deep_health.py` | Deep health dependency status |
+| `test_a2a.py` | Agent-to-agent protocol routes |
+| `test_reports.py` | Per-agent report payload |
+| `test_suggestions.py` | Suggestions extractor / grounding |
+| `test_token_usage.py` | Token/cost aggregation |
+| `test_token_optimization.py` | Deterministic token-waste detectors |
+| `test_api_key_agent_bind.py` | First-use bind of a key to one agent |
+| `test_invalid_api_key.py` | Rejected / malformed API keys |
+| `test_tenant_isolation.py` | Cross-tenant read isolation |
+| `test_exceptions.py` | HTTP exception handlers |
+| `test_secret_fallback_security.py` | Secret fallback hardening |
+| `test_telemetry.py` | Anonymous usage telemetry |
 
 ## CI gates
 
@@ -71,5 +81,5 @@ Optional (weekly / manual): `.github/workflows/integration.yml` — full stack i
 
 - Python tests: use `pytest` + `pytest-asyncio`. Fixtures in `core/tests/conftest.py`.
 - Mark integration tests: `@pytest.mark.integration`
-- TypeScript SDK: Jest in `sdk/typescript/src/tests/`
+- TypeScript SDK: Vitest in `sdk/typescript/` (`npm test`)
 - MCP tests: pytest in `mcp/tests/test_server.py`

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -2,7 +2,7 @@
 
 > Single source of truth for the Dashboard module. Reverse-engineered directly from the codebase.
 >
-> **Last verified:** 2026-08-21 · API key limits: Self-Hosted 1 / Pro 2 / Team 5 / Enterprise 50 (enforcement via `API_KEY_LIMITS_ENFORCED`, default OFF; self-hosted resolved via `DEPLOYMENT_MODE`, not `users.plan`). Self-host embeddings off unless `EMBEDDINGS_ENABLED=true`.
+> **Last verified:** 2026-08-25 · API key limits: Self-Hosted 1 / Pro 2 / Team 5 / Enterprise 50 (enforcement via `API_KEY_LIMITS_ENFORCED`, default OFF; self-hosted resolved via `DEPLOYMENT_MODE`, not `users.plan`). Self-host embeddings off unless `EMBEDDINGS_ENABLED=true`.
 >
 > **OSS scope:** This repo ships the tenant dashboard and public marketing/community surfaces. The managed-cloud **operator admin console** (`/admin`, `/v1/admin/*`) is **not** in this tree — §16 / §20.5 admin sections are historical reference only.
 >
@@ -458,7 +458,7 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 
 ## 15. Local Development, Build & Environment
 
-**Scripts (`package.json`):** `dev` (`next dev`), `build` (`next build`), `start` (`next start`), `lint` (`next lint`). **No `test` script — there are no tests.**
+**Scripts (`package.json`):** `dev` (`next dev`), `build` (`next build`), `start` (`next start`), `lint` (`next lint`), `test` (`vitest run`), `test:watch` (`vitest`). CI runs lint + vitest + build.
 
 **Build output:** `output: 'standalone'` (`next.config.mjs`) for containerized deploy.
 

--- a/dashboard/hooks/useResendCooldown.test.tsx
+++ b/dashboard/hooks/useResendCooldown.test.tsx
@@ -1,0 +1,36 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useResendCooldown } from './useResendCooldown'
+
+describe('useResendCooldown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('starts able to resend and locks for the configured window', () => {
+    const { result } = renderHook(() => useResendCooldown(3))
+    expect(result.current.canResend).toBe(true)
+    expect(result.current.cooldown).toBe(0)
+
+    act(() => {
+      result.current.startCooldown()
+    })
+    expect(result.current.canResend).toBe(false)
+    expect(result.current.cooldown).toBe(3)
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+    expect(result.current.cooldown).toBe(2)
+
+    act(() => {
+      vi.advanceTimersByTime(2000)
+    })
+    expect(result.current.cooldown).toBe(0)
+    expect(result.current.canResend).toBe(true)
+  })
+})

--- a/dashboard/lib/auth-errors.test.ts
+++ b/dashboard/lib/auth-errors.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { AuthRequestError } from './api'
+import {
+  authErrorMessage,
+  isAlreadyRegisteredError,
+  isGdprConsentError,
+  isNoAccountError,
+} from './auth-errors'
+
+describe('auth-errors classifiers', () => {
+  it('isNoAccountError matches 404 AuthRequestError', () => {
+    expect(isNoAccountError(new AuthRequestError('No account', 404))).toBe(true)
+    expect(isNoAccountError(new AuthRequestError('Conflict', 409))).toBe(false)
+    expect(isNoAccountError(new Error('No account'))).toBe(false)
+  })
+
+  it('isAlreadyRegisteredError matches 409 AuthRequestError', () => {
+    expect(isAlreadyRegisteredError(new AuthRequestError('Taken', 409))).toBe(true)
+    expect(isAlreadyRegisteredError(new AuthRequestError('No account', 404))).toBe(false)
+  })
+
+  it('isGdprConsentError matches 401 messages that mention GDPR consent', () => {
+    expect(
+      isGdprConsentError(new AuthRequestError('GDPR consent required', 401)),
+    ).toBe(true)
+    expect(isGdprConsentError(new AuthRequestError('Invalid token', 401))).toBe(false)
+    expect(
+      isGdprConsentError(new AuthRequestError('GDPR consent required', 400)),
+    ).toBe(false)
+  })
+
+  it('authErrorMessage prefers Error.message then fallback', () => {
+    expect(authErrorMessage(new AuthRequestError('OTP expired', 401), 'fallback')).toBe(
+      'OTP expired',
+    )
+    expect(authErrorMessage(new Error('network'), 'fallback')).toBe('network')
+    expect(authErrorMessage('not-an-error', 'fallback')).toBe('fallback')
+  })
+})

--- a/dashboard/lib/signup-funnel.test.ts
+++ b/dashboard/lib/signup-funnel.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  SIGNUP_CONSENT_GDPR_KEY,
+  SIGNUP_CONSENT_MARKETING_KEY,
+  SIGNUP_PLAN_KEY,
+  clearSignupSession,
+  getStoredSignupPlan,
+  hasSignupConsent,
+} from './signup-funnel'
+
+describe('signup-funnel helpers', () => {
+  afterEach(() => {
+    sessionStorage.clear()
+  })
+
+  it('hasSignupConsent is true only when GDPR flag is 1', () => {
+    expect(hasSignupConsent()).toBe(false)
+    sessionStorage.setItem(SIGNUP_CONSENT_GDPR_KEY, '0')
+    expect(hasSignupConsent()).toBe(false)
+    sessionStorage.setItem(SIGNUP_CONSENT_GDPR_KEY, '1')
+    expect(hasSignupConsent()).toBe(true)
+  })
+
+  it('getStoredSignupPlan accepts only pro or team', () => {
+    expect(getStoredSignupPlan()).toBeNull()
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, 'enterprise')
+    expect(getStoredSignupPlan()).toBeNull()
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, 'pro')
+    expect(getStoredSignupPlan()).toBe('pro')
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, 'team')
+    expect(getStoredSignupPlan()).toBe('team')
+  })
+
+  it('clearSignupSession removes plan and both consent keys', () => {
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, 'pro')
+    sessionStorage.setItem(SIGNUP_CONSENT_GDPR_KEY, '1')
+    sessionStorage.setItem(SIGNUP_CONSENT_MARKETING_KEY, '1')
+    clearSignupSession()
+    expect(sessionStorage.getItem(SIGNUP_PLAN_KEY)).toBeNull()
+    expect(sessionStorage.getItem(SIGNUP_CONSENT_GDPR_KEY)).toBeNull()
+    expect(sessionStorage.getItem(SIGNUP_CONSENT_MARKETING_KEY)).toBeNull()
+  })
+})

--- a/wiki/Agents-and-API-Keys.md
+++ b/wiki/Agents-and-API-Keys.md
@@ -26,21 +26,23 @@ When you **Create agent** on the dashboard:
 
 ### Create more keys for one agent
 
-Open agent → **API keys** → **New key**
+**Settings** (header gear) with that agent selected → **New key**.
+
+OSS self-host typically allows one active key (plan cap 1 when `API_KEY_LIMITS_ENFORCED` is on). Managed Pro/Team can add more.
 
 ### Revoke a key
 
-Agent page or Settings overview → trash icon. Revoked immediately.
+Settings → trash icon. Takes effect immediately.
 
 ### Delete an agent
 
-Deletes agent + all events + all its keys. Cannot be undone.
+Deletes the agent, its events, and its keys. Cannot be undone.
 
 ---
 
 ## Tenant-wide keys (multi-agent apps)
 
-**Settings → Tenant-wide API key**
+**Managed cloud only:** **Settings → Tenant-wide API key**. OSS uses per-agent keys.
 
 - No agent scope (`agent_id` is null)
 - One key can log to `conv-user1`, `conv-user2`, `sales-agent-xyz`, etc.
@@ -74,7 +76,7 @@ Keys are SHA-256 hashed server-side. Full key shown **once** at creation.
 
 | Mistake | Result |
 |---------|--------|
-| `API=...` instead of `AGENTDB_API_KEY=` | Key ignored |
+| `API=...` instead of `ZIZKADB_API_KEY=` | Key ignored (`AGENTDB_API_KEY` still works as a legacy alias) |
 | Space or line break in key | 401 Invalid API key |
 | Key for `agent-A`, code logs `agent-B` | 403 Agent mismatch |
 | Only `pm2 restart` after `.env` change | Stale baked env — run `npm run build` for Next.js apps |
@@ -87,6 +89,6 @@ Means **no successful authenticated request** hit the API with that key.
 
 - 401 = key never reached server correctly
 - 403 = key reached server but wrong agent name (may still update last_used)
-- Settings **Send test event** uses JWT, not your API key, and logs to `dashboard-connection-test`
+- Managed cloud: Settings **Send test event** uses JWT, not your API key, and logs to `dashboard-connection-test`
 
-Use **Test agent** on the agent page to verify that specific agent.
+Use **Test agent** on Settings (with that agent selected in the header) to verify the key for that agent.

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,6 +1,6 @@
 # ZizkaDB Wiki
 
-**Dont Observe - Audit your AI Agent.** — causal lineage, time travel, semantic search, and dashboards for AI agents.
+**Don't observe — audit your AI agent.** Causal lineage, time travel, semantic search, and dashboards for AI agents.
 
 | Resource | Link |
 |----------|------|
@@ -11,7 +11,7 @@
 | PyPI MCP | [zizkadb-mcp](https://pypi.org/project/zizkadb-mcp/) **0.1.6** |
 | PyPI LangChain | [zizkadb-langchain](https://pypi.org/project/zizkadb-langchain/) **0.1.2** |
 | PyPI CrewAI | [zizkadb-crewai](https://pypi.org/project/zizkadb-crewai/) **0.1.2** |
-| npm SDK | [zizkadb-sdk](https://www.npmjs.com/package/zizkadb-sdk) **0.2.5** |
+| npm SDK | [zizkadb-sdk](https://www.npmjs.com/package/zizkadb-sdk) **0.2.7** |
 | Docs site | [db.zizka.ai/docs](https://db.zizka.ai/docs) |
 | Managed cloud (optional) | [db.zizka.ai/signup](https://db.zizka.ai/signup) |
 

--- a/wiki/MCP-and-Cursor.md
+++ b/wiki/MCP-and-Cursor.md
@@ -65,6 +65,11 @@ Dev key `zizkadb_dev_local` is auto-injected on localhost (matches `DEV_API_KEY`
 | `why` | Causal chain |
 | `query_events` | List/filter recent events |
 | `time_travel` | State at timestamp |
+| `get_baseline` | Behavioral baseline vs recent sessions |
+| `get_token_usage` | Token/cost aggregation for an agent |
+| `get_token_optimization` | Deterministic token-waste suggestions |
+| `memory_diff` | What changed after a session |
+| `forget` | GDPR-style delete by metadata field |
 
 ## Example prompt in Cursor
 

--- a/wiki/REST-API.md
+++ b/wiki/REST-API.md
@@ -77,12 +77,34 @@ GET /v1/events/{event_id}/why?depth=10
 
 **API key creation** requires a dashboard login session (JWT), not an API key. Active keys per tenant are limited by plan (Self-Hosted 1, Pro 2, Team 5, Enterprise 50; unknown/no plan unlimited); exceeding the limit returns `409` with `{detail:{code:"api_key_limit_reached", plan, limit, used}}`. Enforcement is gated by the `API_KEY_LIMITS_ENFORCED` server flag; self-hosted deployments resolve their plan via `DEPLOYMENT_MODE=self_hosted`, not the `users.plan` column.
 
+## Memory
+
+| Method | Path | Description |
+|--------|------|-------------|
+| POST | `/v1/memory/context` | Prompt-ready context for an agent (`agent` required) |
+| GET | `/v1/memory/diff` | What changed after a session |
+| DELETE | `/v1/memory/forget` | GDPR-style delete by metadata field |
+
+Scoped API keys must match the `agent` on these routes (`assert_agent_allowed`).
+
+## Analytics (per agent)
+
+| Method | Path | Description |
+|--------|------|-------------|
+| GET | `/v1/agents/{id}/report` | Date-ranged report (`from`, `to`, `granularity`) |
+| GET | `/v1/agents/{id}/suggestions` | Evidence-backed AI suggestions (`refresh=1` bypasses cache) |
+| GET | `/v1/agents/{id}/baseline` | Behavioral baseline |
+| GET | `/v1/agents/{id}/token-usage` | Token/cost aggregation |
+| GET | `/v1/agents/{id}/token-optimization` | Deterministic token-waste detectors |
+
 ## Health
 
 ```http
 GET /health
 → {"status":"ok","version":"0.1.0"}
 ```
+
+`GET /health/deep` checks Postgres, Redis, and Qdrant. Use that for real dependency status; `/health` is liveness only.
 
 ## Common status codes
 
@@ -122,4 +144,4 @@ Content-Type: application/json
 | `source` | no | Allowlist: `enterprise`, `landing`, `newsletter` — invalid → **422** |
 | `botcheck` | no | Honeypot; non-empty → **400** |
 
-Response **201:** `{ "id": "<uuid>", "created_at": "<iso>" }`. Rate limit: 8 requests / hour / IP (**429**). Admin list: `GET /v1/admin/demo-requests` (JWT, founder OTP).
+Response **201:** `{ "id": "<uuid>", "created_at": "<iso>" }`. Rate limit: 8 requests / hour / IP (**429**). Listing demo requests is a managed-cloud operator action — there is no `/v1/admin` router in this OSS repo.

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -10,6 +10,7 @@
 | `docker compose ... --build` hangs/fails on `load metadata for docker.io/library/...` with `DeadlineExceeded` | Registry metadata check timed out even though the base image is already cached locally. Pre-pull once: `docker pull python:3.12-slim && docker pull node:20-alpine`, then re-run `bash scripts/setup-local.sh` — the build reuses the cached layers and finishes in seconds. |
 | Port 8000 / 3001 in use | Stop other services or edit compose ports |
 | Dashboard empty after demo | Login → **Open my dashboard →** → agent **support-bot** |
+| `/health` is 200 but events fail | `/health` is liveness only. Check `curl http://localhost:8000/health/deep` for Postgres/Redis/Qdrant |
 | `zizkadb demo` fails | Ensure API healthy: `curl http://localhost:8000/health` |
 
 ---
@@ -24,15 +25,15 @@ No successful authenticated request reached the API.
 | Space in key | Re-paste as one continuous line |
 | Wrong URL | Must be `https://db.zizka.ai/v1/events` not `/v1_` |
 | Placeholder in curl | Use real key, not `YOUR_KEY` |
-| Revoked key | Create new key on agent page |
+| Revoked key | Create a new key in Settings |
 
 Test from server:
 
 ```bash
 cd ~/your-app
-export $(grep -E '^AGENTDB_API_KEY=' .env | xargs)
+export $(grep -E '^ZIZKADB_API_KEY=' .env | xargs)
 curl -s -w "\nHTTP %{http_code}\n" \
-  -H "Authorization: Bearer ${AGENTDB_API_KEY}" \
+  -H "Authorization: Bearer ${ZIZKADB_API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"agent":"YOUR_AGENT","event":"test","data":{}}' \
   https://db.zizka.ai/v1/events


### PR DESCRIPTION
## Summary
- Fix wiki drift against current product: npm 0.2.7, Settings-based API keys, full MCP tool list, memory/analytics REST routes, no OSS `/v1/admin`.
- Correct KB §15 (vitest exists) and the agent test-file map (drop phantom `test_deep_health.py`, Vitest not Jest).
- Add vitest coverage for signup-funnel helpers, auth-error classifiers, and the OTP resend cooldown hook.

## Test plan
- [ ] Skim wiki Home, Agents-and-API-Keys, MCP-and-Cursor, REST-API, Troubleshooting
- [ ] Confirm Settings is where keys / Test agent live (no agent-detail page)
- [ ] `cd dashboard && npm test` — new files: `signup-funnel.test.ts`, `auth-errors.test.ts`, `useResendCooldown.test.tsx`


Made with [Cursor](https://cursor.com)