### PR TITLE
refactor(dashboard): share signup funnel guard

### DIFF
--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -431,7 +431,7 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 
 1. **Duplicate plan definitions** (landing, `/signup/plan`, backend `PLAN_CATALOG`) → drift risk; consolidate on one API or shared config.
 2. **No shared trial-CTA component** — 13 inline links; a `<StartTrialButton plan?>` would centralize analytics + copy.
-3. **Repeated funnel-guard logic** (`sessionStorage` plan/consent checks re-implemented in `/signup`, `/signup/start`) → extract a hook (`useSignupFunnelGuard`).
+3. ~~**Repeated funnel-guard logic**~~ — **done 2026-08-25:** `useSignupFunnelGuard` (`hooks/useSignupFunnelGuard.ts`) plus `signupOtpRedirect` / `resolveSignupStartPlan` in `lib/signup-funnel.ts`. `/signup` and `/signup/start` share the same plan/consent redirects and keep the fallback gate so the form does not flash.
 4. **Duplicated OTP form** (`login` vs `signup` are ~90% identical) → shared `<OtpForm/>`.
 5. **No analytics/telemetry** on funnel steps → hard to measure drop-off.
 6. **No React Query/SWR** → manual polling + no dedupe/caching; billing status fetched on mount by `TenantPlanBanner`.

--- a/dashboard/app/signup/page.tsx
+++ b/dashboard/app/signup/page.tsx
@@ -12,12 +12,12 @@ import {
 import { setToken } from "@/lib/auth";
 import { OTP_LENGTH } from "@/lib/constants";
 import { useResendCooldown } from "@/hooks/useResendCooldown";
+import { useSignupFunnelGuard } from "@/hooks/useSignupFunnelGuard";
 import {
   clearSignupSession,
   getStoredSignupPlan,
   hasSignupConsent,
   SIGNUP_CONSENT_MARKETING_KEY,
-  SIGNUP_PLAN_KEY,
 } from "@/lib/signup-funnel";
 import { BrandLogo } from "@/components/BrandLogo";
 import {
@@ -72,10 +72,7 @@ function SignupForm() {
   const verifyLock = useRef(false);
   const verifyFormRef = useRef<HTMLFormElement>(null);
   const { cooldown, canResend, startCooldown } = useResendCooldown();
-  // Gate the form render until the guard confirms the user belongs on /signup.
-  // Prevents the email screen from flashing before a redirect to /signup/plan
-  // or /signup/start resolves. Monotonic: only ever set true.
-  const [checked, setChecked] = useState(false);
+  const { ready: checked } = useSignupFunnelGuard("otp");
 
   useEffect(() => {
     // Always start from email step when entering /signup to avoid stale OTP view.
@@ -83,25 +80,7 @@ function SignupForm() {
     setOtp("");
     setError("");
     setAlreadyRegistered(false);
-
-    const planParam = searchParams.get("plan");
-    if (planParam === "pro" || planParam === "team") {
-      sessionStorage.setItem(SIGNUP_PLAN_KEY, planParam);
-    }
-
-    const stored = getStoredSignupPlan();
-    if (!stored) {
-      router.replace("/signup/plan");
-      return;
-    }
-
-    if (!hasSignupConsent()) {
-      router.replace(`/signup/start?plan=${stored}`);
-      return;
-    }
-
-    setChecked(true);
-  }, [searchParams, router]);
+  }, [searchParams]);
 
   useEffect(() => {
     if (

--- a/dashboard/app/signup/start/page.tsx
+++ b/dashboard/app/signup/start/page.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { Suspense, useEffect, useState } from 'react'
-import { useRouter, useSearchParams } from 'next/navigation'
+import { Suspense, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import { BrandLogo } from '@/components/BrandLogo'
-import { SIGNUP_CONSENT_GDPR_KEY, SIGNUP_CONSENT_MARKETING_KEY, SIGNUP_PLAN_KEY, getStoredSignupPlan } from '@/lib/signup-funnel'
+import { useSignupFunnelGuard } from '@/hooks/useSignupFunnelGuard'
+import { SIGNUP_CONSENT_GDPR_KEY, SIGNUP_CONSENT_MARKETING_KEY } from '@/lib/signup-funnel'
 import { authPage, authCard, authTitle, authSubtitle, authSubmitBtn, authMutedLink } from '@/components/marketing/auth-styles'
 import { M } from '@/components/marketing/marketing-theme'
 
@@ -44,24 +45,9 @@ export default function SignupStartPage() {
 
 function SignupStartInner() {
   const router = useRouter()
-  const searchParams = useSearchParams()
-  const [plan, setPlan] = useState<'pro' | 'team' | null>(null)
+  const { ready, plan } = useSignupFunnelGuard('consent')
   const [gdprConsent, setGdprConsent] = useState(false)
   const [marketingConsent, setMarketingConsent] = useState(false)
-
-  useEffect(() => {
-    const planParam = searchParams.get('plan')
-    const resolved =
-      planParam === 'pro' || planParam === 'team'
-        ? planParam
-        : getStoredSignupPlan()
-    if (!resolved) {
-      router.replace('/signup/plan')
-      return
-    }
-    sessionStorage.setItem(SIGNUP_PLAN_KEY, resolved)
-    setPlan(resolved)
-  }, [searchParams, router])
 
   function handleContinue() {
     if (!plan || !gdprConsent) return
@@ -70,7 +56,7 @@ function SignupStartInner() {
     router.push(`/signup?plan=${plan}`)
   }
 
-  if (!plan) return <StartFallback />
+  if (!ready || !plan) return <StartFallback />
 
   return (
     <div style={{

--- a/dashboard/hooks/useSignupFunnelGuard.test.tsx
+++ b/dashboard/hooks/useSignupFunnelGuard.test.tsx
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import { SIGNUP_CONSENT_GDPR_KEY, SIGNUP_PLAN_KEY } from '@/lib/signup-funnel'
+import { useSignupFunnelGuard } from './useSignupFunnelGuard'
+
+const replace = vi.fn()
+let currentParams = new URLSearchParams()
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ replace }),
+  useSearchParams: () => currentParams,
+}))
+
+beforeEach(() => {
+  replace.mockReset()
+  currentParams = new URLSearchParams()
+  sessionStorage.clear()
+})
+
+describe('useSignupFunnelGuard', () => {
+  it('otp step with no plan redirects to /signup/plan', () => {
+    renderHook(() => useSignupFunnelGuard('otp'))
+    expect(replace).toHaveBeenCalledWith('/signup/plan')
+  })
+
+  it('otp step with plan but no consent redirects to /signup/start', () => {
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, 'pro')
+    renderHook(() => useSignupFunnelGuard('otp'))
+    expect(replace).toHaveBeenCalledWith('/signup/start?plan=pro')
+  })
+
+  it('otp step persists ?plan= and is ready when consent exists', () => {
+    currentParams = new URLSearchParams('plan=team')
+    sessionStorage.setItem(SIGNUP_CONSENT_GDPR_KEY, '1')
+    const { result } = renderHook(() => useSignupFunnelGuard('otp'))
+    expect(replace).not.toHaveBeenCalled()
+    expect(result.current.ready).toBe(true)
+    expect(result.current.plan).toBe('team')
+    expect(sessionStorage.getItem(SIGNUP_PLAN_KEY)).toBe('team')
+  })
+
+  it('consent step with no plan redirects to /signup/plan', () => {
+    const { result } = renderHook(() => useSignupFunnelGuard('consent'))
+    expect(replace).toHaveBeenCalledWith('/signup/plan')
+    expect(result.current.ready).toBe(false)
+  })
+})

--- a/dashboard/hooks/useSignupFunnelGuard.ts
+++ b/dashboard/hooks/useSignupFunnelGuard.ts
@@ -1,0 +1,53 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useRouter, useSearchParams } from 'next/navigation'
+import {
+  getStoredSignupPlan,
+  persistSignupPlanParam,
+  resolveSignupStartPlan,
+  signupOtpRedirect,
+} from '@/lib/signup-funnel'
+
+export type SignupFunnelStep = 'otp' | 'consent'
+
+/**
+ * Shared plan/consent gate for /signup (OTP) and /signup/start (consent).
+ * Returns ready=false until the user belongs on this step (pages should
+ * render a fallback so the form never flashes before a redirect).
+ */
+export function useSignupFunnelGuard(step: SignupFunnelStep): {
+  ready: boolean
+  plan: 'pro' | 'team' | null
+} {
+  const router = useRouter()
+  const searchParams = useSearchParams()
+  const [ready, setReady] = useState(false)
+  const [plan, setPlan] = useState<'pro' | 'team' | null>(null)
+
+  useEffect(() => {
+    const planParam = searchParams.get('plan')
+
+    if (step === 'otp') {
+      persistSignupPlanParam(planParam)
+      const redirect = signupOtpRedirect()
+      if (redirect) {
+        router.replace(redirect)
+        return
+      }
+      setPlan(getStoredSignupPlan())
+      setReady(true)
+      return
+    }
+
+    const resolved = resolveSignupStartPlan(planParam)
+    if (!resolved) {
+      router.replace('/signup/plan')
+      return
+    }
+    setPlan(resolved)
+    setReady(true)
+  }, [searchParams, router, step])
+
+  return { ready, plan }
+}

--- a/dashboard/lib/signup-funnel.test.ts
+++ b/dashboard/lib/signup-funnel.test.ts
@@ -6,6 +6,9 @@ import {
   clearSignupSession,
   getStoredSignupPlan,
   hasSignupConsent,
+  persistSignupPlanParam,
+  resolveSignupStartPlan,
+  signupOtpRedirect,
 } from './signup-funnel'
 
 describe('signup-funnel helpers', () => {
@@ -29,6 +32,28 @@ describe('signup-funnel helpers', () => {
     expect(getStoredSignupPlan()).toBe('pro')
     sessionStorage.setItem(SIGNUP_PLAN_KEY, 'team')
     expect(getStoredSignupPlan()).toBe('team')
+  })
+
+  it('persistSignupPlanParam stores only pro or team', () => {
+    persistSignupPlanParam('enterprise')
+    expect(sessionStorage.getItem(SIGNUP_PLAN_KEY)).toBeNull()
+    persistSignupPlanParam('pro')
+    expect(sessionStorage.getItem(SIGNUP_PLAN_KEY)).toBe('pro')
+  })
+
+  it('signupOtpRedirect sends to plan, then consent, then null', () => {
+    expect(signupOtpRedirect()).toBe('/signup/plan')
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, 'team')
+    expect(signupOtpRedirect()).toBe('/signup/start?plan=team')
+    sessionStorage.setItem(SIGNUP_CONSENT_GDPR_KEY, '1')
+    expect(signupOtpRedirect()).toBeNull()
+  })
+
+  it('resolveSignupStartPlan prefers URL plan and persists it', () => {
+    expect(resolveSignupStartPlan(null)).toBeNull()
+    expect(resolveSignupStartPlan('pro')).toBe('pro')
+    expect(sessionStorage.getItem(SIGNUP_PLAN_KEY)).toBe('pro')
+    expect(resolveSignupStartPlan('enterprise')).toBe('pro')
   })
 
   it('clearSignupSession removes plan and both consent keys', () => {

--- a/dashboard/lib/signup-funnel.ts
+++ b/dashboard/lib/signup-funnel.ts
@@ -21,3 +21,35 @@ export function getStoredSignupPlan(): 'pro' | 'team' | null {
   const stored = sessionStorage.getItem(SIGNUP_PLAN_KEY)
   return stored === 'pro' || stored === 'team' ? stored : null
 }
+
+/** Persist `?plan=pro|team` from the URL. Ignores any other value. */
+export function persistSignupPlanParam(planParam: string | null): void {
+  if (typeof window === 'undefined') return
+  if (planParam === 'pro' || planParam === 'team') {
+    sessionStorage.setItem(SIGNUP_PLAN_KEY, planParam)
+  }
+}
+
+/**
+ * Where `/signup` (OTP) should send the user, or null if they belong there.
+ * Call after persistSignupPlanParam so `?plan=` is already stored.
+ */
+export function signupOtpRedirect(): string | null {
+  const stored = getStoredSignupPlan()
+  if (!stored) return '/signup/plan'
+  if (!hasSignupConsent()) return `/signup/start?plan=${stored}`
+  return null
+}
+
+/**
+ * Plan for `/signup/start`. Persists a valid URL or stored plan.
+ * Returns null when the user must go back to `/signup/plan`.
+ */
+export function resolveSignupStartPlan(planParam: string | null): 'pro' | 'team' | null {
+  if (typeof window === 'undefined') return null
+  const resolved =
+    planParam === 'pro' || planParam === 'team' ? planParam : getStoredSignupPlan()
+  if (!resolved) return null
+  sessionStorage.setItem(SIGNUP_PLAN_KEY, resolved)
+  return resolved
+}


### PR DESCRIPTION
## Summary
- Extract plan/consent redirect helpers so `/signup` and `/signup/start` no longer copy the same sessionStorage checks.
- Add `useSignupFunnelGuard` and keep the fallback gate so the OTP/consent form does not flash before a redirect.
- Mark KB §13 item 3 done.

## Test plan
- [ ] Open `/signup` with empty session → lands on `/signup/plan`
- [ ] Pick a plan, skip consent → `/signup` redirects to `/signup/start`
- [ ] Complete consent → OTP page renders (no flash of the email form)
- [ ] `cd dashboard && npm test` — `signup-funnel.test.ts` and `useSignupFunnelGuard.test.tsx`


Made with [Cursor](https://cursor.com)