### PR TITLE
Add interactive Why demo to OSS Activity dashboard.

### DIFF
--- a/dashboard/app/dashboard/activity/page.tsx
+++ b/dashboard/app/dashboard/activity/page.tsx
@@ -161,7 +161,9 @@ function ActivityContent() {
         </div>
       )}
 
-      {segment === 'events' && <EventsSegment events={events} stats={stats} />}
+      {segment === 'events' && (
+        <EventsSegment agentId={agentId} events={events} stats={stats} />
+      )}
       {segment === 'sessions' && <SessionsSegment agentId={agentId} />}
       {segment === 'timetravel' && <TimeTravelSegment agentId={agentId} />}
     </>

--- a/dashboard/components/dashboard/EventList.tsx
+++ b/dashboard/components/dashboard/EventList.tsx
@@ -2,7 +2,7 @@
 
 import { memo, useMemo } from 'react'
 import { format } from 'date-fns'
-import { AlertCircle, ChevronDown, ChevronRight } from 'lucide-react'
+import { AlertCircle, ChevronDown, ChevronRight, GitBranch } from 'lucide-react'
 import type { AgentEvent } from '@/lib/api'
 import { eventColor, groupBySession, isErrorEvent } from '@/lib/events'
 import { colors, radii } from '@/lib/design-tokens'
@@ -23,6 +23,7 @@ interface EventRowProps {
   selected: boolean
   expanded: boolean
   onSelect: (e: AgentEvent) => void
+  onOpenWhy?: (e: AgentEvent) => void
   onToggleExpand: (id: string) => void
 }
 
@@ -35,6 +36,7 @@ const EventRow = memo(function EventRow({
   selected,
   expanded,
   onSelect,
+  onOpenWhy,
   onToggleExpand,
 }: EventRowProps) {
   const preview = JSON.stringify(event.data ?? {}).slice(0, 90)
@@ -84,7 +86,26 @@ const EventRow = memo(function EventRow({
               </div>
             </div>
           </div>
-          <div className="flex items-center gap-3 shrink-0 text-xs font-mono" style={{ color: colors.textFaint }}>
+          <div className="flex items-center gap-2 shrink-0 text-xs font-mono" style={{ color: colors.textFaint }}>
+            {onOpenWhy && (
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  onOpenWhy(event)
+                }}
+                className="inline-flex items-center gap-1 px-2 py-1 rounded transition row-hover"
+                style={{
+                  background: colors.surfaceHover,
+                  border: `1px solid ${colors.borderStrong}`,
+                  color: colors.success,
+                }}
+                title="Trace what caused this event"
+              >
+                <GitBranch size={11} aria-hidden />
+                Why?
+              </button>
+            )}
             <span>#{event.sequence_no}</span>
             <span>{format(new Date(event.timestamp), 'HH:mm:ss')}</span>
           </div>
@@ -146,12 +167,14 @@ export function EventList({
   selected,
   expanded,
   onSelect,
+  onOpenWhy,
   onToggleExpand,
 }: {
   events: AgentEvent[]
   selected: AgentEvent | null
   expanded: string | null
   onSelect: (e: AgentEvent) => void
+  onOpenWhy?: (e: AgentEvent) => void
   onToggleExpand: (id: string) => void
 }) {
   const grouped = useMemo(() => groupBySession(events), [events])
@@ -187,6 +210,7 @@ export function EventList({
                 selected={selected?.event_id === ev.event_id}
                 expanded={expanded === ev.event_id}
                 onSelect={onSelect}
+                onOpenWhy={onOpenWhy}
                 onToggleExpand={onToggleExpand}
               />
             ))}

--- a/dashboard/components/dashboard/EventsSegment.tsx
+++ b/dashboard/components/dashboard/EventsSegment.tsx
@@ -1,15 +1,20 @@
 'use client'
 
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useSearchParams } from 'next/navigation'
 import { Search, X } from 'lucide-react'
 import type { AgentEvent, AgentStats } from '@/lib/api'
+import { getEvents } from '@/lib/api'
+import { getToken } from '@/lib/auth'
 import { eventColor } from '@/lib/events'
 import { colors, radii } from '@/lib/design-tokens'
 import { Button, EmptyState, ErrorState, Skeleton } from '@/components/ui'
 import type { AgentEventsState } from '@/hooks/useAgentEvents'
 import { useWhyChain } from '@/hooks/useWhyChain'
+import { seedWhyDemo } from '@/lib/why-demo'
 import { EventList } from './EventList'
 import { EventDetailPanel, type PanelTab } from './EventDetailPanel'
+import { WhyDemoBanner } from './WhyDemoBanner'
 
 function FilterPill({
   label,
@@ -46,18 +51,66 @@ function FilterPill({
 }
 
 export function EventsSegment({
+  agentId,
   events,
   stats,
 }: {
+  agentId: string | null
   events: AgentEventsState
   stats: AgentStats | null
 }) {
+  const searchParams = useSearchParams()
   const [selected, setSelected] = useState<AgentEvent | null>(null)
   const [expanded, setExpanded] = useState<string | null>(null)
   const [panelTab, setPanelTab] = useState<PanelTab>('data')
+  const [demoRunning, setDemoRunning] = useState(false)
+  const [demoError, setDemoError] = useState<string | null>(null)
+  const autoDemoRan = useRef(false)
   const why = useWhyChain()
 
   const { displayEvents, searchResults } = events
+
+  const openWhy = useCallback(
+    (ev: AgentEvent) => {
+      setSelected(ev)
+      setPanelTab('why')
+      why.load(ev.event_id)
+    },
+    [why],
+  )
+
+  const runWhyDemo = useCallback(async () => {
+    if (!agentId) return
+    const token = getToken()
+    if (!token) return
+
+    setDemoRunning(true)
+    setDemoError(null)
+    try {
+      const leafId = await seedWhyDemo(token, agentId)
+      const rows = await getEvents(token, agentId, { limit: '20' })
+      await events.refresh()
+      const leaf = rows.find((r) => r.event_id === leafId)
+      if (leaf) {
+        openWhy(leaf)
+      } else {
+        setDemoError('Demo logged events but could not find the leaf event — refresh the page.')
+      }
+    } catch (e) {
+      setDemoError(e instanceof Error ? e.message : 'Why demo failed')
+    } finally {
+      setDemoRunning(false)
+    }
+  }, [agentId, events, openWhy])
+
+  // Deep link from `zizkadb demo` or README: ?agent=support-bot&demo=why
+  useEffect(() => {
+    if (autoDemoRan.current) return
+    if (searchParams.get('demo') !== 'why') return
+    if (!agentId || events.loading) return
+    autoDemoRan.current = true
+    void runWhyDemo()
+  }, [agentId, events.loading, runWhyDemo, searchParams])
 
   // Re-clicking the selected event closes the panel.
   const selectEvent = useCallback(
@@ -119,6 +172,10 @@ export function EventsSegment({
   return (
     <div className="flex flex-col lg:flex-row gap-4">
       <div className="flex-1 min-w-0">
+        {!searchResults && agentId && (
+          <WhyDemoBanner onRun={runWhyDemo} running={demoRunning} error={demoError} />
+        )}
+
         <form onSubmit={onSubmitSearch} className="flex gap-2 mb-4">
           <div className="relative flex-1">
             <Search
@@ -234,7 +291,7 @@ export function EventsSegment({
           ) : (
             <EmptyState
               title="No events yet"
-              description="Once this agent logs its first event with the SDK, it will appear here in real time."
+              description="Run the Why demo above, or log your first event with the SDK — it will appear here in real time."
             />
           )
         ) : (
@@ -244,6 +301,7 @@ export function EventsSegment({
               selected={selected}
               expanded={expanded}
               onSelect={selectEvent}
+              onOpenWhy={openWhy}
               onToggleExpand={(id) => setExpanded(expanded === id ? null : id)}
             />
 

--- a/dashboard/components/dashboard/WhyDemoBanner.tsx
+++ b/dashboard/components/dashboard/WhyDemoBanner.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import { GitBranch, Sparkles } from 'lucide-react'
+import { colors, radii } from '@/lib/design-tokens'
+import { Button } from '@/components/ui'
+
+export function WhyDemoBanner({
+  onRun,
+  running,
+  error,
+}: {
+  onRun: () => void
+  running: boolean
+  error: string | null
+}) {
+  return (
+    <div
+      className="mb-4 p-4"
+      style={{
+        background: colors.successBg,
+        border: `1px solid ${colors.success}40`,
+        borderRadius: radii.lg,
+      }}
+    >
+      <div className="flex flex-col sm:flex-row sm:items-center gap-3 sm:justify-between">
+        <div className="flex gap-3 min-w-0">
+          <div
+            className="shrink-0 flex items-center justify-center rounded-lg"
+            style={{
+              width: 36,
+              height: 36,
+              background: `${colors.success}20`,
+              color: colors.success,
+            }}
+          >
+            <GitBranch size={18} aria-hidden />
+          </div>
+          <div className="min-w-0">
+            <p className="text-sm font-medium" style={{ color: colors.textStrong }}>
+              Try the Why demo
+            </p>
+            <p className="text-xs mt-0.5" style={{ color: colors.textMuted }}>
+              Logs a 3-step support chain, then opens the causal{' '}
+              <span className="font-medium" style={{ color: colors.text }}>
+                Why?
+              </span>{' '}
+              panel — the same flow as{' '}
+              <code className="font-mono text-[11px]" style={{ color: colors.success }}>
+                zizkadb demo
+              </code>
+              .
+            </p>
+          </div>
+        </div>
+        <Button size="sm" tone="primary" onClick={onRun} disabled={running}>
+          <span className="inline-flex items-center gap-1.5">
+            <Sparkles size={14} aria-hidden />
+            {running ? 'Running demo…' : 'Run Why demo'}
+          </span>
+        </Button>
+      </div>
+      {error && (
+        <p className="text-xs mt-2" style={{ color: colors.danger }} role="alert">
+          {error}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/dashboard/lib/api.ts
+++ b/dashboard/lib/api.ts
@@ -212,6 +212,30 @@ export async function getWhyChain(token: string, eventId: string): Promise<WhyCh
   return apiFetch(`/v1/events/${eventId}/why`, token)
 }
 
+export interface LogEventResult {
+  event_id: string
+  timestamp: string
+  sequence_no: number
+  checksum?: string
+  indexed?: boolean
+}
+
+export interface LogEventRequest {
+  agent: string
+  event: string
+  data: Record<string, unknown>
+  parent_id?: string | null
+  session_id?: string | null
+  metadata?: Record<string, unknown> | null
+}
+
+export async function postEvent(token: string, body: LogEventRequest): Promise<LogEventResult> {
+  return apiFetch('/v1/events', token, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
 // The backend's search response shape isn't fully pinned down (some call
 // sites defensively handle both `{ results: [...] }` and a bare array) — kept
 // loosely typed here rather than forcing a shape that would fight that

--- a/dashboard/lib/why-demo.test.ts
+++ b/dashboard/lib/why-demo.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { WHY_DEMO_STEPS, seedWhyDemo } from './why-demo'
+
+vi.mock('./api', () => ({
+  postEvent: vi.fn(),
+}))
+
+import { postEvent } from './api'
+
+describe('WHY_DEMO_STEPS', () => {
+  it('defines a 3-step causal chain', () => {
+    expect(WHY_DEMO_STEPS).toHaveLength(3)
+    expect(WHY_DEMO_STEPS[0].event).toBe('user_message')
+    expect(WHY_DEMO_STEPS[2].parentKey).toBe('reply')
+  })
+})
+
+describe('seedWhyDemo', () => {
+  beforeEach(() => {
+    vi.mocked(postEvent).mockReset()
+  })
+
+  it('posts events in order with parent links', async () => {
+    vi.mocked(postEvent)
+      .mockResolvedValueOnce({ event_id: 'u1', timestamp: '', sequence_no: 1 })
+      .mockResolvedValueOnce({ event_id: 'r1', timestamp: '', sequence_no: 2 })
+      .mockResolvedValueOnce({ event_id: 't1', timestamp: '', sequence_no: 3 })
+
+    const leaf = await seedWhyDemo('tok', 'support-bot')
+
+    expect(leaf).toBe('t1')
+    expect(postEvent).toHaveBeenCalledTimes(3)
+    expect(postEvent).toHaveBeenNthCalledWith(1, 'tok', {
+      agent: 'support-bot',
+      event: 'user_message',
+      data: { text: 'Why was my order delayed?' },
+      parent_id: undefined,
+    })
+    expect(postEvent).toHaveBeenNthCalledWith(2, 'tok', {
+      agent: 'support-bot',
+      event: 'llm_response',
+      data: { model: 'gpt-4o', tokens: 412 },
+      parent_id: 'u1',
+    })
+    expect(postEvent).toHaveBeenNthCalledWith(3, 'tok', {
+      agent: 'support-bot',
+      event: 'tool_call',
+      data: { tool: 'lookup_order', order_id: 'ORD-8842' },
+      parent_id: 'r1',
+    })
+  })
+})

--- a/dashboard/lib/why-demo.ts
+++ b/dashboard/lib/why-demo.ts
@@ -1,0 +1,48 @@
+import { postEvent, type LogEventResult } from './api'
+
+/** Agent id used by `zizkadb demo` and README quickstart. */
+export const WHY_DEMO_AGENT = 'support-bot'
+
+export type WhyDemoStep = {
+  event: string
+  data: Record<string, unknown>
+  parentKey?: 'user' | 'reply'
+}
+
+/** Ordered steps for the support-order-delay causal chain (matches sdk demo_run.py). */
+export const WHY_DEMO_STEPS: WhyDemoStep[] = [
+  { event: 'user_message', data: { text: 'Why was my order delayed?' } },
+  { event: 'llm_response', data: { model: 'gpt-4o', tokens: 412 }, parentKey: 'user' },
+  {
+    event: 'tool_call',
+    data: { tool: 'lookup_order', order_id: 'ORD-8842' },
+    parentKey: 'reply',
+  },
+]
+
+/**
+ * Log the 3-step causal demo chain via POST /v1/events.
+ * Returns the leaf event_id (tool_call) for opening the Why panel.
+ */
+export async function seedWhyDemo(token: string, agent: string): Promise<string> {
+  const ids: { user?: string; reply?: string } = {}
+
+  for (const step of WHY_DEMO_STEPS) {
+    let parent_id: string | undefined
+    if (step.parentKey === 'user') parent_id = ids.user
+    if (step.parentKey === 'reply') parent_id = ids.reply
+
+    const res: LogEventResult = await postEvent(token, {
+      agent,
+      event: step.event,
+      data: step.data,
+      parent_id,
+    })
+
+    if (step.event === 'user_message') ids.user = res.event_id
+    if (step.event === 'llm_response') ids.reply = res.event_id
+    if (step.event === 'tool_call') return res.event_id
+  }
+
+  throw new Error('Why demo did not produce a leaf event')
+}

--- a/sdk/python/zizkadb/demo_run.py
+++ b/sdk/python/zizkadb/demo_run.py
@@ -18,7 +18,7 @@ def _is_local_host(host: str) -> bool:
 def dashboard_activity_url(host: str, agent: str = DEMO_AGENT) -> str:
     """Deep link to Activity for an agent (local or cloud)."""
     base = "http://localhost:3001" if _is_local_host(host) else "https://db.zizka.ai"
-    return f"{base}/dashboard/activity?agent={agent}"
+    return f"{base}/dashboard/activity?agent={agent}&demo=why"
 
 
 async def run_support_order_delay_demo(host: str | None = None) -> str:


### PR DESCRIPTION
One-click demo seeds a causal chain and opens the Why panel; event rows get a Why? button and zizkadb demo deep-links with ?demo=why.

## Summary

<!-- What changed and why (1–3 bullets). -->

## Test plan

- [ ] `ruff check core/ sdk/python/ mcp/ integrations/` (if Python touched)
- [ ] `pytest core/tests/ -m "not integration"` (if core touched)
- [ ] `cd dashboard && npm run lint && npm test && npm run build` (if dashboard touched)
- [ ] Manual: <!-- steps or "docs only" -->

## Areas touched

- [ ] API / schema
- [ ] SDK (Python / TypeScript)
- [ ] Dashboard
- [ ] MCP / integrations
- [ ] Docs only
- [ ] Infra / CI

## Breaking changes

<!-- None, or describe migration. -->

Fixes #<!-- issue number if applicable -->
