### PR TITLE
test: harden A2A protocol coverage for sender, tenant, and keys

### DIFF
--- a/.cursor/rules/coding-standards.mdc
+++ b/.cursor/rules/coding-standards.mdc
@@ -52,3 +52,14 @@ cd dashboard && npm run lint && npm test && npm run build
 ```
 
 See `.cursor/skills/zizkadb-test/SKILL.md` for the full matrix.
+
+## Opening a GitHub PR
+
+Fill every sidebar field in the **same** `gh pr create` (not a later `gh pr edit`):
+
+- `--label` — `enhancement`, `bug`, and/or `documentation` (add `documentation` when KB/ADR/`CLAUDE.md` changed). Never `good first issue` on PRs.
+- `--assignee saadamjad`
+- `--reviewer Zizka-ai`
+- Body includes `Closes #N` when this PR completes the issue, or `Related to #N` when it must not auto-close.
+- Footer: **Made with [Cursor](https://cursor.com) and Saad**
+- Never `git push` to `main`. Never `gh pr merge`.

--- a/.cursor/rules/testing.mdc
+++ b/.cursor/rules/testing.mdc
@@ -52,7 +52,7 @@ ZIZKADB_RUN_INTEGRATION=1 pytest core/tests/test_integration_selfhost.py -v
 | `test_marketing_subscriptions.py` | Marketing subscription create + honeypot |
 | `test_settings_auth.py` | Settings embeddings requires dashboard session |
 | `test_pg_pool_warn.py` | Postgres pool × workers warning (no live DB) |
-| `test_a2a.py` | Agent-to-agent protocol routes |
+| `test_a2a.py` | `POST /v1/a2a/messages`: sender from scoped key, same-tenant recipient, 404 unknown, 403 tenant-wide/JWT |
 | `test_reports.py` | Per-agent report payload |
 | `test_suggestions.py` | Suggestions extractor / grounding |
 | `test_token_usage.py` | Token/cost aggregation |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,8 @@ pytest core/tests/ -m "not integration" -v
 cd dashboard && npm run lint && npm test && npm run build
 ```
 
+When opening a PR, set **all** GitHub links in the same `gh pr create`: `--label` (`enhancement` / `bug` / `documentation`), `--assignee saadamjad`, `--reviewer Zizka-ai`, and `Closes #N` (or `Related to #N` if the issue must stay open). Do not leave labels, assignee, reviewer, or issue linking for a follow-up edit.
+
 See [.cursor/skills/zizkadb-test/SKILL.md](.cursor/skills/zizkadb-test/SKILL.md).
 
 ## Integrating ZizkaDB into user agents (product)

--- a/core/CLAUDE.md
+++ b/core/CLAUDE.md
@@ -33,6 +33,20 @@ Under `/v1/agents`: per-agent analytics (`/stats`, `/sessions`, `/baseline`, `/b
 
 Swagger UI: `http://localhost:8000/swagger` · OpenAPI schema: `/openapi.json`
 
+### A2A (`POST /v1/a2a/messages`)
+
+SDK-only. Auth is `get_tenant`, but a **tenant-wide key or JWT without `agent_id` is 403** — the sender is never a request field.
+
+| Rule | Result |
+|---|---|
+| Sender | `tenant["agent_id"]` from an agent-scoped API key |
+| Extra JSON (`sender_agent`, `from`, …) | Ignored; does not change sender |
+| Recipient | Must exist in the **same** `tenant_id` (`agents` lookup binds both) |
+| Unknown / other-tenant recipient | **404**, no `write_event` |
+| Self-send (`sender == recipient`) | **400** |
+
+Coverage: `core/tests/test_a2a.py`.
+
 ---
 
 ## Auth dependency decision tree

--- a/core/tests/test_a2a.py
+++ b/core/tests/test_a2a.py
@@ -237,6 +237,38 @@ async def test_cross_tenant_recipient_is_rejected(mock_pool):
     assert "agent_id = $2" in sql
     assert tenant_id == "tenant-1"
     assert recipient == "agent-other-tenant"
+    mock_pool.fetchval.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_recipient_lookup_ignores_tenant_id_in_payload(
+    mock_pool,
+    mock_write_event,
+):
+    """A client-supplied tenant_id in metadata must not change the SQL bind."""
+    mock_pool.fetchval.return_value = None
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-other-tenant",
+        message="Hello",
+        metadata={"tenant_id": "tenant-other"},
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await send_message(
+            body,
+            tenant=TENANT,
+        )
+
+    assert exc.value.status_code == 404
+
+    sql, tenant_id, recipient = mock_pool.fetchval.await_args.args
+
+    assert "tenant_id = $1" in sql
+    assert tenant_id == "tenant-1"
+    assert tenant_id != "tenant-other"
+    assert recipient == "agent-other-tenant"
+    mock_write_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/core/tests/test_a2a.py
+++ b/core/tests/test_a2a.py
@@ -178,7 +178,10 @@ async def test_metadata_sender_does_not_override_authenticated_agent(
 
 
 @pytest.mark.asyncio
-async def test_tenant_wide_key_cannot_send_a2a_message():
+async def test_tenant_wide_key_cannot_send_a2a_message(
+    mock_pool,
+    mock_write_event,
+):
     body = A2AMessageRequest(
         recipient_agent="agent-b",
         message="Hello",
@@ -191,6 +194,51 @@ async def test_tenant_wide_key_cannot_send_a2a_message():
         )
 
     assert exc.value.status_code == 403
+    assert "agent-scoped" in str(exc.value.detail).lower()
+    mock_pool.fetchval.assert_not_called()
+    mock_write_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_empty_agent_id_cannot_send_a2a_message(
+    mock_pool,
+    mock_write_event,
+):
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Hello",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await send_message(
+            body,
+            tenant={"tenant_id": "tenant-1", "agent_id": ""},
+        )
+
+    assert exc.value.status_code == 403
+    mock_pool.fetchval.assert_not_called()
+    mock_write_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dashboard_jwt_without_agent_cannot_send_a2a_message(
+    mock_pool,
+    mock_write_event,
+):
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Hello",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        await send_message(
+            body,
+            tenant={"tenant_id": "tenant-1", "user_id": "user-1"},
+        )
+
+    assert exc.value.status_code == 403
+    mock_pool.fetchval.assert_not_called()
+    mock_write_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/core/tests/test_a2a.py
+++ b/core/tests/test_a2a.py
@@ -194,7 +194,7 @@ async def test_tenant_wide_key_cannot_send_a2a_message():
 
 
 @pytest.mark.asyncio
-async def test_recipient_must_exist(mock_pool):
+async def test_recipient_must_exist(mock_pool, mock_write_event):
     mock_pool.fetchval.return_value = None
 
     body = A2AMessageRequest(
@@ -209,6 +209,8 @@ async def test_recipient_must_exist(mock_pool):
         )
 
     assert exc.value.status_code == 404
+    assert "agent-does-not-exist" in str(exc.value.detail)
+    mock_write_event.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/core/tests/test_a2a.py
+++ b/core/tests/test_a2a.py
@@ -120,6 +120,63 @@ async def test_sender_is_derived_from_authenticated_agent(
     assert kwargs["data"]["sender_agent"] == "agent-a"
 
 
+def test_a2a_request_model_has_no_sender_field():
+    """Clients cannot declare a sender — it is not part of the request schema."""
+    assert "sender_agent" not in A2AMessageRequest.model_fields
+    assert "agent_id" not in A2AMessageRequest.model_fields
+
+
+@pytest.mark.asyncio
+async def test_extra_sender_fields_cannot_spoof_authenticated_agent(
+    mock_pool,
+    mock_write_event,
+):
+    """Extra JSON like sender_agent / agent_id must not override the scoped key."""
+    mock_pool.fetchval.return_value = 1
+
+    body = A2AMessageRequest.model_validate(
+        {
+            "recipient_agent": "agent-b",
+            "message": "spoof attempt",
+            "sender_agent": "agent-evil",
+            "agent_id": "agent-evil",
+            "from": "agent-evil",
+        }
+    )
+
+    assert "sender_agent" not in body.model_fields_set
+    assert "agent_id" not in body.model_fields_set
+
+    result = await send_message(body, tenant=TENANT)
+
+    assert result["sender_agent"] == "agent-a"
+    kwargs = mock_write_event.await_args.kwargs
+    assert kwargs["agent"] == "agent-a"
+    assert kwargs["data"]["sender_agent"] == "agent-a"
+
+
+@pytest.mark.asyncio
+async def test_metadata_sender_does_not_override_authenticated_agent(
+    mock_pool,
+    mock_write_event,
+):
+    mock_pool.fetchval.return_value = 1
+
+    body = A2AMessageRequest(
+        recipient_agent="agent-b",
+        message="Hello",
+        metadata={"sender_agent": "agent-evil", "agent_id": "agent-evil"},
+    )
+
+    result = await send_message(body, tenant=TENANT)
+
+    assert result["sender_agent"] == "agent-a"
+    kwargs = mock_write_event.await_args.kwargs
+    assert kwargs["agent"] == "agent-a"
+    assert kwargs["data"]["sender_agent"] == "agent-a"
+    assert kwargs["metadata"]["sender_agent"] == "agent-evil"
+
+
 @pytest.mark.asyncio
 async def test_tenant_wide_key_cannot_send_a2a_message():
     body = A2AMessageRequest(

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -535,6 +535,8 @@ One bearer-token entry point resolves **three** credential types, in order:
 
 Router prefixes are mounted in `core/main.py:66-79`.
 
+**SDK-only (not called from `lib/api.ts`):** `POST /v1/a2a/messages` (`core/api/a2a.py`) — agent-scoped API key required; sender is the key’s `agent_id`; recipient must exist in the same tenant. See `core/CLAUDE.md` (A2A).
+
 **Auth (`core/api/auth.py`, prefix `/v1/auth`):**
 | Dashboard fn (`lib/api.ts`) | Method · Path | Backend |
 |---|---|---|


### PR DESCRIPTION
## Summary
- Scoped keys cannot spoof `sender_agent` via extra JSON or metadata.
- Recipient lookup always binds the authenticated `tenant_id`; unknown / other-tenant agents are 404 and do not write an event.
- Tenant-wide keys, empty `agent_id`, and JWTs without an agent are 403 before any DB lookup.
- Document the contract in `core/CLAUDE.md`, KB §17.3, and the test map.

Closes #162
Related to #114, #122

## Review
- **Touch points:** `POST /v1/a2a/messages` (`core/api/a2a.py`) only. No route, request, or response shape change. Dashboard does not call this endpoint.
- **Edge cases:** Extra `sender_agent` / `from` fields are ignored (Pydantic default), not 422. Empty `agent_id` is treated as unscoped (403). Tests invoke `send_message` directly (same as existing file), not HTTP `TestClient`.
- **Production risks:** None from this PR — tests and docs only. Issue #122’s dashboard insights / VPN work is out of scope and stays open.
- **Docs updated:** `core/CLAUDE.md` A2A table, KB §17.3 SDK-only note, `.cursor/rules/testing.mdc`, plus PR-create metadata in `AGENTS.md` / `coding-standards.mdc`.

## Test plan
- [ ] `pytest core/tests/test_a2a.py -v`
- [ ] `ruff check core/`
- [ ] Confirm OpenAPI still shows `POST /v1/a2a/messages` with no `sender_agent` field

Made with [Cursor](https://cursor.com) and Saad