### PR TITLE
Pause activity events/stats polling when tab is hidden

### DIFF
--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -345,7 +345,7 @@ All in `lib/api.ts` via `apiFetch` (except unauthenticated `fetch` calls for OTP
 
 **Error handling:** `formatApiError` flattens string / array / `{msg}` FastAPI detail shapes. `DashboardPage` special-cases `401`/"invalid token" → redirect to `/login` (`dashboard/page.tsx:54`).
 
-**Polling:** Shared agent list every 10s (`hooks/useAgents.ts`); `/health` every 30s via `useConnectionHealth` (header AccountMenu). Both skip ticks while `document.visibilityState === 'hidden'` and check again on `visibilitychange`. Event/stats pollers (`useAgentEvents`, `useAgentStats`) still run in background tabs. Billing status fetched once by `TenantPlanBanner` on mount; `useApiKeyQuota` refreshes on window focus. Hidden-tab health can stay stale `'ok'` until the tab is shown again.
+**Polling:** Shared agent list every 10s (`hooks/useAgents.ts`); `/health` every 30s via `useConnectionHealth` (header AccountMenu); activity events/stats every 10s (`useAgentEvents`, `useAgentStats`). All skip ticks while `document.visibilityState === 'hidden'` and fetch again on `visibilitychange`. Billing status fetched once by `TenantPlanBanner` on mount; `useApiKeyQuota` refreshes on window focus. Hidden-tab health can stay stale `'ok'` until the tab is shown again.
 
 ---
 
@@ -920,7 +920,7 @@ sits inside a `<Suspense>` boundary — required or the build fails on CSR bailo
 | `requireAuth()` | no token → `window.location.href='/login'`, throws |
 | Agents home | explicit `router.replace('/login')` on missing/invalid token |
 | Edge auth | middleware cookie check on `/dashboard/*` |
-| Polling | agents 10s (`useAgents`, hidden-tab pause), events/stats 10s (still run when hidden), health 30s (`useConnectionHealth`, hidden-tab pause) |
+| Polling | agents/events/stats 10s (hidden-tab pause), health 30s (`useConnectionHealth`, hidden-tab pause) |
 | `NEXT_PUBLIC_DEV_MODE=true` | dev login bypass; dev onboarding copy |
 
 ### 19.11 Signup email/OTP — `app/signup/page.tsx`

--- a/dashboard/hooks/useAgentEvents.poll.test.tsx
+++ b/dashboard/hooks/useAgentEvents.poll.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { AgentEvent } from '@/lib/api'
+
+const getEvents = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  getEvents: (...a: unknown[]) => getEvents(...a),
+  searchEvents: vi.fn(),
+}))
+
+vi.mock('@/lib/auth', () => ({ getToken: () => 'tok' }))
+
+vi.mock('@/lib/constants', () => ({ POLL_INTERVAL_MS: 10_000 }))
+
+import { useAgentEvents } from './useAgentEvents'
+
+function ev(id: string): AgentEvent {
+  return {
+    event_id: id,
+    agent: 'a1',
+    timestamp: '2026-01-01T00:00:00Z',
+    event: 'action',
+    data: {},
+    parent_id: null,
+    session_id: null,
+    sequence_no: 1,
+  } as AgentEvent
+}
+
+describe('useAgentEvents polling', () => {
+  beforeEach(() => {
+    getEvents.mockReset()
+    getEvents.mockResolvedValue([ev('a')])
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not poll events while the tab is hidden', async () => {
+    const { result } = renderHook(() => useAgentEvents('a1'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(getEvents).toHaveBeenCalledTimes(1)
+
+    vi.useFakeTimers()
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(getEvents).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/hooks/useAgentEvents.ts
+++ b/dashboard/hooks/useAgentEvents.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { getEvents, searchEvents, type AgentEvent } from '@/lib/api'
 import { getToken } from '@/lib/auth'
 import { POLL_INTERVAL_MS } from '@/lib/constants'
+import { isDocumentVisible } from '@/lib/page-visible'
 import { normalizeSearchResults } from '@/lib/events'
 
 export const PAGE_SIZE = 50
@@ -114,18 +115,26 @@ export function useAgentEvents(agentId: string | null): AgentEventsState {
   }, [agentId, fetchEvents])
 
   // Live polling. Paused while search results are displayed so they survive.
+  // Interval ticks are skipped while the tab is hidden; a fetch runs when visible.
   useEffect(() => {
     if (!agentId || loading || searchResults) return
     let cancelled = false
 
-    const interval = setInterval(() => {
-      if (cancelled) return
+    const poll = () => {
+      if (cancelled || !isDocumentVisible()) return
       fetchEvents(1, false, filterType)
-    }, POLL_INTERVAL_MS)
+    }
+
+    const interval = setInterval(poll, POLL_INTERVAL_MS)
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') poll()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
 
     return () => {
       cancelled = true
       clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibility)
     }
   }, [agentId, loading, searchResults, filterType, fetchEvents])
 

--- a/dashboard/hooks/useAgentStats.test.tsx
+++ b/dashboard/hooks/useAgentStats.test.tsx
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { AgentStats } from '@/lib/api'
+
+const getAgentStats = vi.fn()
+
+vi.mock('@/lib/api', () => ({
+  getAgentStats: (...a: unknown[]) => getAgentStats(...a),
+}))
+
+vi.mock('@/lib/auth', () => ({ getToken: () => 'tok' }))
+
+vi.mock('@/lib/constants', () => ({ POLL_INTERVAL_MS: 10_000 }))
+
+import { useAgentStats } from './useAgentStats'
+
+function stats(): AgentStats {
+  return {
+    total_events: 1,
+    sessions: 1,
+    top_events: [],
+    last_event_at: '2026-01-01T00:00:00Z',
+  } as AgentStats
+}
+
+describe('useAgentStats', () => {
+  beforeEach(() => {
+    getAgentStats.mockReset()
+    getAgentStats.mockResolvedValue(stats())
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'visible',
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('loads stats on mount', async () => {
+    const { result } = renderHook(() => useAgentStats('a1'))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(getAgentStats).toHaveBeenCalledWith('tok', 'a1')
+    expect(result.current.stats?.total_events).toBe(1)
+  })
+
+  it('does not poll while the tab is hidden', async () => {
+    vi.useFakeTimers()
+    renderHook(() => useAgentStats('a1'))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(getAgentStats).toHaveBeenCalledTimes(1)
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: () => 'hidden',
+    })
+    await act(async () => {
+      vi.advanceTimersByTime(10_000)
+    })
+    expect(getAgentStats).toHaveBeenCalledTimes(1)
+  })
+})

--- a/dashboard/hooks/useAgentStats.ts
+++ b/dashboard/hooks/useAgentStats.ts
@@ -4,11 +4,14 @@ import { useCallback, useEffect, useState } from 'react'
 import { getAgentStats, type AgentStats } from '@/lib/api'
 import { getToken } from '@/lib/auth'
 import { POLL_INTERVAL_MS } from '@/lib/constants'
+import { isDocumentVisible } from '@/lib/page-visible'
 
 /**
  * Summary counters for one agent, refreshed on the shared poll interval.
  * Poll failures stay silent — the already-rendered numbers are better than an
  * error banner over a transient blip.
+ *
+ * Interval ticks are skipped while the tab is hidden; a load runs when visible.
  */
 export function useAgentStats(agentId: string | null) {
   const [stats, setStats] = useState<AgentStats | null>(null)
@@ -44,15 +47,25 @@ export function useAgentStats(agentId: string | null) {
       setLoading(false)
     })
 
-    const interval = setInterval(async () => {
+    const poll = async () => {
+      if (cancelled || !isDocumentVisible()) return
       const res = await load()
       if (cancelled || !res) return
       setStats(res)
+    }
+
+    const interval = setInterval(() => {
+      void poll()
     }, POLL_INTERVAL_MS)
+    const onVisibility = () => {
+      if (document.visibilityState === 'visible') void poll()
+    }
+    document.addEventListener('visibilitychange', onVisibility)
 
     return () => {
       cancelled = true
       clearInterval(interval)
+      document.removeEventListener('visibilitychange', onVisibility)
     }
   }, [agentId, load])
 


### PR DESCRIPTION
## Summary
- Completes the Day 3 follow-up from #158 / #159: `useAgentEvents` and `useAgentStats` now skip poll ticks while `document.visibilityState === 'hidden'` and refresh on `visibilitychange`, matching `useAgents` and `useConnectionHealth`.
- Adds hidden-tab regression tests for both hooks.
- Updates KB polling notes (§8, §19.10).

## Review
- Activity page with a selected agent: switch to another tab for 30s — network tab should show no repeated `/v1/events` or agent-stats calls until you return.
- Search results still pause event polling (unchanged).

## Test plan
- [x] `npm test -- --run hooks/useAgentStats.test.tsx hooks/useAgentEvents.poll.test.tsx`
- [x] `npm run lint`
- [ ] CI green

Closes #170

Made with [Cursor](https://cursor.com) and Saad