### PR TITLE
fix(dashboard): stop OtpForm auto-submit loop breaking main CI

### DIFF
--- a/dashboard/components/auth/OtpForm.test.tsx
+++ b/dashboard/components/auth/OtpForm.test.tsx
@@ -117,7 +117,7 @@ describe('OtpForm', () => {
       target: { value: '654321' },
     })
 
-    await waitFor(() => expect(onVerified).toHaveBeenCalled())
+    await waitFor(() => expect(onVerified).toHaveBeenCalledTimes(1))
     await waitFor(() =>
       expect(
         screen.getByRole('button', { name: /create account/i }),

--- a/dashboard/components/auth/OtpForm.tsx
+++ b/dashboard/components/auth/OtpForm.tsx
@@ -44,6 +44,7 @@ export function OtpForm({
   const [noAccount, setNoAccount] = useState(false)
   const [alreadyRegistered, setAlreadyRegistered] = useState(false)
   const verifyLock = useRef(false)
+  const autoSubmitPaused = useRef(false)
   const verifyFormRef = useRef<HTMLFormElement>(null)
   const { cooldown, canResend, startCooldown } = useResendCooldown()
 
@@ -56,7 +57,8 @@ export function OtpForm({
       step !== 'otp' ||
       otp.length !== OTP_LENGTH ||
       loading ||
-      verifyLock.current
+      verifyLock.current ||
+      autoSubmitPaused.current
     ) {
       return
     }
@@ -117,6 +119,7 @@ export function OtpForm({
     try {
       const result = await onVerified({ email, otp })
       if (result === 'aborted') {
+        autoSubmitPaused.current = true
         verifyLock.current = false
         setLoading(false)
       }
@@ -130,6 +133,7 @@ export function OtpForm({
 
   function handleUseDifferentEmail() {
     verifyLock.current = false
+    autoSubmitPaused.current = false
     setStep('email')
     setOtp('')
     clearFlags()
@@ -220,9 +224,10 @@ export function OtpForm({
             id="otp-form-code"
             type="text"
             value={otp}
-            onChange={(e) =>
+            onChange={(e) => {
+              autoSubmitPaused.current = false
               setOtp(e.target.value.replace(/\D/g, '').slice(0, OTP_LENGTH))
-            }
+            }}
             placeholder="000000"
             required
             autoFocus


### PR DESCRIPTION
## Summary
- When `onVerified` returns `'aborted'` (signup GDPR redirect), `OtpForm` no longer re-triggers auto-submit while the OTP is still 6 digits.
- Regression test asserts `onVerified` is called once, not in a loop.

Closes #168

## Review
- **Touch points:** `components/auth/OtpForm.tsx` only. Login and signup pages unchanged.
- **Edge cases:** User can edit OTP after abort to retry auto-submit (`autoSubmitPaused` clears on change). "Use a different email" also clears the pause.
- **Production risks:** Signup GDPR redirect no longer spams `onVerified` before navigation. Successful verify path unchanged.
- **Docs:** None — behavior fix, no contract change.

## Test plan
- [x] `cd dashboard && npm test -- components/auth/OtpForm.test.tsx` (108ms, was hanging ~46min on CI)
- [ ] Merge and confirm main CI dashboard job passes

Made with [Cursor](https://cursor.com) and Saad