### PR TITLE
refactor(dashboard): share OtpForm across login and signup

### DIFF
--- a/.cursor/rules/coding-standards.mdc
+++ b/.cursor/rules/coding-standards.mdc
@@ -7,6 +7,17 @@ alwaysApply: true
 
 These rules apply to **every** change without needing to be named in the prompt. Area-specific guides load automatically via `.cursor/rules/*.mdc` globs and module `CLAUDE.md` files.
 
+## Before starting any task
+
+Multiple people land on `main`. Do this **first**, every time — new work and follow-up commits:
+
+```bash
+git fetch origin main
+git checkout -B main origin/main
+```
+
+Then create the feature branch from that tip (`git checkout -b <topic>`), or merge `origin/main` into an existing PR branch. Never start from a leftover local branch or a stale `main`. Never `git push` to `main`.
+
 ## Read automatically by area
 
 | Working in… | Consult first |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,10 @@ This file helps Cursor, Copilot, Claude Code, and other agents work on **this re
 
 Area-specific rules load automatically from `.cursor/rules/*.mdc` by file path.
 
+## Before starting
+
+`git fetch origin main` then `git checkout -B main origin/main`. Branch from that tip (or merge `origin/main` into an existing PR branch). Never start from a stale local `main` or a leftover topic branch. Never push to `main`.
+
 ## Critical invariants
 
 1. **Auth:** SDK routes → `get_tenant`; dashboard management → `require_dashboard_session`; per-agent routes → `assert_agent_allowed`.
@@ -40,4 +44,3 @@ For **using** ZizkaDB as a product (not hacking this repo), point users to:
 
 - [CONNECT.md](CONNECT.md)
 - [docs/integrate/any-agent.md](docs/integrate/any-agent.md)
-- [docs/integrations/livekit.md](docs/integrations/livekit.md) — LiveKit voice agents (`zizkadb-livekit`)

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -2,7 +2,7 @@
 
 > Single source of truth for the Dashboard module. Reverse-engineered directly from the codebase.
 >
-> **Last verified:** 2026-08-27 · API key limits: Self-Hosted 1 / Pro 2 / Team 5 / Enterprise 50 (enforcement via `API_KEY_LIMITS_ENFORCED`, default OFF; self-hosted resolved via `DEPLOYMENT_MODE`, not `users.plan`). Self-host embeddings off unless `EMBEDDINGS_ENABLED=true`.
+> **Last verified:** 2026-08-30 · API key limits: Self-Hosted 1 / Pro 2 / Team 5 / Enterprise 50 (enforcement via `API_KEY_LIMITS_ENFORCED`, default OFF; self-hosted resolved via `DEPLOYMENT_MODE`, not `users.plan`). Self-host embeddings off unless `EMBEDDINGS_ENABLED=true`.
 >
 > **OSS scope:** This repo ships the tenant dashboard and public marketing/community surfaces. The managed-cloud **operator admin console** (`/admin`, `/v1/admin/*`) is **not** in this tree — §16 / §20.5 admin sections are historical reference only.
 >
@@ -119,6 +119,7 @@ dashboard/
 │   │                        # EventList, EventDetailPanel, EventsSegment,
 │   │                        # SessionsSegment, TimeTravelSegment, BehaviorPanel,
 │   │                        # FleetTable, AgentKeysSection
+│   ├── auth/OtpForm.tsx      # Shared login/signup email + OTP (intent-scoped)
 │   ├── TenantPlanBanner.tsx, ApiKeyUsage.tsx
 │   ├── ConnectionStatus.tsx (+ GettingStartedChecklist)
 │   ├── SiteNav.tsx, BrandLogo.tsx, AgentApiKeys.tsx, brand.ts
@@ -301,7 +302,7 @@ There is a **separate** lead-capture path (`lib/demo.ts` → `submitDemoRequest`
 
 **Auth model:** passwordless email OTP for managed cloud; `POST /v1/auth/request-otp` then `/verify-otp` returns a JWT (`access_token`, 7-day TTL per `TOKEN_MAX_AGE_SEC`). Self-host DEV_MODE offers `POST /v1/auth/dev-token`.
 
-**Signup vs login:** Both flows use `intent` on `requestOtp` / `verifyOtp` (`login` | `signup`, default `login`). Login request-otp returns **404** when no account exists; signup returns **409** when the email is already registered. Login verify only succeeds for existing users; signup requires `gdpr_consent=true` and creates a new tenant/user. OTP is consumed atomically inside the verify transaction (invalid OTP or pre-check failures do not burn the code). After success, auth uses `window.location.assign` (hard redirect) to avoid stuck OTP screens. Helpers: `lib/auth-errors.ts`, `lib/signup-funnel.ts`, `hooks/useResendCooldown.ts` (60s resend cooldown on login and signup).
+**Signup vs login:** Both flows use `intent` on `requestOtp` / `verifyOtp` (`login` | `signup`, default `login`). Login request-otp returns **404** when no account exists; signup returns **409** when the email is already registered. Login verify only succeeds for existing users; signup requires `gdpr_consent=true` and creates a new tenant/user. OTP is consumed atomically inside the verify transaction (invalid OTP or pre-check failures do not burn the code). After success, auth uses `window.location.assign` (hard redirect) to avoid stuck OTP screens. Helpers: `lib/auth-errors.ts`, `lib/signup-funnel.ts`, `hooks/useResendCooldown.ts` (60s resend cooldown), shared `<OtpForm intent>` (`components/auth/OtpForm.tsx`). `requestOtp` payloads stay separate (`login` vs `signup`).
 
 **Billing / trial (no payment provider):** signup OTP verify sets `plan=pro` (if unset), `subscription_status=trialing`, `trial_ends_at=+30d` (also converts legacy `pending_checkout` rows). `postAuthRedirect()` always returns `/dashboard`. `getBillingStatus` / `billing_status_payload` always return `has_access: true`, `enforced: false`, `requires_checkout: false` — informational only for `TenantPlanBanner`.
 
@@ -432,7 +433,7 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 1. **Duplicate plan definitions** (landing, `/signup/plan`, backend `PLAN_CATALOG`) → drift risk; consolidate on one API or shared config.
 2. ~~**No shared trial-CTA component**~~ — **done 2026-08-26:** `<StartTrialButton plan?>` (`components/marketing/StartTrialButton.tsx`) plus `startTrialHref()` in `lib/plans.ts`. Landing hero/footer, SiteNav, and managed pricing cards share `/signup/plan` (no plan) or `/signup?plan=`. Docs, login, and trust links are left as-is.
 3. ~~**Repeated funnel-guard logic**~~ — **done 2026-08-25:** `useSignupFunnelGuard` (`hooks/useSignupFunnelGuard.ts`) plus `signupOtpRedirect` / `resolveSignupStartPlan` in `lib/signup-funnel.ts`. `/signup` and `/signup/start` share the same plan/consent redirects and keep the fallback gate so the form does not flash.
-4. **Duplicated OTP form** (`login` vs `signup` are ~90% identical) → shared `<OtpForm/>`.
+4. ~~**Duplicated OTP form**~~ — **done 2026-08-30:** `<OtpForm intent>` (`components/auth/OtpForm.tsx`) owns email/OTP/resend, `useResendCooldown`, `verifyLock`, and `OTP_LENGTH`. Login still `requestOtp(email, 'login')`; signup still `requestOtp(email, 'signup')`. Pages keep verify side effects (`onVerified`).
 5. **No analytics/telemetry** on funnel steps → hard to measure drop-off.
 6. **No React Query/SWR** → manual polling + no dedupe/caching; billing status fetched on mount by `TenantPlanBanner`.
 7. **Inconsistent styling systems** (Tailwind vs inline).
@@ -885,12 +886,12 @@ sits inside a `<Suspense>` boundary — required or the build fails on CSR bailo
 
 ### 19.6 Login — `app/login/page.tsx`
 
-- **Consts:** `IS_DEV_MODE`, `API_URL`. Suspense wrapper.
-- **State:** `email`, `otp`, `step`, `loading`, `devLoading`, `navigating`, `error`, `noAccount`; `verifyLock` ref prevents double verify; `useResendCooldown` (60s).
-- **`safeNext`:** uses `next` param only if it starts with `/dashboard` and not `//`; else `/dashboard`. `?email=` pre-fills email; `?deleted=1` shows re-register banner.
-- **Effect:** existing token → hard redirect `safeNext`. OTP auto-submits at 6 digits via `verifyFormRef.requestSubmit()`.
-- **API:** `requestOtp(email, 'login')`; `verifyOtp(email, otp, { intent: 'login' })` → `setToken` → `window.location.assign(safeNext)`.
-- **Errors:** `authErrorMessage` / `isNoAccountError` (404) → inline "Create account" CTA. Resend with cooldown. Dev-token bypass when `IS_DEV_MODE`.
+- **Consts:** `IS_DEV_MODE`. Suspense wrapper. Email/OTP UI is `<OtpForm intent="login">`.
+- **Page state:** `devLoading`, `navigating`, `error` (dev-token only). Form state (`email`, `otp`, `step`, `loading`, `noAccount`, `verifyLock`, cooldown) lives in `OtpForm`.
+- **`safeNext`:** uses `next` param only if it starts with `/dashboard` and not `//`; else `/dashboard`. `?email=` pre-fills via `initialEmail`; `?deleted=1` shows re-register banner.
+- **Effect:** existing token → hard redirect `safeNext`. OTP auto-submits at 6 digits inside `OtpForm`.
+- **API:** `OtpForm` calls `requestOtp(email, 'login')`; `onVerified` calls `verifyOtp(email, otp, { intent: 'login' })` → `setToken` → `window.location.assign(safeNext)`.
+- **Errors:** 404 → inline "Create account" CTA in `OtpForm`. Resend with 60s cooldown. Dev-token bypass when `IS_DEV_MODE`.
 
 ### 19.7 Plan selection — `app/signup/plan/page.tsx`
 
@@ -908,6 +909,7 @@ sits inside a `<Suspense>` boundary — required or the build fails on CSR bailo
 - **`useConnectionHealth.ts`** — state `health: 'checking'|'ok'|'error'`; mount + **30s `/health` poll** (`cache:'no-store'`, `cancelled` + interval + `visibilitychange` cleanup). Ticks skipped while the tab is hidden; a check runs when the tab becomes visible. First paint in a hidden tab can stay `'checking'`.
 - **`ConnectionStatus.tsx`** — no longer polls. Exports `GettingStartedChecklist` only (Activity empty state; Python snippet + step 1 copy differ by edition).
 - **`AgentApiKeys.tsx`** — state keys/loading/creating/revokingId/newKey/copied/err/testBusy/testMsg (`:24-32`); `load` useCallback → `getAgentApiKeys` (normalizes to array, `:34-44`); effect re-loads when `agentId` changes (`:46-48`). `createAgentApiKey` (`:55`) → reload; `revokeAgentApiKey` (`:72`, confirm first `:66-67`); `sendAgentTestEvent` (`:110`) → `onTestSuccess?.()` (`:112`). One-time key display; copy resets 2s (`:84`).
+- **`OtpForm.tsx`** — shared login/signup email + code form. `requestOtp(email, intent)` only (no extra payload fields). `onVerified({ email, otp })` for verify; return `'aborted'` to unlock without an error (signup GDPR redirect). Signup 409 → "Sign in →"; login 404 → "Create account".
 
 ### 19.10 Cross-cutting quick reference
 
@@ -923,11 +925,11 @@ sits inside a `<Suspense>` boundary — required or the build fails on CSR bailo
 
 ### 19.11 Signup email/OTP — `app/signup/page.tsx`
 
-- **Step 3 of the funnel** (account creation). Suspense-wrapped (`useSearchParams`); `SignupForm` inner.
-- **State:** `email`, `otp`, `step` (`'email'|'otp'`), `loading`, `error`, `alreadyRegistered`, and `checked` (the render gate).
-- **Guard effect:** resets step/otp/error; persists `?plan=` via `SIGNUP_PLAN_KEY`; missing plan → `/signup/plan`; missing consent → `/signup/start`; else `setChecked(true)`. Renders `SignupFallback` until `checked`.
-- **API:** `requestOtp(email, 'signup')`; `verifyOtp(..., { intent: 'signup', gdprConsent, marketingConsent })` → `setToken` → `clearSignupSession()` → best-effort `selectBillingPlan` → `window.location.assign('/dashboard')`.
-- **UX:** OTP auto-submit at 6 digits; resend with 60s cooldown; `auth-errors` helpers for 409/GDPR; "already registered" links to `/login?email=`.
+- **Step 3 of the funnel** (account creation). Suspense-wrapped (`useSearchParams`); `SignupForm` inner. Email/OTP UI is `<OtpForm intent="signup" key={searchParams}>`.
+- **Page state:** `navigating` plus `checked` from `useSignupFunnelGuard('otp')`. Form state lives in `OtpForm`.
+- **Guard:** missing plan → `/signup/plan`; missing consent → `/signup/start`. Renders `SignupFallback` until `checked`.
+- **API:** `OtpForm` calls `requestOtp(email, 'signup')`; `onVerified` checks GDPR then `verifyOtp(..., { intent: 'signup', gdprConsent, marketingConsent })` → `setToken` → `clearSignupSession()` → `selectBillingPlan` → `window.location.assign('/dashboard')`. Missing GDPR or `isGdprConsentError` → `router.replace('/signup/start')` and `'aborted'`.
+- **UX:** OTP auto-submit at 6 digits; resend with 60s cooldown; 409 → "Sign in →" to `/login?email=`.
 
 ### 19.12 Before-you-begin / consent — `app/signup/start/page.tsx`
 

--- a/dashboard/app/login/page.tsx
+++ b/dashboard/app/login/page.tsx
@@ -1,14 +1,13 @@
 "use client";
 
-import { useState, useEffect, useRef, Suspense } from "react";
+import { useState, useEffect, Suspense } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { requestOtp, verifyOtp, devLogin } from "@/lib/api";
-import { authErrorMessage, isNoAccountError } from "@/lib/auth-errors";
+import { verifyOtp, devLogin } from "@/lib/api";
 import { getToken, setToken } from "@/lib/auth";
-import { OTP_LENGTH, IS_DEV_MODE } from "@/lib/constants";
-import { useResendCooldown } from "@/hooks/useResendCooldown";
+import { IS_DEV_MODE } from "@/lib/constants";
 import { BrandLogo } from "@/components/BrandLogo";
+import { OtpForm } from "@/components/auth/OtpForm";
 
 function completeAuthRedirect(path: string) {
   window.location.assign(path);
@@ -42,31 +41,17 @@ function LoginFallback() {
 
 function LoginForm() {
   const searchParams = useSearchParams();
-  const [email, setEmail] = useState("");
-  const [otp, setOtp] = useState("");
-  const [step, setStep] = useState<"email" | "otp">("email");
-  const [loading, setLoading] = useState(false);
   const [devLoading, setDevLoading] = useState(false);
   const [navigating, setNavigating] = useState(false);
   const [error, setError] = useState("");
-  const [noAccount, setNoAccount] = useState(false);
-  const verifyLock = useRef(false);
-  const verifyFormRef = useRef<HTMLFormElement>(null);
-  const { cooldown, canResend, startCooldown } = useResendCooldown();
 
   const accountDeleted = searchParams.get("deleted") === "1";
-  const emailPrefill = searchParams.get("email");
+  const emailPrefill = searchParams.get("email") ?? "";
   const nextPath = searchParams.get("next");
   const safeNext =
     nextPath && nextPath.startsWith("/dashboard") && !nextPath.startsWith("//")
       ? nextPath
       : "/dashboard";
-
-  useEffect(() => {
-    if (emailPrefill) {
-      setEmail(emailPrefill);
-    }
-  }, [emailPrefill]);
 
   useEffect(() => {
     const existing = getToken();
@@ -76,72 +61,17 @@ function LoginForm() {
     }
   }, [safeNext]);
 
-  useEffect(() => {
-    if (
-      step !== "otp" ||
-      otp.length !== OTP_LENGTH ||
-      loading ||
-      navigating ||
-      verifyLock.current
-    )
-      return;
-    verifyFormRef.current?.requestSubmit();
-  }, [otp, step, loading, navigating]);
-
-  async function sendLoginOtp() {
-    await requestOtp(email, "login");
-    setStep("otp");
-    startCooldown();
-  }
-
-  async function handleRequestOtp(e: React.FormEvent) {
-    e.preventDefault();
-    setLoading(true);
-    setError("");
-    setNoAccount(false);
-    try {
-      await sendLoginOtp();
-    } catch (err) {
-      setNoAccount(isNoAccountError(err));
-      setError(authErrorMessage(err, "Failed to send code. Try again."));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleResendOtp() {
-    if (!canResend || loading) return;
-    setLoading(true);
-    setError("");
-    setNoAccount(false);
-    try {
-      await sendLoginOtp();
-    } catch (err) {
-      setNoAccount(isNoAccountError(err));
-      setError(authErrorMessage(err, "Failed to resend code. Try again."));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleVerifyOtp(e: React.FormEvent) {
-    e.preventDefault();
-    if (verifyLock.current || navigating) return;
-    verifyLock.current = true;
-    setLoading(true);
-    setError("");
-    setNoAccount(false);
-    try {
-      const data = await verifyOtp(email, otp, { intent: "login" });
-      setToken(data.access_token);
-      setNavigating(true);
-      completeAuthRedirect(safeNext);
-    } catch (err) {
-      verifyLock.current = false;
-      setNoAccount(isNoAccountError(err));
-      setError(authErrorMessage(err, "Invalid or expired code."));
-      setLoading(false);
-    }
+  async function handleVerified({
+    email,
+    otp,
+  }: {
+    email: string;
+    otp: string;
+  }) {
+    const data = await verifyOtp(email, otp, { intent: "login" });
+    setToken(data.access_token);
+    setNavigating(true);
+    completeAuthRedirect(safeNext);
   }
 
   async function handleDevLogin() {
@@ -304,248 +234,19 @@ function LoginForm() {
             </p>
           )}
 
-          {step === "email" ? (
-            <>
-              {!IS_DEV_MODE && (
-                <h1
-                  style={{
-                    fontSize: 20,
-                    fontWeight: 700,
-                    color: "#111",
-                    marginBottom: 6,
-                  }}
-                >
-                  Sign in
-                </h1>
-              )}
-              {!IS_DEV_MODE && (
-                <p style={{ fontSize: 14, color: "#888", marginBottom: 24 }}>
-                  Enter your email and we&apos;ll send a 6-digit login code.
-                </p>
-              )}
-              <form
-                onSubmit={handleRequestOtp}
-                style={{ display: "flex", flexDirection: "column", gap: 16 }}
-              >
-                <div>
-                  <label
-                    style={{
-                      display: "block",
-                      fontSize: 13,
-                      fontWeight: 500,
-                      color: "#555",
-                      marginBottom: 6,
-                    }}
-                  >
-                    Email address
-                  </label>
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="you@company.com"
-                    required
-                    autoFocus={!IS_DEV_MODE}
-                    style={{
-                      width: "100%",
-                      boxSizing: "border-box",
-                      padding: "10px 14px",
-                      borderRadius: 9,
-                      fontSize: 14,
-                      border: "1px solid #ddd",
-                      outline: "none",
-                      color: "#111",
-                      background: "#fafafa",
-                    }}
-                    onFocus={(e) => (e.target.style.borderColor = "#111")}
-                    onBlur={(e) => (e.target.style.borderColor = "#ddd")}
-                  />
-                </div>
-                {error && (
-                  <div style={{ fontSize: 13, color: "#ef4444" }}>
-                    <p style={{ margin: 0 }}>{error}</p>
-                    {noAccount && (
-                      <Link
-                        href="/signup"
-                        style={{
-                          display: "inline-block",
-                          marginTop: 10,
-                          padding: "8px 14px",
-                          borderRadius: 8,
-                          background: "#111",
-                          color: "#fff",
-                          fontWeight: 600,
-                          textDecoration: "none",
-                          fontSize: 13,
-                        }}
-                      >
-                        Create account
-                      </Link>
-                    )}
-                  </div>
-                )}
-                <button
-                  type="submit"
-                  disabled={loading || !email}
-                  style={{
-                    padding: "11px",
-                    borderRadius: 9,
-                    fontSize: 14,
-                    fontWeight: 500,
-                    background: "#111",
-                    color: "#fff",
-                    border: "none",
-                    cursor: "pointer",
-                    opacity: loading || !email ? 0.4 : 1,
-                  }}
-                >
-                  {loading ? "Sending..." : "Send code →"}
-                </button>
-                <p style={{ fontSize: 12, color: "#bbb", textAlign: "center" }}>
-                  We send a 6-digit code to your email. No password needed.
-                </p>
-              </form>
-            </>
-          ) : (
-            <>
-              <h1
-                style={{
-                  fontSize: 20,
-                  fontWeight: 700,
-                  color: "#111",
-                  marginBottom: 6,
-                }}
-              >
-                Check your email
-              </h1>
-              <p style={{ fontSize: 14, color: "#888", marginBottom: 24 }}>
-                We sent a 6-digit code to{" "}
-                <strong style={{ color: "#111" }}>{email}</strong>
-              </p>
-              <form
-                ref={verifyFormRef}
-                onSubmit={handleVerifyOtp}
-                style={{ display: "flex", flexDirection: "column", gap: 16 }}
-              >
-                <div>
-                  <label
-                    style={{
-                      display: "block",
-                      fontSize: 13,
-                      fontWeight: 500,
-                      color: "#555",
-                      marginBottom: 6,
-                    }}
-                  >
-                    Login code
-                  </label>
-                  <input
-                    type="text"
-                    value={otp}
-                    onChange={(e) =>
-                      setOtp(
-                        e.target.value.replace(/\D/g, "").slice(0, OTP_LENGTH),
-                      )
-                    }
-                    placeholder="000000"
-                    required
-                    autoFocus
-                    maxLength={OTP_LENGTH}
-                    disabled={loading}
-                    style={{
-                      width: "100%",
-                      boxSizing: "border-box",
-                      padding: "12px",
-                      borderRadius: 9,
-                      fontSize: 24,
-                      border: "1px solid #ddd",
-                      outline: "none",
-                      color: "#111",
-                      background: "#fafafa",
-                      textAlign: "center",
-                      letterSpacing: "0.4em",
-                      fontFamily: "monospace",
-                    }}
-                    onFocus={(e) => (e.target.style.borderColor = "#111")}
-                    onBlur={(e) => (e.target.style.borderColor = "#ddd")}
-                  />
-                </div>
-                {error && (
-                  <div style={{ fontSize: 13, color: "#ef4444" }}>
-                    <p style={{ margin: 0 }}>{error}</p>
-                    {noAccount && (
-                      <Link
-                        href="/signup"
-                        style={{
-                          display: "inline-block",
-                          marginTop: 10,
-                          padding: "8px 14px",
-                          borderRadius: 8,
-                          background: "#111",
-                          color: "#fff",
-                          fontWeight: 600,
-                          textDecoration: "none",
-                          fontSize: 13,
-                        }}
-                      >
-                        Create account
-                      </Link>
-                    )}
-                  </div>
-                )}
-                <button
-                  type="submit"
-                  disabled={loading || otp.length < OTP_LENGTH}
-                  style={{
-                    padding: "11px",
-                    borderRadius: 9,
-                    fontSize: 14,
-                    fontWeight: 500,
-                    background: "#111",
-                    color: "#fff",
-                    border: "none",
-                    cursor: "pointer",
-                    opacity: loading || otp.length < OTP_LENGTH ? 0.4 : 1,
-                  }}
-                >
-                  {loading ? "Signing you in…" : "Sign in →"}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleResendOtp}
-                  disabled={!canResend || loading}
-                  style={{
-                    fontSize: 13,
-                    color: canResend ? "#555" : "#bbb",
-                    background: "none",
-                    border: "none",
-                    cursor: canResend && !loading ? "pointer" : "not-allowed",
-                  }}
-                >
-                  {canResend ? "Resend code" : `Resend code in ${cooldown}s`}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    verifyLock.current = false;
-                    setStep("email");
-                    setOtp("");
-                    setError("");
-                    setNoAccount(false);
-                  }}
-                  style={{
-                    fontSize: 13,
-                    color: "#888",
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                  }}
-                >
-                  ← Use a different email
-                </button>
-              </form>
-            </>
+          {error && (
+            <p style={{ fontSize: 13, color: "#ef4444", marginTop: 0 }}>
+              {error}
+            </p>
           )}
+
+          <OtpForm
+            intent="login"
+            initialEmail={emailPrefill}
+            autoFocusEmail={!IS_DEV_MODE}
+            hideEmailHeading={IS_DEV_MODE}
+            onVerified={handleVerified}
+          />
         </div>
 
         {!IS_DEV_MODE && (

--- a/dashboard/app/signup/page.tsx
+++ b/dashboard/app/signup/page.tsx
@@ -1,17 +1,11 @@
 "use client";
 
-import { Suspense, useEffect, useRef, useState } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { requestOtp, verifyOtp, selectBillingPlan } from "@/lib/api";
-import {
-  authErrorMessage,
-  isAlreadyRegisteredError,
-  isGdprConsentError,
-} from "@/lib/auth-errors";
+import { verifyOtp, selectBillingPlan } from "@/lib/api";
+import { isGdprConsentError } from "@/lib/auth-errors";
 import { setToken } from "@/lib/auth";
-import { OTP_LENGTH } from "@/lib/constants";
-import { useResendCooldown } from "@/hooks/useResendCooldown";
 import { useSignupFunnelGuard } from "@/hooks/useSignupFunnelGuard";
 import {
   clearSignupSession,
@@ -20,15 +14,9 @@ import {
   SIGNUP_CONSENT_MARKETING_KEY,
 } from "@/lib/signup-funnel";
 import { BrandLogo } from "@/components/BrandLogo";
+import { OtpForm } from "@/components/auth/OtpForm";
 import {
-  authPage,
   authCard,
-  authTitle,
-  authSubtitle,
-  authLabel,
-  authInput,
-  authSubmitBtn,
-  authLink,
   authMutedLink,
 } from "@/components/marketing/auth-styles";
 import { M } from "@/components/marketing/marketing-theme";
@@ -62,91 +50,25 @@ function SignupFallback() {
 function SignupForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const [email, setEmail] = useState("");
-  const [otp, setOtp] = useState("");
-  const [step, setStep] = useState<"email" | "otp">("email");
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState("");
-  const [alreadyRegistered, setAlreadyRegistered] = useState(false);
   const [navigating, setNavigating] = useState(false);
-  const verifyLock = useRef(false);
-  const verifyFormRef = useRef<HTMLFormElement>(null);
-  const { cooldown, canResend, startCooldown } = useResendCooldown();
   const { ready: checked } = useSignupFunnelGuard("otp");
 
-  useEffect(() => {
-    // Always start from email step when entering /signup to avoid stale OTP view.
-    setStep("email");
-    setOtp("");
-    setError("");
-    setAlreadyRegistered(false);
-  }, [searchParams]);
-
-  useEffect(() => {
-    if (
-      step !== "otp" ||
-      otp.length !== OTP_LENGTH ||
-      loading ||
-      navigating ||
-      verifyLock.current
-    )
-      return;
-    verifyFormRef.current?.requestSubmit();
-  }, [otp, step, loading, navigating]);
-
-  async function sendSignupOtp() {
-    await requestOtp(email, "signup");
-    setStep("otp");
-    startCooldown();
-  }
-
-  async function handleRequestOtp(e: React.FormEvent) {
-    e.preventDefault();
-    setLoading(true);
-    setError("");
-    setAlreadyRegistered(false);
-    try {
-      await sendSignupOtp();
-    } catch (e) {
-      setAlreadyRegistered(isAlreadyRegisteredError(e));
-      setError(authErrorMessage(e, "Could not send code. Please try again."));
-    } finally {
-      setLoading(false);
+  async function handleVerified({
+    email,
+    otp,
+  }: {
+    email: string;
+    otp: string;
+  }) {
+    const gdprConsent = hasSignupConsent();
+    const marketingConsent =
+      sessionStorage.getItem(SIGNUP_CONSENT_MARKETING_KEY) === "1";
+    if (!gdprConsent) {
+      const plan = getStoredSignupPlan() ?? "pro";
+      router.replace(`/signup/start?plan=${plan}`);
+      return "aborted";
     }
-  }
-
-  async function handleResendOtp() {
-    if (!canResend || loading) return;
-    setLoading(true);
-    setError("");
-    setAlreadyRegistered(false);
     try {
-      await sendSignupOtp();
-    } catch (e) {
-      setAlreadyRegistered(isAlreadyRegisteredError(e));
-      setError(authErrorMessage(e, "Failed to resend code. Try again."));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function handleVerifyOtp(e: React.FormEvent) {
-    e.preventDefault();
-    if (verifyLock.current || navigating) return;
-    verifyLock.current = true;
-    setLoading(true);
-    setError("");
-    try {
-      const gdprConsent = hasSignupConsent();
-      const marketingConsent =
-        sessionStorage.getItem(SIGNUP_CONSENT_MARKETING_KEY) === "1";
-      if (!gdprConsent) {
-        verifyLock.current = false;
-        setLoading(false);
-        const plan = getStoredSignupPlan() ?? "pro";
-        router.replace(`/signup/start?plan=${plan}`);
-        return;
-      }
       const data = await verifyOtp(email, otp, {
         intent: "signup",
         gdprConsent,
@@ -161,17 +83,12 @@ function SignupForm() {
       }
       window.location.assign("/dashboard");
     } catch (e) {
-      verifyLock.current = false;
-      setNavigating(false);
       if (isGdprConsentError(e)) {
-        setLoading(false);
         const plan = getStoredSignupPlan() ?? "pro";
         router.replace(`/signup/start?plan=${plan}`);
-        return;
+        return "aborted";
       }
-      setAlreadyRegistered(isAlreadyRegisteredError(e));
-      setError(authErrorMessage(e, "Invalid or expired code."));
-      setLoading(false);
+      throw e;
     }
   }
 
@@ -216,161 +133,12 @@ function SignupForm() {
           />
         </div>
 
-        {/* Card */}
         <div style={authCard}>
-          {step === "email" ? (
-            <>
-              <h1 style={authTitle}>Create your account</h1>
-              <p style={authSubtitle}>
-                Enter your email. We send a 6-digit code — no password needed.
-              </p>
-              <form
-                onSubmit={handleRequestOtp}
-                style={{ display: "flex", flexDirection: "column", gap: 16 }}
-              >
-                <div>
-                  <label style={authLabel}>Work email</label>
-                  <input
-                    type="email"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    placeholder="you@company.com"
-                    required
-                    autoFocus
-                    style={authInput}
-                    onFocus={(e) => (e.target.style.borderColor = M.brandLight)}
-                    onBlur={(e) => (e.target.style.borderColor = M.lineStrong)}
-                  />
-                </div>
-                {error && (
-                  <p style={{ fontSize: 13, color: M.danger, margin: 0 }}>
-                    {error}
-                    {alreadyRegistered && (
-                      <>
-                        {" "}
-                        <Link
-                          href={`/login?email=${encodeURIComponent(email)}`}
-                          style={{ color: M.brandLight, fontWeight: 600 }}
-                        >
-                          Sign in →
-                        </Link>
-                      </>
-                    )}
-                  </p>
-                )}
-                <button
-                  type="submit"
-                  disabled={loading || !email}
-                  style={{
-                    ...authSubmitBtn,
-                    opacity: loading || !email ? 0.4 : 1,
-                  }}
-                >
-                  {loading ? "Sending..." : "Send verification code →"}
-                </button>
-              </form>
-            </>
-          ) : (
-            <>
-              <h1 style={authTitle}>Verify your email</h1>
-              <p style={authSubtitle}>
-                We sent a 6-digit code to{" "}
-                <strong style={{ color: M.ink }}>{email}</strong>
-              </p>
-              <form
-                ref={verifyFormRef}
-                onSubmit={handleVerifyOtp}
-                style={{ display: "flex", flexDirection: "column", gap: 16 }}
-              >
-                <div>
-                  <label style={authLabel}>Verification code</label>
-                  <input
-                    type="text"
-                    value={otp}
-                    onChange={(e) =>
-                      setOtp(
-                        e.target.value.replace(/\D/g, "").slice(0, OTP_LENGTH),
-                      )
-                    }
-                    placeholder="000000"
-                    required
-                    autoFocus
-                    maxLength={OTP_LENGTH}
-                    disabled={loading}
-                    style={{
-                      ...authInput,
-                      padding: "12px",
-                      fontSize: 28,
-                      textAlign: "center",
-                      letterSpacing: "0.4em",
-                      fontFamily: "monospace",
-                    }}
-                    onFocus={(e) => (e.target.style.borderColor = M.brandLight)}
-                    onBlur={(e) => (e.target.style.borderColor = M.lineStrong)}
-                  />
-                </div>
-                {error && (
-                  <p style={{ fontSize: 13, color: M.danger, margin: 0 }}>
-                    {error}
-                    {alreadyRegistered && (
-                      <>
-                        {" "}
-                        <Link
-                          href={`/login?email=${encodeURIComponent(email)}`}
-                          style={{ color: M.brandLight, fontWeight: 600 }}
-                        >
-                          Sign in →
-                        </Link>
-                      </>
-                    )}
-                  </p>
-                )}
-                <button
-                  type="submit"
-                  disabled={loading || otp.length < OTP_LENGTH}
-                  style={{
-                    ...authSubmitBtn,
-                    opacity: loading || otp.length < OTP_LENGTH ? 0.4 : 1,
-                  }}
-                >
-                  {loading ? "Verifying..." : "Create account →"}
-                </button>
-                <button
-                  type="button"
-                  onClick={handleResendOtp}
-                  disabled={!canResend || loading}
-                  style={{
-                    fontSize: 13,
-                    color: canResend ? M.muted : M.faint,
-                    background: "none",
-                    border: "none",
-                    cursor: canResend && !loading ? "pointer" : "not-allowed",
-                  }}
-                >
-                  {canResend ? "Resend code" : `Resend code in ${cooldown}s`}
-                </button>
-                <button
-                  type="button"
-                  onClick={() => {
-                    verifyLock.current = false;
-                    setStep("email");
-                    setOtp("");
-                    setError("");
-                    setAlreadyRegistered(false);
-                  }}
-                  style={{
-                    fontSize: 13,
-                    color: M.faint,
-                    background: "none",
-                    border: "none",
-                    cursor: "pointer",
-                  }}
-                >
-                  ← Use a different email
-                </button>
-              </form>
-            </>
-          )}
+          <OtpForm
+            key={searchParams.toString()}
+            intent="signup"
+            onVerified={handleVerified}
+          />
         </div>
 
         <p

--- a/dashboard/components/auth/OtpForm.test.tsx
+++ b/dashboard/components/auth/OtpForm.test.tsx
@@ -1,0 +1,127 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { AuthRequestError, requestOtp } = vi.hoisted(() => {
+  class AuthRequestError extends Error {
+    readonly status: number
+    constructor(message: string, status: number) {
+      super(message)
+      this.name = 'AuthRequestError'
+      this.status = status
+    }
+  }
+  return { AuthRequestError, requestOtp: vi.fn() }
+})
+
+vi.mock('@/lib/api', () => ({
+  AuthRequestError,
+  requestOtp,
+}))
+
+import { OtpForm } from './OtpForm'
+
+beforeEach(() => {
+  requestOtp.mockReset()
+  requestOtp.mockResolvedValue({})
+})
+
+describe('OtpForm', () => {
+  it('sends login requestOtp without mixing in signup fields', async () => {
+    render(<OtpForm intent="login" onVerified={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'you@company.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }))
+
+    await waitFor(() =>
+      expect(requestOtp).toHaveBeenCalledWith('you@company.com', 'login'),
+    )
+    expect(requestOtp.mock.calls[0]).toHaveLength(2)
+    expect(screen.getByText(/we sent a 6-digit code to/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /resend code in/i })).toBeDisabled()
+  })
+
+  it('sends signup requestOtp with intent signup only', async () => {
+    render(<OtpForm intent="signup" onVerified={vi.fn()} />)
+
+    fireEvent.change(screen.getByLabelText('Work email'), {
+      target: { value: 'new@company.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send verification code/i }))
+
+    await waitFor(() =>
+      expect(requestOtp).toHaveBeenCalledWith('new@company.com', 'signup'),
+    )
+    expect(requestOtp.mock.calls[0]).toHaveLength(2)
+  })
+
+  it('shows create-account on login 404, not the signup sign-in link', async () => {
+    requestOtp.mockRejectedValueOnce(new AuthRequestError('No account', 404))
+    render(<OtpForm intent="login" onVerified={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'missing@company.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }))
+    await waitFor(() => expect(screen.getByText('Create account')).toBeInTheDocument())
+    expect(screen.queryByText('Sign in →')).not.toBeInTheDocument()
+  })
+
+  it('shows sign-in on signup 409, not the login create-account CTA', async () => {
+    requestOtp.mockRejectedValueOnce(new AuthRequestError('Taken', 409))
+    render(<OtpForm intent="signup" onVerified={vi.fn()} />)
+    fireEvent.change(screen.getByLabelText('Work email'), {
+      target: { value: 'taken@company.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send verification code/i }))
+    await waitFor(() => expect(screen.getByText('Sign in →')).toBeInTheDocument())
+    expect(screen.queryByText('Create account')).not.toBeInTheDocument()
+  })
+
+  it('calls onVerified with email and otp and keeps requestOtp payloads separate', async () => {
+    const onVerified = vi.fn().mockResolvedValue(undefined)
+    render(<OtpForm intent="login" onVerified={onVerified} />)
+
+    fireEvent.change(screen.getByLabelText('Email address'), {
+      target: { value: 'you@company.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send code/i }))
+    await waitFor(() => expect(screen.getByLabelText('Login code')).toBeInTheDocument())
+
+    fireEvent.change(screen.getByLabelText('Login code'), {
+      target: { value: '123456' },
+    })
+
+    await waitFor(() =>
+      expect(onVerified).toHaveBeenCalledWith({
+        email: 'you@company.com',
+        otp: '123456',
+      }),
+    )
+    expect(requestOtp).toHaveBeenCalledWith('you@company.com', 'login')
+  })
+
+  it('unlocks when onVerified returns aborted', async () => {
+    const onVerified = vi.fn().mockResolvedValue('aborted')
+    render(<OtpForm intent="signup" onVerified={onVerified} />)
+
+    fireEvent.change(screen.getByLabelText('Work email'), {
+      target: { value: 'you@company.com' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /send verification code/i }))
+    await waitFor(() =>
+      expect(screen.getByLabelText('Verification code')).toBeInTheDocument(),
+    )
+
+    fireEvent.change(screen.getByLabelText('Verification code'), {
+      target: { value: '654321' },
+    })
+
+    await waitFor(() => expect(onVerified).toHaveBeenCalled())
+    await waitFor(() =>
+      expect(
+        screen.getByRole('button', { name: /create account/i }),
+      ).not.toBeDisabled(),
+    )
+  })
+})

--- a/dashboard/components/auth/OtpForm.tsx
+++ b/dashboard/components/auth/OtpForm.tsx
@@ -1,0 +1,447 @@
+'use client'
+
+import Link from 'next/link'
+import { useEffect, useRef, useState, type CSSProperties, type FormEvent } from 'react'
+import {
+  authInput,
+  authLabel,
+  authSubmitBtn,
+  authSubtitle,
+  authTitle,
+} from '@/components/marketing/auth-styles'
+import { M } from '@/components/marketing/marketing-theme'
+import { useResendCooldown } from '@/hooks/useResendCooldown'
+import { requestOtp } from '@/lib/api'
+import {
+  authErrorMessage,
+  isAlreadyRegisteredError,
+  isNoAccountError,
+} from '@/lib/auth-errors'
+import { OTP_LENGTH } from '@/lib/constants'
+
+export type OtpFormIntent = 'login' | 'signup'
+
+export function OtpForm({
+  intent,
+  onVerified,
+  initialEmail = '',
+  autoFocusEmail = true,
+  hideEmailHeading = false,
+}: {
+  intent: OtpFormIntent
+  onVerified: (args: { email: string; otp: string }) => Promise<void | 'aborted'>
+  initialEmail?: string
+  autoFocusEmail?: boolean
+  hideEmailHeading?: boolean
+}) {
+  const copy = COPY[intent]
+  const styles = intent === 'signup' ? SIGNUP_STYLES : LOGIN_STYLES
+  const [email, setEmail] = useState(initialEmail)
+  const [otp, setOtp] = useState('')
+  const [step, setStep] = useState<'email' | 'otp'>('email')
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [noAccount, setNoAccount] = useState(false)
+  const [alreadyRegistered, setAlreadyRegistered] = useState(false)
+  const verifyLock = useRef(false)
+  const verifyFormRef = useRef<HTMLFormElement>(null)
+  const { cooldown, canResend, startCooldown } = useResendCooldown()
+
+  useEffect(() => {
+    if (initialEmail) setEmail(initialEmail)
+  }, [initialEmail])
+
+  useEffect(() => {
+    if (
+      step !== 'otp' ||
+      otp.length !== OTP_LENGTH ||
+      loading ||
+      verifyLock.current
+    ) {
+      return
+    }
+    verifyFormRef.current?.requestSubmit()
+  }, [otp, step, loading])
+
+  function clearFlags() {
+    setError('')
+    setNoAccount(false)
+    setAlreadyRegistered(false)
+  }
+
+  function applyRequestError(err: unknown) {
+    setNoAccount(intent === 'login' && isNoAccountError(err))
+    setAlreadyRegistered(intent === 'signup' && isAlreadyRegisteredError(err))
+  }
+
+  async function sendCode() {
+    await requestOtp(email, intent)
+    setStep('otp')
+    startCooldown()
+  }
+
+  async function handleRequestOtp(e: FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    clearFlags()
+    try {
+      await sendCode()
+    } catch (err) {
+      applyRequestError(err)
+      setError(authErrorMessage(err, copy.requestError))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleResendOtp() {
+    if (!canResend || loading) return
+    setLoading(true)
+    clearFlags()
+    try {
+      await sendCode()
+    } catch (err) {
+      applyRequestError(err)
+      setError(authErrorMessage(err, copy.resendError))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function handleVerifyOtp(e: FormEvent) {
+    e.preventDefault()
+    if (verifyLock.current) return
+    verifyLock.current = true
+    setLoading(true)
+    clearFlags()
+    try {
+      const result = await onVerified({ email, otp })
+      if (result === 'aborted') {
+        verifyLock.current = false
+        setLoading(false)
+      }
+    } catch (err) {
+      verifyLock.current = false
+      applyRequestError(err)
+      setError(authErrorMessage(err, copy.verifyError))
+      setLoading(false)
+    }
+  }
+
+  function handleUseDifferentEmail() {
+    verifyLock.current = false
+    setStep('email')
+    setOtp('')
+    clearFlags()
+  }
+
+  const errorBlock = error ? (
+    <ErrorBlock
+      intent={intent}
+      error={error}
+      email={email}
+      noAccount={noAccount}
+      alreadyRegistered={alreadyRegistered}
+    />
+  ) : null
+
+  if (step === 'email') {
+    return (
+      <>
+        {!hideEmailHeading && (
+          <>
+            <h1 style={styles.title}>{copy.emailTitle}</h1>
+            <p style={styles.subtitle}>{copy.emailSubtitle}</p>
+          </>
+        )}
+        <form
+          onSubmit={handleRequestOtp}
+          style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+        >
+          <div>
+            <label htmlFor="otp-form-email" style={styles.label}>
+              {copy.emailLabel}
+            </label>
+            <input
+              id="otp-form-email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@company.com"
+              required
+              autoFocus={autoFocusEmail}
+              style={styles.emailInput}
+              onFocus={(e) => {
+                e.target.style.borderColor = styles.focusBorder
+              }}
+              onBlur={(e) => {
+                e.target.style.borderColor = styles.blurBorder
+              }}
+            />
+          </div>
+          {errorBlock}
+          <button
+            type="submit"
+            disabled={loading || !email}
+            style={{
+              ...styles.submit,
+              opacity: loading || !email ? 0.4 : 1,
+            }}
+          >
+            {loading ? copy.sendingLabel : copy.sendLabel}
+          </button>
+          {copy.emailHint ? (
+            <p style={{ fontSize: 12, color: '#bbb', textAlign: 'center' }}>
+              {copy.emailHint}
+            </p>
+          ) : null}
+        </form>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <h1 style={styles.title}>{copy.otpTitle}</h1>
+      <p style={styles.subtitle}>
+        We sent a 6-digit code to{' '}
+        <strong style={{ color: styles.emailStrong }}>{email}</strong>
+      </p>
+      <form
+        ref={verifyFormRef}
+        onSubmit={handleVerifyOtp}
+        style={{ display: 'flex', flexDirection: 'column', gap: 16 }}
+      >
+        <div>
+          <label htmlFor="otp-form-code" style={styles.label}>
+            {copy.otpLabel}
+          </label>
+          <input
+            id="otp-form-code"
+            type="text"
+            value={otp}
+            onChange={(e) =>
+              setOtp(e.target.value.replace(/\D/g, '').slice(0, OTP_LENGTH))
+            }
+            placeholder="000000"
+            required
+            autoFocus
+            maxLength={OTP_LENGTH}
+            disabled={loading}
+            style={styles.otpInput}
+            onFocus={(e) => {
+              e.target.style.borderColor = styles.focusBorder
+            }}
+            onBlur={(e) => {
+              e.target.style.borderColor = styles.blurBorder
+            }}
+          />
+        </div>
+        {errorBlock}
+        <button
+          type="submit"
+          disabled={loading || otp.length < OTP_LENGTH}
+          style={{
+            ...styles.submit,
+            opacity: loading || otp.length < OTP_LENGTH ? 0.4 : 1,
+          }}
+        >
+          {loading ? copy.verifyingLabel : copy.verifyLabel}
+        </button>
+        <button
+          type="button"
+          onClick={handleResendOtp}
+          disabled={!canResend || loading}
+          style={{
+            fontSize: 13,
+            color: canResend ? styles.resendReady : styles.resendWait,
+            background: 'none',
+            border: 'none',
+            cursor: canResend && !loading ? 'pointer' : 'not-allowed',
+          }}
+        >
+          {canResend ? 'Resend code' : `Resend code in ${cooldown}s`}
+        </button>
+        <button
+          type="button"
+          onClick={handleUseDifferentEmail}
+          style={{
+            fontSize: 13,
+            color: styles.backLink,
+            background: 'none',
+            border: 'none',
+            cursor: 'pointer',
+          }}
+        >
+          ← Use a different email
+        </button>
+      </form>
+    </>
+  )
+}
+
+function ErrorBlock({
+  intent,
+  error,
+  email,
+  noAccount,
+  alreadyRegistered,
+}: {
+  intent: OtpFormIntent
+  error: string
+  email: string
+  noAccount: boolean
+  alreadyRegistered: boolean
+}) {
+  if (intent === 'signup') {
+    return (
+      <p style={{ fontSize: 13, color: M.danger, margin: 0 }}>
+        {error}
+        {alreadyRegistered ? (
+          <>
+            {' '}
+            <Link
+              href={`/login?email=${encodeURIComponent(email)}`}
+              style={{ color: M.brandLight, fontWeight: 600 }}
+            >
+              Sign in →
+            </Link>
+          </>
+        ) : null}
+      </p>
+    )
+  }
+
+  return (
+    <div style={{ fontSize: 13, color: '#ef4444' }}>
+      <p style={{ margin: 0 }}>{error}</p>
+      {noAccount ? (
+        <Link
+          href="/signup"
+          style={{
+            display: 'inline-block',
+            marginTop: 10,
+            padding: '8px 14px',
+            borderRadius: 8,
+            background: '#111',
+            color: '#fff',
+            fontWeight: 600,
+            textDecoration: 'none',
+            fontSize: 13,
+          }}
+        >
+          Create account
+        </Link>
+      ) : null}
+    </div>
+  )
+}
+
+const COPY = {
+  login: {
+    emailTitle: 'Sign in',
+    emailSubtitle: "Enter your email and we'll send a 6-digit login code.",
+    emailLabel: 'Email address',
+    sendLabel: 'Send code →',
+    sendingLabel: 'Sending...',
+    emailHint: 'We send a 6-digit code to your email. No password needed.',
+    otpTitle: 'Check your email',
+    otpLabel: 'Login code',
+    verifyLabel: 'Sign in →',
+    verifyingLabel: 'Signing you in…',
+    requestError: 'Failed to send code. Try again.',
+    resendError: 'Failed to resend code. Try again.',
+    verifyError: 'Invalid or expired code.',
+  },
+  signup: {
+    emailTitle: 'Create your account',
+    emailSubtitle: 'Enter your email. We send a 6-digit code — no password needed.',
+    emailLabel: 'Work email',
+    sendLabel: 'Send verification code →',
+    sendingLabel: 'Sending...',
+    emailHint: '',
+    otpTitle: 'Verify your email',
+    otpLabel: 'Verification code',
+    verifyLabel: 'Create account →',
+    verifyingLabel: 'Verifying...',
+    requestError: 'Could not send code. Please try again.',
+    resendError: 'Failed to resend code. Try again.',
+    verifyError: 'Invalid or expired code.',
+  },
+} as const
+
+const LOGIN_INPUT: CSSProperties = {
+  width: '100%',
+  boxSizing: 'border-box',
+  padding: '10px 14px',
+  borderRadius: 9,
+  fontSize: 14,
+  border: '1px solid #ddd',
+  outline: 'none',
+  color: '#111',
+  background: '#fafafa',
+}
+
+const LOGIN_STYLES = {
+  title: {
+    fontSize: 20,
+    fontWeight: 700,
+    color: '#111',
+    marginBottom: 6,
+  } satisfies CSSProperties,
+  subtitle: { fontSize: 14, color: '#888', marginBottom: 24 } satisfies CSSProperties,
+  label: {
+    display: 'block',
+    fontSize: 13,
+    fontWeight: 500,
+    color: '#555',
+    marginBottom: 6,
+  } satisfies CSSProperties,
+  emailInput: LOGIN_INPUT,
+  otpInput: {
+    ...LOGIN_INPUT,
+    padding: 12,
+    fontSize: 24,
+    textAlign: 'center',
+    letterSpacing: '0.4em',
+    fontFamily: 'monospace',
+  } satisfies CSSProperties,
+  submit: {
+    padding: 11,
+    borderRadius: 9,
+    fontSize: 14,
+    fontWeight: 500,
+    background: '#111',
+    color: '#fff',
+    border: 'none',
+    cursor: 'pointer',
+  } satisfies CSSProperties,
+  focusBorder: '#111',
+  blurBorder: '#ddd',
+  emailStrong: '#111',
+  resendReady: '#555',
+  resendWait: '#bbb',
+  backLink: '#888',
+}
+
+const SIGNUP_STYLES = {
+  title: authTitle,
+  subtitle: authSubtitle,
+  label: authLabel,
+  emailInput: authInput,
+  otpInput: {
+    ...authInput,
+    padding: '12px',
+    fontSize: 28,
+    textAlign: 'center',
+    letterSpacing: '0.4em',
+    fontFamily: 'monospace',
+  } satisfies CSSProperties,
+  submit: authSubmitBtn,
+  focusBorder: M.brandLight,
+  blurBorder: M.lineStrong,
+  emailStrong: M.ink,
+  resendReady: M.muted,
+  resendWait: M.faint,
+  backLink: M.faint,
+}


### PR DESCRIPTION
## Summary
- Extract `<OtpForm intent>` for the email → OTP → resend UI used by login and signup.
- Keep `requestOtp` payloads separate (`login` vs `signup`). Pages keep verify side effects (`?next=`, `?deleted=1`, dev-token, GDPR, `selectBillingPlan`).
- Mark KB §13 item 4 done.
- Agent rules: always `git fetch origin main` and reset local `main` to `origin/main` before starting.

Closes #166

## Review
- **Touch points:** `/login` and `/signup` only. Funnel guard, plan picker, and consent page are unchanged.
- **Edge cases:** Login 404 → Create account. Signup 409 → Sign in. Missing GDPR or `isGdprConsentError` returns `'aborted'` so the form unlocks. `?email=` prefill, `?deleted=1` banner, `?next=` (must start with `/dashboard`), and DEV_MODE heading hide stay on the pages. Signup remounts the form when search params change.
- **Production risks:** Auto-submit at 6 digits still goes through `onVerified`. If a page forgets to return `'aborted'` on a redirect-before-verify, the form would stay locked — signup handles both GDPR paths. Dev-token errors now render above the shared form, not inside it.
- **Docs updated:** `DASHBOARD_KNOWLEDGE_BASE.md` §2, §7, §13.4, §19.6, §19.9, §19.11; `AGENTS.md` and `.cursor/rules/coding-standards.mdc` (start from updated `origin/main`).

## Test plan
- [x] `cd dashboard && npm test -- components/auth/OtpForm.test.tsx`
- [x] Login: send code (`intent=login`), 6-digit auto-submit, resend cooldown, `?deleted=1`, `?next=/dashboard/settings`, DEV_MODE "Open my dashboard"
- [x] Signup: still plan → consent → OTP; 409 shows Sign in; missing consent redirects to `/signup/start`
- [x] `cd dashboard && npm run lint && npm run build`

Made with [Cursor](https://cursor.com) and Saad
