### PR TITLE
refactor(dashboard): share StartTrialButton for managed-cloud CTAs

### DIFF
--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -430,7 +430,7 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 ## 13. Areas for Improvement (documented, not changed)
 
 1. **Duplicate plan definitions** (landing, `/signup/plan`, backend `PLAN_CATALOG`) → drift risk; consolidate on one API or shared config.
-2. **No shared trial-CTA component** — 13 inline links; a `<StartTrialButton plan?>` would centralize analytics + copy.
+2. ~~**No shared trial-CTA component**~~ — **done 2026-08-26:** `<StartTrialButton plan?>` (`components/marketing/StartTrialButton.tsx`) plus `startTrialHref()` in `lib/plans.ts`. Landing hero/footer, SiteNav, and managed pricing cards share `/signup/plan` (no plan) or `/signup?plan=`. Docs, login, and trust links are left as-is.
 3. ~~**Repeated funnel-guard logic**~~ — **done 2026-08-25:** `useSignupFunnelGuard` (`hooks/useSignupFunnelGuard.ts`) plus `signupOtpRedirect` / `resolveSignupStartPlan` in `lib/signup-funnel.ts`. `/signup` and `/signup/start` share the same plan/consent redirects and keep the fallback gate so the form does not flash.
 4. **Duplicated OTP form** (`login` vs `signup` are ~90% identical) → shared `<OtpForm/>`.
 5. **No analytics/telemetry** on funnel steps → hard to measure drop-off.
@@ -443,7 +443,7 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 
 ## 14. Potential Risks
 
-1. **Copy inconsistency on credit card:** landing pricing may still say "card required" while funnel says "No credit card required" — align copy when payment is reintroduced.
+1. ~~**Copy inconsistency on credit card:**~~ — **checked 2026-08-26:** funnel says "No credit card required"; landing pricing cards have no "card required" copy. Revisit if checkout is reintroduced.
 2. **Access token is XSS-exposed:** the **access** JWT lives in `localStorage` + a non-`HttpOnly` (JS-readable) cookie. (The **refresh** token is a proper `HttpOnly` cookie set by the backend — `core/api/auth.py:104-112` — so it is not JS-readable.) A structural fix would move the access token to an `HttpOnly` server-set cookie too. Middleware trusts the access cookie only.
 3. **Auth source mismatch:** middleware reads the access cookie, app code reads localStorage. If one is cleared (cookie expiry vs localStorage), a user can pass the edge guard but fail client calls, or vice-versa.
 4. ~~**`selectBillingPlan` best-effort swallow**~~ — **fixed:** signup now awaits `selectBillingPlan` and surfaces errors instead of silent `catch {}`.

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -9,6 +9,7 @@ import { MarketingShell } from "@/components/marketing/MarketingShell";
 import { HeroOperationalField } from "@/components/marketing/HeroOperationalField";
 import { LiveDashboardDemo } from "@/components/marketing/LiveDashboardDemo";
 import { PricingCard } from "@/components/marketing/PricingCard";
+import { StartTrialButton } from "@/components/marketing/StartTrialButton";
 import { LANDING_PRICING_PLANS } from "@/components/marketing/pricing-plans";
 import { BRAND } from "@/components/brand";
 import {
@@ -130,9 +131,9 @@ export default function LandingPage() {
               marginBottom: 48,
             }}
           >
-            <Link href="/signup" style={primaryBtn}>
+            <StartTrialButton style={primaryBtn}>
               Use managed cloud
-            </Link>
+            </StartTrialButton>
             <a
               href={GITHUB_URL}
               target="_blank"
@@ -196,9 +197,9 @@ export default function LandingPage() {
               </p>
               <LiveDashboardDemo variant="managed" autoRotateMs={6000} />
               <div style={{ marginTop: 16 }}>
-                <Link href="/signup" style={{ ...primaryBtn, fontSize: 14, padding: "12px 22px" }}>
+                <StartTrialButton style={{ ...primaryBtn, fontSize: 14, padding: "12px 22px" }}>
                   Get started
-                </Link>
+                </StartTrialButton>
               </div>
             </div>
           </div>
@@ -326,9 +327,9 @@ export default function LandingPage() {
               title="Debug production incidents"
               body="Prompt change broke behavior? Replay the full session, trace the decision chain, find root cause."
               actions={
-                <Link href="/signup" style={{ ...primaryBtn, fontSize: 14, padding: "12px 22px" }}>
+                <StartTrialButton style={{ ...primaryBtn, fontSize: 14, padding: "12px 22px" }}>
                   Get started
-                </Link>
+                </StartTrialButton>
               }
             />
             <FeatureCard
@@ -434,9 +435,9 @@ export default function LandingPage() {
               flexWrap: "wrap",
             }}
           >
-            <Link href="/signup" style={primaryBtn}>
+            <StartTrialButton style={primaryBtn}>
               Use managed cloud
-            </Link>
+            </StartTrialButton>
             <Link href="/docs" style={ghostBtn}>
               Read the docs
             </Link>

--- a/dashboard/components/SiteNav.tsx
+++ b/dashboard/components/SiteNav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useState } from "react";
 import type { CSSProperties } from "react";
 import { BrandLogo } from "./BrandLogo";
+import { StartTrialButton } from "./marketing/StartTrialButton";
 import {
   BRAND,
   BRAND_DARK,
@@ -159,9 +160,9 @@ export function SiteNav({ active, suffix }: SiteNavProps) {
           >
             Sign in
           </Link>
-          <Link href="/signup" style={brandCtaStyle}>
+          <StartTrialButton style={brandCtaStyle}>
             Get started
-          </Link>
+          </StartTrialButton>
         </div>
 
         <button
@@ -226,13 +227,12 @@ export function SiteNav({ active, suffix }: SiteNavProps) {
               >
                 Sign in
               </Link>
-              <Link
-                href="/signup"
+              <StartTrialButton
                 onClick={() => setMenuOpen(false)}
                 style={{ ...brandCtaStyle, justifyContent: "center", width: "100%" }}
               >
                 Get started
-              </Link>
+              </StartTrialButton>
             </div>
           </div>
         </div>

--- a/dashboard/components/marketing/StartTrialButton.tsx
+++ b/dashboard/components/marketing/StartTrialButton.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+import type { ManagedPlanId } from "@/lib/plans";
+import { startTrialHref } from "@/lib/plans";
+
+/**
+ * Managed-cloud trial CTA. Pass `plan` to skip the picker (`/signup?plan=`).
+ * Callers keep their own styles — this only centralizes the href.
+ */
+export function StartTrialButton({
+  plan,
+  children,
+  style,
+  className,
+  onClick,
+}: {
+  plan?: ManagedPlanId;
+  children: ReactNode;
+  style?: CSSProperties;
+  className?: string;
+  onClick?: () => void;
+}) {
+  return (
+    <Link href={startTrialHref(plan)} style={style} className={className} onClick={onClick}>
+      {children}
+    </Link>
+  );
+}

--- a/dashboard/components/marketing/pricing-plans.ts
+++ b/dashboard/components/marketing/pricing-plans.ts
@@ -10,7 +10,7 @@ export interface PricingPlan {
   note?: string
 }
 
-import { MANAGED_PLANS } from "@/lib/plans";
+import { MANAGED_PLANS, startTrialHref } from "@/lib/plans";
 
 const managedPricing = MANAGED_PLANS.map(
   (p): PricingPlan => ({
@@ -19,7 +19,7 @@ const managedPricing = MANAGED_PLANS.map(
     sub: p.priceSub,
     features: p.features,
     cta: "Get started",
-    href: `/signup?plan=${p.id}`,
+    href: startTrialHref(p.id),
     highlight: p.highlight,
     ctaPrimary: p.id === "pro",
   }),

--- a/dashboard/lib/plans.test.ts
+++ b/dashboard/lib/plans.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { MANAGED_PLANS, managedPlanById } from './plans'
+import { MANAGED_PLANS, managedPlanById, startTrialHref } from './plans'
 
 describe('MANAGED_PLANS', () => {
   it('defines pro and team with matching API key caps', () => {
@@ -13,5 +13,16 @@ describe('MANAGED_PLANS', () => {
     expect(managedPlanById('pro').id).toBe('pro')
     // @ts-expect-error exercising fallback for invalid runtime input
     expect(managedPlanById('unknown').id).toBe('pro')
+  })
+})
+
+describe('startTrialHref', () => {
+  it('sends plan-less CTAs to the plan picker', () => {
+    expect(startTrialHref()).toBe('/signup/plan')
+  })
+
+  it('sends pro and team CTAs into the funnel with ?plan=', () => {
+    expect(startTrialHref('pro')).toBe('/signup?plan=pro')
+    expect(startTrialHref('team')).toBe('/signup?plan=team')
   })
 })

--- a/dashboard/lib/plans.ts
+++ b/dashboard/lib/plans.ts
@@ -34,3 +34,9 @@ export const MANAGED_PLANS: readonly ManagedPlanMeta[] = [
 export function managedPlanById(id: ManagedPlanId): ManagedPlanMeta {
   return MANAGED_PLANS.find((p) => p.id === id) ?? MANAGED_PLANS[0]
 }
+
+/** Managed-cloud trial CTA. No plan → plan picker; pro/team skip straight into the funnel. */
+export function startTrialHref(plan?: ManagedPlanId): string {
+  if (plan === 'pro' || plan === 'team') return `/signup?plan=${plan}`
+  return '/signup/plan'
+}


### PR DESCRIPTION
## Summary
- Add `startTrialHref` so plan-less CTAs go to `/signup/plan` and pro/team skip to `/signup?plan=`.
- Route landing hero/footer, SiteNav, and pricing cards through `<StartTrialButton>` without restyling.
- Mark KB §13 item 2 done; note §14 credit-card copy is already aligned.

## Test plan
- [ ] Click hero "Use managed cloud" → `/signup/plan`
- [ ] Click a Pro/Team pricing card CTA → `/signup?plan=pro` or `team`
- [ ] Nav "Get started" (desktop + mobile) → `/signup/plan`
- [ ] Docs, login, and trust signup links unchanged


Made with [Cursor](https://cursor.com)