### PR TITLE
docs: GitHub docs for zizkadb-livekit 0.1.0

### DIFF
--- a/.cursor/rules/infra-deploy.mdc
+++ b/.cursor/rules/infra-deploy.mdc
@@ -69,7 +69,7 @@ There is no AWS pipeline, no CodeDeploy, no ECS task definition.
 | `scripts/quickstart-remote.sh` | OSS quickstart without cloning — downloads config only |
 | `scripts/verify-release.sh` | Pre-publish gate (must pass before `publish-packages.sh`) |
 | `scripts/publish-packages.sh` | Publish `zizkadb-sdk` (PyPI + npm) and `zizkadb-mcp` (PyPI) |
-| `scripts/publish-integrations.sh` | Publish `zizkadb-langchain` and `zizkadb-crewai` to PyPI |
+| `scripts/publish-integrations.sh` | Publish `zizkadb-langchain`, `zizkadb-crewai`, `zizkadb-livekit` to PyPI |
 | `scripts/reset-local-db.sh` | Wipe local Docker volumes — LOCAL DEV ONLY, refuses in production |
 | `scripts/smoke-test.sh` | Smoke test against a running stack |
 | `scripts/seed-support-bot-events.py` | Seed 50+ sessions for drift/baseline testing |

--- a/.cursor/rules/sdk-integrations-mcp.mdc
+++ b/.cursor/rules/sdk-integrations-mcp.mdc
@@ -39,21 +39,13 @@ const baseline = await db.baseline({ agent: 'my-bot' })
 
 ## Integrations (`integrations/`)
 
-Two standalone packages: `zizkadb-langchain` and `zizkadb-crewai`. **Published on PyPI** — `pip install zizkadb-langchain zizkadb-crewai`.
+Three standalone packages: `zizkadb-langchain`, `zizkadb-crewai`, `zizkadb-livekit`. **Published on PyPI**.
 
-### Critical: code lives in two places — keep both in sync
-
-| Standalone (published package) | Bundled in SDK |
-|---|---|
-| `integrations/langchain/zizkadb_langchain/callbacks.py` | `sdk/python/zizkadb/integrations/langchain/callbacks.py` |
-| `integrations/crewai/zizkadb_crewai/logger.py` | `sdk/python/zizkadb/integrations/crewai/logger.py` |
-
-When editing integration logic, update both locations.
-
-Dev monorepo install:
-```bash
-pip install -e sdk/python -e integrations/langchain -e integrations/crewai
-```
+| Package | Class | Notes |
+|---|---|---|
+| `zizkadb-langchain` | `ZizkaDBCallbackHandler` | Duplicated in SDK — keep both in sync |
+| `zizkadb-crewai` | `ZizkaDBCrewLogger` | Duplicated in SDK — keep both in sync |
+| `zizkadb-livekit` | `ZizkaDBLiveKitObserver` | Standalone only — `integrations/livekit/` |
 
 ## MCP Server (`mcp/`)
 
@@ -78,6 +70,7 @@ Cursor/Claude Desktop config: `.cursor/mcp.json.example`.
 - `openai-agent/` — OpenAI function calling
 - `langchain-agent/` — LangChain with `ZizkaDBCallbackHandler`
 - `crewai-agent/` — CrewAI with `ZizkaDBCrewLogger`
+- `livekit-agent/` — LiveKit voice with `ZizkaDBLiveKitObserver`
 - `mcp-cursor/` — Cursor MCP config
 
 Import paths in examples use standalone package names:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,4 @@ For **using** ZizkaDB as a product (not hacking this repo), point users to:
 
 - [CONNECT.md](CONNECT.md)
 - [docs/integrate/any-agent.md](docs/integrate/any-agent.md)
+- [docs/integrations/livekit.md](docs/integrations/livekit.md) — LiveKit voice agents (`zizkadb-livekit`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,16 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Integrations
+
+- **`zizkadb-livekit` 0.1.0** (PyPI) — LiveKit Agents voice calls → ZizkaDB Sessions + Events (transcript only, no audio stored). Depends on `zizkadb-sdk>=0.2.7` + `livekit-agents>=1.3.0`. Docs: [docs/integrations/livekit.md](docs/integrations/livekit.md), example: [examples/livekit-agent/](examples/livekit-agent/).
+
 ## [0.2.8] — 2026-08-27
 
 ### Install telemetry (OSS adoption)
 
 - **Python SDK 0.2.7**, **TypeScript SDK 0.2.7 (npm)**, **MCP 0.1.6**, **langchain 0.1.3**, **crewai 0.1.3**: count **installs** at import/client/server start (including self-hosted localhost), not on first API call
-- Per-package telemetry keys: `python`, `langchain`, `crewai`, `mcp`, `typescript`, `docker`
+- Per-package telemetry keys: `python`, `langchain`, `crewai`, `livekit`, `mcp`, `typescript`, `docker`
 - **Docker quickstart**: anonymous install ping (`sdk=docker`, `mode=self-hosted`) after stack is healthy
 - **`sdk_telemetry`**: composite primary key `(install_id, sdk)` so Python + MCP + Docker on one machine each count separately
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ ZizkaDB is a causal event database for AI agents. It lets you log every agent ac
 | Dashboard | Next.js 14 App Router | `dashboard/app/` |
 | Python SDK | `zizkadb-sdk` (PyPI) | `sdk/python/zizkadb/client.py` |
 | TypeScript SDK | `zizkadb-sdk` (npm) | `sdk/typescript/src/index.ts` |
-| Integrations | `zizkadb-langchain`, `zizkadb-crewai` | `integrations/` (standalone) + `sdk/python/zizkadb/integrations/` (bundled) |
+| Integrations | `zizkadb-langchain`, `zizkadb-crewai`, `zizkadb-livekit` | `integrations/` (standalone) + LangChain/CrewAI bundled in `sdk/python/zizkadb/integrations/` |
 | MCP server | `zizkadb-mcp` (PyPI, **MIT**) | `mcp/zizkadb_mcp/server.py` |
 | Infra | Docker Compose | `infra/docker-compose.yml` (prod) + `infra/docker-compose.dev.yml` (dev overlay) |
 | CI | GitHub Actions | `.github/workflows/ci.yml` (lint+tests+vitest) · `integration.yml` (weekly stack) · `publish-images.yml` (GHCR on `v*` tag) |

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@ Self-hosted audit trail for AI agents — one command or one dashboard click fro
 [![CI](https://github.com/Zizka-ai/ZizkaDB/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Zizka-ai/ZizkaDB/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
 [![Release](https://img.shields.io/badge/release-v0.2.7-f97316)](https://github.com/Zizka-ai/ZizkaDB/releases)
+[![Python SDK](https://img.shields.io/pypi/v/zizkadb-sdk?label=Python%20SDK)](https://pypi.org/project/zizkadb-sdk/)
+[![LangChain](https://img.shields.io/pypi/v/zizkadb-langchain?label=LangChain)](https://pypi.org/project/zizkadb-langchain/)
+[![CrewAI](https://img.shields.io/pypi/v/zizkadb-crewai?label=CrewAI)](https://pypi.org/project/zizkadb-crewai/)
+[![LiveKit](https://img.shields.io/pypi/v/zizkadb-livekit?label=LiveKit)](https://pypi.org/project/zizkadb-livekit/)
+[![MCP](https://img.shields.io/pypi/v/zizkadb-mcp?label=MCP)](https://pypi.org/project/zizkadb-mcp/)
 
 **[Try it ↓](#try-it-60-seconds)** · **[START_HERE.md](START_HERE.md)** · **[CONNECT.md](CONNECT.md)** · **[Cloud →](https://db.zizka.ai/signup)**
 
@@ -83,6 +88,14 @@ Full guides: **[CONNECT.md](CONNECT.md)** · [LangChain](CONNECT.md#langchain) �
 
 Scaffold a project: `zizkadb init my-agent --template basic`
 
+### Voice agents (LiveKit)
+
+```bash
+pip install zizkadb-livekit
+```
+
+One LiveKit call → one **Session** in Activity (transcript only, no audio in ZizkaDB). Full guide: [CONNECT.md → LiveKit](CONNECT.md#livekit-agents-voice) · [docs/integrations/livekit.md](docs/integrations/livekit.md) · [example](examples/livekit-agent/).
+
 ---
 
 <details>
@@ -127,6 +140,9 @@ No — `http://localhost:8000` uses a built-in dev key. Dashboard: [localhost:30
 **How is this different from Langfuse / LangSmith?**  
 They **observe** span trees. ZizkaDB **audits** with explicit `parent_id` chains and `db.why()` on your Postgres — self-host under AGPL, no trace billing.
 
+**Voice agents with LiveKit?**  
+Install **`zizkadb-livekit`** — one pip command, connect to Docker with `ZIZKADB_HOST=http://localhost:8000`. See [LiveKit guide](CONNECT.md#livekit-agents-voice).
+
 **`zizkadb demo` connection refused?**  
 Start the stack: `curl -fsSL …/quickstart-remote.sh | bash` or `bash scripts/setup-local.sh`.
 
@@ -138,7 +154,8 @@ Start the stack: `curl -fsSL …/quickstart-remote.sh | bash` or `bash scripts/s
 | | |
 | --- | --- |
 | Worked example | [worked/01-support-order-delay](worked/01-support-order-delay/) |
-| Examples | [examples/](examples/) |
+| Examples | [examples/](examples/) — includes [LiveKit voice agent](examples/livekit-agent/) |
+| LiveKit integration | [docs/integrations/livekit.md](docs/integrations/livekit.md) |
 | Self-hosting | [wiki/Self-Hosting](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) |
 | Integrate any agent | [docs/integrate/](docs/integrate/) |
 | Issues · Discussions | [Issues](https://github.com/Zizka-ai/ZizkaDB/issues) · [Discussions](https://github.com/Zizka-ai/ZizkaDB/discussions) |

--- a/START_HERE.md
+++ b/START_HERE.md
@@ -29,7 +29,7 @@ async with ZizkaDB(host="http://localhost:8000") as db:
     (await db.why(tool.event_id)).print()
 ```
 
-→ [CONNECT.md](CONNECT.md) for LangChain, CrewAI, TypeScript, MCP
+→ [CONNECT.md](CONNECT.md) for LangChain, CrewAI, **LiveKit (voice)**, TypeScript, MCP
 
 ## Next
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Start here if you are not sure which file to read.
 | [Supported vs generic frameworks](integrate/frameworks.md) | LangChain, CrewAI, LiveKit, LangGraph, etc. |
 | [LiveKit (voice agents)](integrations/livekit.md) | `zizkadb-livekit` — one call → one session |
 | [LangChain](integrations/langchain.md) | Callback handler package |
+| [CrewAI](integrations/crewai.md) | Crew logger package |
 | [CONNECT.md](../CONNECT.md) | Copy-paste: Python, TS, LangChain, CrewAI, LiveKit, MCP, REST |
 
 ## Source of truth

--- a/docs/integrations/livekit.md
+++ b/docs/integrations/livekit.md
@@ -1,11 +1,25 @@
 # LiveKit integration
 
-**Package:** `zizkadb-livekit` on PyPI **0.1.0**  
-**Install:** one command — pulls `zizkadb-sdk` and `livekit-agents` automatically.
+**Package:** [`zizkadb-livekit`](https://pypi.org/project/zizkadb-livekit/) **0.1.0** on PyPI (AGPL-3.0)  
+**Class:** `ZizkaDBLiveKitObserver`  
+**Source:** [`integrations/livekit/zizkadb_livekit/`](../../integrations/livekit/zizkadb_livekit/)  
+**Runnable example:** [`examples/livekit-agent/`](../../examples/livekit-agent/)
+
+## Why this exists
+
+Voice agents built with [LiveKit Agents](https://docs.livekit.io/agents/) need the same operational audit trail as text agents: *why did the agent say that, and which tool caused it?*
+
+`zizkadb-livekit` maps **one LiveKit call → one ZizkaDB session** in the existing **Activity → Sessions / Events** UI. Transcript text is copied from LiveKit's session report at call end — **no audio** is stored in ZizkaDB.
+
+Event types match text agents: `session_started`, `user_message`, `assistant_response`, `tool_call`, `tool_result`, `error`, `session_ended`. Each event links via `parent_id` so `db.why()` works in the dashboard.
+
+## Install (one command)
 
 ```bash
 pip install zizkadb-livekit
 ```
+
+Pulls `zizkadb-sdk>=0.2.7` and `livekit-agents>=1.3.0` automatically. No separate core SDK install.
 
 Start ZizkaDB (Docker):
 
@@ -13,36 +27,72 @@ Start ZizkaDB (Docker):
 curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
 ```
 
-## What it does
-
-| Concept | Behavior |
-|---------|----------|
-| **Session** | One LiveKit call = one `session_id` (e.g. `call_{room_name}`) |
-| **Transcript** | Text from LiveKit `make_session_report()` — no audio in ZizkaDB |
-| **Events** | `session_started`, `user_message`, `assistant_response`, `tool_call`, `tool_result`, `error`, `session_ended` |
-| **Why?** | Causal `parent_id` chain — same Activity UI as text agents |
-
 ## Quick wiring
 
 ```python
+import os
+from livekit.agents import AgentServer, JobContext, AgentSession, Agent
 from zizkadb import ZizkaDB
 from zizkadb_livekit import ZizkaDBLiveKitObserver
 
-observer = ZizkaDBLiveKitObserver(db, agent="support-voice", session_id=f"call_{room}")
-await observer.ingest_session_report(ctx)  # on_session_end
+server = AgentServer()
+_observer: ZizkaDBLiveKitObserver | None = None
+
+async def on_session_end(ctx: JobContext) -> None:
+    if _observer is not None:
+        await _observer.ingest_session_report(ctx)
+
+@server.rtc_session(agent_name="support-voice", on_session_end=on_session_end)
+async def entrypoint(ctx: JobContext):
+    global _observer
+    await ctx.connect()
+
+    db = ZizkaDB(host=os.getenv("ZIZKADB_HOST", "http://localhost:8000"))
+    _observer = ZizkaDBLiveKitObserver(
+        db,
+        agent=os.getenv("ZIZKADB_AGENT", "support-voice"),
+        session_id=f"call_{ctx.room.name}",
+    )
+    await _observer.log_session_started(room=ctx.room.name, job_id=ctx.job.id)
+
+    session = AgentSession(...)  # your STT / LLM / TTS
+    _observer.attach(session, job_ctx=ctx)  # optional realtime turns
+    await session.start(agent=Agent(instructions="..."), room=ctx.room)
 ```
+
+After a test call: **http://localhost:3001 → Activity → support-voice → Sessions**.
 
 ## Environment
 
+| Variable | Purpose |
+|----------|---------|
+| `ZIZKADB_HOST` | Self-host API URL (default `http://localhost:8000`) |
+| `ZIZKADB_AGENT` | Agent name — must match dashboard |
+| `ZIZKADB_API_KEY` | Cloud key (`zizkadb_live_...`) instead of `host=` |
+| LiveKit vars | `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` — see [LiveKit docs](https://docs.livekit.io/) |
+
+## Event mapping
+
+| ZizkaDB event | Source |
+|---------------|--------|
+| `session_started` | Call connect |
+| `user_message` | LiveKit user transcript |
+| `assistant_response` | LiveKit agent transcript |
+| `tool_call` / `tool_result` | Tools + pipeline events from report |
+| `error` | Failures |
+| `session_ended` | Post-call ingest |
+
+Manual helpers: `log_tool_call`, `log_tool_result`, `log_error`.
+
+## Monorepo dev
+
 ```bash
-export ZIZKADB_HOST=http://localhost:8000   # self-host Docker stack
-export ZIZKADB_AGENT=support-voice          # must match dashboard agent name
-# Cloud: export ZIZKADB_API_KEY=zizkadb_live_...
+pip install -e sdk/python -e integrations/livekit
+pytest sdk/python/tests/test_livekit_observer.py -v
 ```
 
-## More
+## Related
 
-- Runnable example: [examples/livekit-agent](../../examples/livekit-agent/)
 - Package README: [integrations/livekit/README.md](../../integrations/livekit/README.md)
+- Connect guide: [CONNECT.md](../../CONNECT.md#livekit-agents-voice)
 - Framework status: [integrate/frameworks.md](../integrate/frameworks.md)
-- Copy-paste connect guide: [CONNECT.md](../../CONNECT.md#livekit-agents-voice)

--- a/examples/README.md
+++ b/examples/README.md
@@ -11,6 +11,8 @@ zizkadb init my-agent --template crewai     # crew logger
 zizkadb init my-agent --template mcp-cursor # ~/.cursor/mcp.json
 ```
 
+Voice agents: **`pip install zizkadb-livekit`** — see [livekit-agent/](livekit-agent/).
+
 ## In this folder
 
 | Example | Description |

--- a/examples/livekit-agent/README.md
+++ b/examples/livekit-agent/README.md
@@ -41,4 +41,4 @@ One **LiveKit call** → one **ZizkaDB session** (`call_{room_name}`). Transcrip
 | `tool_call` | From session report pipeline events |
 | `session_ended` | After `make_session_report()` ingest |
 
-Package: **`zizkadb-livekit`** on PyPI (depends on `zizkadb-sdk>=0.2.7` — no 0.2.8 required).
+Package: **`zizkadb-livekit`** on [PyPI](https://pypi.org/project/zizkadb-livekit/) **0.1.0** — one install pulls `zizkadb-sdk` automatically.

--- a/llms.txt
+++ b/llms.txt
@@ -10,7 +10,7 @@ ZizkaDB is open-source (AGPL-3.0, except MCP server which is MIT). It runs as a 
 - [Dashboard](dashboard/) — Next.js 14 App Router. Marketing + authenticated agent fleet view.
 - [Python SDK](sdk/python/) — `zizkadb-sdk` **0.2.7** on PyPI. Async client, `zizkadb init` CLI.
 - [TypeScript SDK](sdk/typescript/) — `zizkadb-sdk` **0.2.7** on npm. Sync constructor, camelCase fields.
-- [Integrations](integrations/) — `zizkadb-langchain` **0.1.2**, `zizkadb-crewai` **0.1.2** on PyPI. `db.why()` causal debugging.
+- [Integrations](integrations/) — `zizkadb-langchain` **0.1.2**, `zizkadb-crewai` **0.1.2**, `zizkadb-livekit` **0.1.0** on PyPI. Voice + text causal debugging via `db.why()`.
 - [MCP Server](mcp/) — `zizkadb-mcp` **0.1.6** on PyPI. MIT license. `uvx zizkadb-mcp`.
 - [Infra](infra/) — Docker Compose. Production: `docker-compose.yml`. Dev overlay: `docker-compose.dev.yml`.
 

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -33,6 +33,16 @@ python agent.py
 
 Templates: `basic`, `openai`, `langchain`, `crewai`, `mcp-cursor`.
 
+## Framework packages (optional)
+
+| Package | Install | Use case |
+|---------|---------|----------|
+| `zizkadb-langchain` | `pip install zizkadb-langchain` | LangChain callbacks |
+| `zizkadb-crewai` | `pip install zizkadb-crewai` | CrewAI crew logger |
+| `zizkadb-livekit` | `pip install zizkadb-livekit` | LiveKit voice → Sessions + Events |
+
+See [integrations/](../integrations/) and [docs/integrations/livekit.md](../docs/integrations/livekit.md).
+
 ## Quickstart
 
 ```python

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -56,7 +56,7 @@ If your app logs to **different agent ids** per user (e.g. `conv-alice`, `conv-b
 | `ZIZKADB_HOST` | Self-hosted API URL |
 | `ZIZKADB_TELEMETRY` | Set `false` to opt out (anonymous ping on client construct) |
 
-Core HTTP client only — LangChain and CrewAI adapters are Python packages (`zizkadb-langchain`, `zizkadb-crewai`).
+Core HTTP client only — LangChain, CrewAI, and LiveKit adapters are Python packages (`zizkadb-langchain`, `zizkadb-crewai`, `zizkadb-livekit`).
 
 ## Links
 

--- a/wiki/Getting-Started.md
+++ b/wiki/Getting-Started.md
@@ -33,7 +33,7 @@ Worked example: [worked/01-support-order-delay](../worked/01-support-order-delay
 
 ### Connect your own agent
 
-See **[CONNECT.md](../CONNECT.md)** — Python, TypeScript, LangChain, CrewAI, MCP, REST.
+See **[CONNECT.md](../CONNECT.md)** — Python, TypeScript, LangChain, CrewAI, **LiveKit (voice)**, MCP, REST.
 
 ### Stack only (no demo)
 

--- a/wiki/Python-SDK.md
+++ b/wiki/Python-SDK.md
@@ -79,6 +79,14 @@ db = ZizkaDB(host="http://localhost:8000")
 
 Localhost auto-uses dev key `zizkadb_dev_local`.
 
+## LiveKit voice agents
+
+```bash
+pip install zizkadb-livekit
+```
+
+One call → one session in Activity. Guide: [docs/integrations/livekit.md](../docs/integrations/livekit.md) · example: [examples/livekit-agent/](../examples/livekit-agent/).
+
 ## Telemetry opt-out
 
 ```bash

--- a/wiki/TypeScript-SDK.md
+++ b/wiki/TypeScript-SDK.md
@@ -32,7 +32,7 @@ chain.print()
 | `ZIZKADB_HOST` | Self-hosted URL |
 | `ZIZKADB_TELEMETRY` | Set `false` to opt out |
 
-Core HTTP client only — LangChain and CrewAI adapters are Python packages (`zizkadb-langchain`, `zizkadb-crewai`).
+Core HTTP client only — LangChain, CrewAI, and LiveKit adapters are Python packages (`zizkadb-langchain`, `zizkadb-crewai`, `zizkadb-livekit`).
 
 ## Self-hosted
 

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -10,6 +10,7 @@
 ### Integrate
 - [Python SDK](Python-SDK)
 - [TypeScript SDK](TypeScript-SDK)
+- [LiveKit (voice)](https://github.com/Zizka-ai/ZizkaDB/blob/main/docs/integrations/livekit.md)
 - [MCP and Cursor](MCP-and-Cursor)
 - [REST API](REST-API)
 - [Multi-Agent Apps](Multi-Agent-Apps)


### PR DESCRIPTION
## Summary
Completes GitHub documentation for **`zizkadb-livekit` 0.1.0** (already on PyPI, code merged in #164).

## Updates
- **README**: PyPI badges (Python, LangChain, CrewAI, LiveKit, MCP), voice agents section, FAQ, docs links
- **Company docs**: expanded [docs/integrations/livekit.md](docs/integrations/livekit.md) (full reference like CrewAI guide)
- **CONNECT / START_HERE / CHANGELOG / llms.txt / AGENTS / CLAUDE**
- **Wiki**: sidebar, Getting Started, Python-SDK, TypeScript-SDK
- **SDK READMEs**, examples index, cursor rules

## Test plan
- [ ] Markdown links resolve
- [ ] LiveKit badge shows 0.1.0 on PyPI
