### PR TITLE
Release PyPI packages 0.2.8 / 0.1.7 / 0.1.3 and sync GitHub docs.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -51,7 +51,7 @@ body:
     attributes:
       label: Version
       description: GitHub release tag, or `pip show zizkadb-sdk`
-      placeholder: v0.2.7 / zizkadb-sdk 0.2.7
+      placeholder: v0.2.8 / zizkadb-sdk 0.2.8
 
   - type: textarea
     id: env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,26 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Integrations
 
-- **`zizkadb-livekit` 0.1.0** (PyPI) — LiveKit Agents voice calls → ZizkaDB Sessions + Events (transcript only, no audio stored). Depends on `zizkadb-sdk>=0.2.7` + `livekit-agents>=1.3.0`. Docs: [docs/integrations/livekit.md](docs/integrations/livekit.md), example: [examples/livekit-agent/](examples/livekit-agent/).
+- **`zizkadb-livekit` 0.1.0** (PyPI) — LiveKit Agents voice calls → ZizkaDB Sessions + Events (transcript only, no audio stored). Depends on `zizkadb-sdk>=0.2.8` + `livekit-agents>=1.3.0`. Docs: [docs/integrations/livekit.md](docs/integrations/livekit.md), example: [examples/livekit-agent/](examples/livekit-agent/).
 
-## [0.2.8] — 2026-08-27
+## [0.2.8] — 2026-09-02
+
+### Python SDK (`zizkadb-sdk` 0.2.8, PyPI)
+
+- Mark **Production/Stable** on PyPI with full package metadata (keywords, audit-trail description)
+
+### MCP (`zizkadb-mcp` 0.1.7)
+
+- Mark **Production/Stable** on PyPI; updated description and keywords
+
+### Integrations
+
+- `zizkadb-langchain` **0.1.3** — Production/Stable; requires `zizkadb-sdk>=0.2.8`
+- `zizkadb-crewai` **0.1.3** — Production/Stable; requires `zizkadb-sdk>=0.2.8`
 
 ### Install telemetry (OSS adoption)
 
-- **Python SDK 0.2.7**, **TypeScript SDK 0.2.7 (npm)**, **MCP 0.1.6**, **langchain 0.1.3**, **crewai 0.1.3**: count **installs** at import/client/server start (including self-hosted localhost), not on first API call
+- **Python SDK 0.2.8**, **MCP 0.1.7**, **langchain 0.1.3**, **crewai 0.1.3**: count **installs** at import/client/server start (including self-hosted localhost), not on first API call
 - Per-package telemetry keys: `python`, `langchain`, `crewai`, `livekit`, `mcp`, `typescript`, `docker`
 - **Docker quickstart**: anonymous install ping (`sdk=docker`, `mode=self-hosted`) after stack is healthy
 - **`sdk_telemetry`**: composite primary key `(install_id, sdk)` so Python + MCP + Docker on one machine each count separately
@@ -80,7 +93,8 @@ Production-hardening sprint merged to `main` (via stacked PRs #125–#139), incl
 
 See [GitHub releases](https://github.com/Zizka-ai/ZizkaDB/releases) for tagged artifacts.
 
-[Unreleased]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.2.7...HEAD
+[Unreleased]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.2.8...HEAD
+[0.2.8]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.2.7...v0.2.8
 [0.2.7]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.2.6...v0.2.7
 [0.2.6]: https://github.com/Zizka-ai/ZizkaDB/compare/v0.1.0...v0.2.6
 [0.1.0]: https://github.com/Zizka-ai/ZizkaDB/releases

--- a/CONNECT.md
+++ b/CONNECT.md
@@ -1,6 +1,6 @@
 # Connect your agent (self-host / OSS)
 
-**Current PyPI releases:** `zizkadb-sdk` **0.2.7** · `zizkadb-mcp` **0.1.6** · `zizkadb-langchain` **0.1.2** · `zizkadb-crewai` **0.1.2** · `zizkadb-livekit` **0.1.0**
+**Current PyPI releases:** `zizkadb-sdk` **0.2.8** · `zizkadb-mcp` **0.1.7** · `zizkadb-langchain` **0.1.3** · `zizkadb-crewai` **0.1.3** · `zizkadb-livekit` **0.1.0**
 
 ## Start the stack (pick one)
 
@@ -28,7 +28,7 @@ Pick your stack below. Use the **same agent name** in code and dashboard.
 ## Python SDK
 
 ```bash
-pip install "zizkadb-sdk>=0.2.7"
+pip install "zizkadb-sdk>=0.2.8"
 ```
 
 ```python
@@ -91,7 +91,7 @@ await db.log({
 ## LangChain
 
 ```bash
-pip install "zizkadb-sdk>=0.2.7" "zizkadb-langchain>=0.1.2"
+pip install "zizkadb-sdk>=0.2.8" "zizkadb-langchain>=0.1.3"
 ```
 
 ```python
@@ -116,7 +116,7 @@ Or scaffold: `zizkadb init my-agent --template langchain`
 ## CrewAI
 
 ```bash
-pip install "zizkadb-sdk>=0.2.7" "zizkadb-crewai>=0.1.2"
+pip install "zizkadb-sdk>=0.2.8" "zizkadb-crewai>=0.1.3"
 ```
 
 ```python
@@ -183,7 +183,7 @@ Full sample: [examples/livekit-agent/](examples/livekit-agent/) · package docs:
 ## MCP (Cursor, Claude Desktop, Windsurf)
 
 ```bash
-pip install "zizkadb-mcp>=0.1.6"
+pip install "zizkadb-mcp>=0.1.7"
 # or: uvx zizkadb-mcp
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Self-hosted audit trail for AI agents — one command or one dashboard click fro
 
 [![CI](https://github.com/Zizka-ai/ZizkaDB/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/Zizka-ai/ZizkaDB/actions/workflows/ci.yml)
 [![License: AGPL-3.0](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](LICENSE)
-[![Release](https://img.shields.io/badge/release-v0.2.7-f97316)](https://github.com/Zizka-ai/ZizkaDB/releases)
+[![Release](https://img.shields.io/badge/release-v0.2.8-f97316)](https://github.com/Zizka-ai/ZizkaDB/releases)
 [![Python SDK](https://img.shields.io/pypi/v/zizkadb-sdk?label=Python%20SDK)](https://pypi.org/project/zizkadb-sdk/)
 [![LangChain](https://img.shields.io/pypi/v/zizkadb-langchain?label=LangChain)](https://pypi.org/project/zizkadb-langchain/)
 [![CrewAI](https://img.shields.io/pypi/v/zizkadb-crewai?label=CrewAI)](https://pypi.org/project/zizkadb-crewai/)

--- a/docs/ARCHITECTURE_REVIEW.md
+++ b/docs/ARCHITECTURE_REVIEW.md
@@ -86,7 +86,7 @@ observability baseline).
 | R10 | **No CD + out-of-tree deploy assets** — `deploy-production.sh` and prod `nginx.conf` are referenced but absent from the repo → DR/reproducibility risk | **Medium** | referenced in `infra/docker-compose.yml:12,99`, `dashboard/ecosystem.config.js:8` |
 | R11 | **Datastore SPOFs** — single Postgres/Qdrant/Redis, no replication/HA | **Medium** | single containers, local volumes |
 | R12 | **Stale docs / dead references** — largely reconciled this cycle (router map 14→9; absent `admin`/`stats`/`community`/`demo`/`marketing`) | **Low** | fixed in `CLAUDE.md`, KB, wiki |
-| R13 | **Version drift** — `core/main.py` 0.1.0, SDKs 0.2.7, MCP 0.1.6; version hardcoded twice in `main.py` | **Low** | vs the "bump together" doc rule |
+| R13 | **Version drift** — `core/main.py` 0.1.0, SDKs 0.2.8, MCP 0.1.7; version hardcoded twice in `main.py` | **Low** | vs the "bump together" doc rule |
 
 ---
 

--- a/docs/integrate/frameworks.md
+++ b/docs/integrate/frameworks.md
@@ -4,13 +4,13 @@ Only list **SUPPORTED** when an adapter or official example exists in this repos
 
 | Framework | Status | Package (version) |
 |-----------|--------|-------------------|
-| **Python (custom)** | Supported | `zizkadb-sdk` **0.2.7** — [any-agent.md](any-agent.md) |
+| **Python (custom)** | Supported | `zizkadb-sdk` **0.2.8** — [any-agent.md](any-agent.md) |
 | **TypeScript / Node** | Supported | `zizkadb-sdk` **0.2.7** (npm) — [CONNECT.md](../../CONNECT.md#typescript-sdk) |
 | **REST / any HTTP client** | Supported | `POST /v1/events` — [wiki/REST-API](../../wiki/REST-API.md) |
-| **LangChain (Python)** | Supported | `zizkadb-langchain` **0.1.2** — [examples/langchain-agent](../../examples/langchain-agent/) |
-| **CrewAI (Python)** | Supported | `zizkadb-crewai` **0.1.2** — [examples/crewai-agent](../../examples/crewai-agent/) |
+| **LangChain (Python)** | Supported | `zizkadb-langchain` **0.1.3** — [examples/langchain-agent](../../examples/langchain-agent/) |
+| **CrewAI (Python)** | Supported | `zizkadb-crewai` **0.1.3** — [examples/crewai-agent](../../examples/crewai-agent/) |
 | **LiveKit Agents (voice)** | Supported | `zizkadb-livekit` **0.1.0** — [docs/integrations/livekit.md](../integrations/livekit.md) · [examples/livekit-agent](../../examples/livekit-agent/) |
-| **MCP (Cursor, Claude Desktop)** | Supported | `zizkadb-mcp` **0.1.6** · [mcp/README.md](../../mcp/README.md) |
+| **MCP (Cursor, Claude Desktop)** | Supported | `zizkadb-mcp` **0.1.7** · [mcp/README.md](../../mcp/README.md) |
 | **OpenAI / Anthropic SDKs** | Example pattern | Manual `log()` around API calls · [examples/openai-agent](../../examples/openai-agent/) |
 | **LangGraph** | Generic only | No official adapter — call `db.log()` inside graph nodes · [any-agent.md](any-agent.md) |
 | **LlamaIndex** | Generic only | Log at retrieval/tool boundaries via SDK or REST |

--- a/docs/integrations/livekit.md
+++ b/docs/integrations/livekit.md
@@ -19,7 +19,7 @@ Event types match text agents: `session_started`, `user_message`, `assistant_res
 pip install zizkadb-livekit
 ```
 
-Pulls `zizkadb-sdk>=0.2.7` and `livekit-agents>=1.3.0` automatically. No separate core SDK install.
+Pulls `zizkadb-sdk>=0.2.8` and `livekit-agents>=1.3.0` automatically. No separate core SDK install.
 
 Start ZizkaDB (Docker):
 

--- a/examples/crewai-agent/requirements.txt
+++ b/examples/crewai-agent/requirements.txt
@@ -1,4 +1,4 @@
-zizkadb-sdk>=0.2.7
-zizkadb-crewai>=0.1.2
+zizkadb-sdk>=0.2.8
+zizkadb-crewai>=0.1.3
 crewai>=0.80.0
 langchain-openai>=0.2.0

--- a/examples/langchain-agent/requirements.txt
+++ b/examples/langchain-agent/requirements.txt
@@ -1,3 +1,3 @@
-zizkadb-sdk>=0.2.7
-zizkadb-langchain>=0.1.2
+zizkadb-sdk>=0.2.8
+zizkadb-langchain>=0.1.3
 langchain-openai>=0.2.0

--- a/examples/minimal-python/requirements.txt
+++ b/examples/minimal-python/requirements.txt
@@ -1,1 +1,1 @@
-zizkadb-sdk>=0.2.7
+zizkadb-sdk>=0.2.8

--- a/examples/openai-agent/requirements.txt
+++ b/examples/openai-agent/requirements.txt
@@ -1,1 +1,1 @@
-zizkadb-sdk>=0.2.7
+zizkadb-sdk>=0.2.8

--- a/integrations/CLAUDE.md
+++ b/integrations/CLAUDE.md
@@ -10,8 +10,8 @@ Standalone adapter packages: **`zizkadb-langchain`**, **`zizkadb-crewai`**, **`z
 
 | Package | Directory | Class | PyPI (current) |
 |---|---|---|---|
-| `zizkadb-langchain` | `integrations/langchain/` | `ZizkaDBCallbackHandler` | `0.1.2` |
-| `zizkadb-crewai` | `integrations/crewai/` | `ZizkaDBCrewLogger` | `0.1.2` |
+| `zizkadb-langchain` | `integrations/langchain/` | `ZizkaDBCallbackHandler` | `0.1.3` |
+| `zizkadb-crewai` | `integrations/crewai/` | `ZizkaDBCrewLogger` | `0.1.3` |
 | `zizkadb-livekit` | `integrations/livekit/` | `ZizkaDBLiveKitObserver` | `0.1.0` |
 
 Install for users:
@@ -19,7 +19,7 @@ Install for users:
 pip install zizkadb-langchain    # or zizkadb-crewai / zizkadb-livekit
 ```
 
-Each package depends on `zizkadb-sdk>=0.2.7` — users install the framework package only.
+Each package depends on `zizkadb-sdk>=0.2.8` — users install the framework package only.
 
 ---
 

--- a/integrations/README.md
+++ b/integrations/README.md
@@ -4,11 +4,11 @@ Official adapters for agent frameworks. Each package is optional — core SDK is
 
 | Package | Registry | Install | Telemetry `sdk` | Use case |
 |---------|----------|---------|-------------------|----------|
-| `zizkadb-sdk` | PyPI **0.2.7** | `pip install zizkadb-sdk` | `python` | Core Python client |
+| `zizkadb-sdk` | PyPI **0.2.8** | `pip install zizkadb-sdk` | `python` | Core Python client |
 | [langchain](langchain/) | PyPI **0.1.3** | `pip install zizkadb-langchain` | `langchain` | LangChain callback handler |
 | [crewai](crewai/) | PyPI **0.1.3** | `pip install zizkadb-crewai` | `crewai` | CrewAI crew logger |
 | [livekit](livekit/) | PyPI **0.1.0** | `pip install zizkadb-livekit` | `livekit` | LiveKit voice → Sessions + Events |
-| [mcp](../mcp/) | PyPI **0.1.6** | `uvx zizkadb-mcp` | `mcp` | Cursor / Claude Desktop tools |
+| [mcp](../mcp/) | PyPI **0.1.7** | `uvx zizkadb-mcp` | `mcp` | Cursor / Claude Desktop tools |
 | TypeScript SDK | npm **0.2.7** | `npm install zizkadb-sdk` | `typescript` | Node / Bun / Deno client |
 | Docker OSS | — | `bash scripts/quickstart.sh` | `docker` | Self-hosted stack |
 

--- a/integrations/crewai/README.md
+++ b/integrations/crewai/README.md
@@ -1,6 +1,6 @@
 # zizkadb-crewai
 
-**PyPI:** [zizkadb-crewai 0.1.2](https://pypi.org/project/zizkadb-crewai/0.1.2/) · requires `zizkadb-sdk>=0.2.7`
+**PyPI:** [zizkadb-crewai 0.1.3](https://pypi.org/project/zizkadb-crewai/0.1.3/) · requires `zizkadb-sdk>=0.2.8`
 
 Self-hosted, open-source **observability and causal debugging** for [CrewAI](https://crewai.com).
 

--- a/integrations/crewai/pyproject.toml
+++ b/integrations/crewai/pyproject.toml
@@ -5,17 +5,35 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "zizkadb-crewai"
 version = "0.1.3"
-description = "CrewAI logging helpers for ZizkaDB causal agent memory"
+description = "CrewAI logging helpers for ZizkaDB — observability and causal debugging for multi-agent crews"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"
+authors = [{ name = "Zizka AI", email = "founder@zizka.ai" }]
+keywords = [
+    "crewai",
+    "ai-agents",
+    "causal-lineage",
+    "agent-audit",
+    "observability",
+    "zizkadb",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
-    "zizkadb-sdk>=0.2.7",
+    "zizkadb-sdk>=0.2.8",
 ]
 
 [project.urls]
-Repository = "https://github.com/Zizka-ai/ZizkaDB"
+Homepage = "https://db.zizka.ai"
 Documentation = "https://db.zizka.ai/docs"
+Repository = "https://github.com/Zizka-ai/ZizkaDB"
+Issues = "https://github.com/Zizka-ai/ZizkaDB/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/integrations/langchain/README.md
+++ b/integrations/langchain/README.md
@@ -1,6 +1,6 @@
 # zizkadb-langchain
 
-**PyPI:** [zizkadb-langchain 0.1.2](https://pypi.org/project/zizkadb-langchain/0.1.2/)
+**PyPI:** [zizkadb-langchain 0.1.3](https://pypi.org/project/zizkadb-langchain/0.1.3/)
 
 LangChain `AsyncCallbackHandler` that logs LLM and tool steps to ZizkaDB with `parent_id` lineage.
 

--- a/integrations/langchain/pyproject.toml
+++ b/integrations/langchain/pyproject.toml
@@ -5,18 +5,36 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "zizkadb-langchain"
 version = "0.1.3"
-description = "LangChain callbacks for ZizkaDB causal agent logging"
+description = "LangChain callbacks for ZizkaDB — causal agent logging with parent_id lineage"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"
+authors = [{ name = "Zizka AI", email = "founder@zizka.ai" }]
+keywords = [
+    "langchain",
+    "ai-agents",
+    "causal-lineage",
+    "agent-audit",
+    "observability",
+    "zizkadb",
+]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
 dependencies = [
-    "zizkadb-sdk>=0.2.7",
+    "zizkadb-sdk>=0.2.8",
     "langchain-core>=0.3.0",
 ]
 
 [project.urls]
-Repository = "https://github.com/Zizka-ai/ZizkaDB"
+Homepage = "https://db.zizka.ai"
 Documentation = "https://db.zizka.ai/docs"
+Repository = "https://github.com/Zizka-ai/ZizkaDB"
+Issues = "https://github.com/Zizka-ai/ZizkaDB/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/integrations/livekit/README.md
+++ b/integrations/livekit/README.md
@@ -1,6 +1,6 @@
 # ZizkaDB + LiveKit Agents
 
-**PyPI:** [zizkadb-livekit 0.1.0](https://pypi.org/project/zizkadb-livekit/) · depends on `zizkadb-sdk>=0.2.7` + `livekit-agents>=1.3.0`
+**PyPI:** [zizkadb-livekit 0.1.0](https://pypi.org/project/zizkadb-livekit/) · depends on `zizkadb-sdk>=0.2.8` + `livekit-agents>=1.3.0`
 
 Log voice calls to ZizkaDB with the same **Activity → Sessions / Events** model as text agents.
 

--- a/integrations/livekit/pyproject.toml
+++ b/integrations/livekit/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = "AGPL-3.0-or-later"
 requires-python = ">=3.10"
 dependencies = [
-    "zizkadb-sdk>=0.2.7",
+    "zizkadb-sdk>=0.2.8",
     "livekit-agents>=1.3.0",
 ]
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,10 +8,10 @@ ZizkaDB is open-source (AGPL-3.0, except MCP server which is MIT). It runs as a 
 
 - [Core API](core/) — FastAPI + asyncpg + PostgreSQL 16/pgvector + Qdrant + Redis. 14 routers at `/v1/`.
 - [Dashboard](dashboard/) — Next.js 14 App Router. Marketing + authenticated agent fleet view.
-- [Python SDK](sdk/python/) — `zizkadb-sdk` **0.2.7** on PyPI. Async client, `zizkadb init` CLI.
+- [Python SDK](sdk/python/) — `zizkadb-sdk` **0.2.8** on PyPI. Async client, `zizkadb init` CLI.
 - [TypeScript SDK](sdk/typescript/) — `zizkadb-sdk` **0.2.7** on npm. Sync constructor, camelCase fields.
-- [Integrations](integrations/) — `zizkadb-langchain` **0.1.2**, `zizkadb-crewai` **0.1.2**, `zizkadb-livekit` **0.1.0** on PyPI. Voice + text causal debugging via `db.why()`.
-- [MCP Server](mcp/) — `zizkadb-mcp` **0.1.6** on PyPI. MIT license. `uvx zizkadb-mcp`.
+- [Integrations](integrations/) — `zizkadb-langchain` **0.1.3**, `zizkadb-crewai` **0.1.3**, `zizkadb-livekit` **0.1.0** on PyPI. Voice + text causal debugging via `db.why()`.
+- [MCP Server](mcp/) — `zizkadb-mcp` **0.1.7** on PyPI. MIT license. `uvx zizkadb-mcp`.
 - [Infra](infra/) — Docker Compose. Production: `docker-compose.yml`. Dev overlay: `docker-compose.dev.yml`.
 
 ## Key context files

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,6 +1,6 @@
 # zizkadb-mcp
 
-**PyPI:** [zizkadb-mcp 0.1.6](https://pypi.org/project/zizkadb-mcp/0.1.6/)
+**PyPI:** [zizkadb-mcp 0.1.7](https://pypi.org/project/zizkadb-mcp/0.1.7/)
 
 MCP server for [ZizkaDB](https://db.zizka.ai). Gives any MCP-compatible AI agent persistent memory, semantic search, causal debugging, and time travel.
 

--- a/mcp/pyproject.toml
+++ b/mcp/pyproject.toml
@@ -4,16 +4,16 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zizkadb-mcp"
-version = "0.1.6"
-description = "MCP server for ZizkaDB — give any AI agent persistent memory and observability"
+version = "0.1.7"
+description = "MCP server for ZizkaDB — operational database and audit trail for AI agents in Cursor, Claude Desktop, and any MCP client"
 readme = "README.md"
 license = "MIT"
 license-files = ["LICENSE"]
 requires-python = ">=3.10"
 authors = [{ name = "Zizka AI", email = "founder@zizka.ai" }]
-keywords = ["mcp", "ai", "agents", "memory", "observability", "zizkadb", "claude", "cursor"]
+keywords = ["mcp", "ai", "agents", "audit", "observability", "zizkadb", "claude", "cursor", "causal-lineage"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -34,6 +34,7 @@ zizkadb-mcp = "zizkadb_mcp.server:main"
 Homepage = "https://db.zizka.ai"
 Documentation = "https://db.zizka.ai/docs"
 Repository = "https://github.com/Zizka-ai/ZizkaDB"
+Issues = "https://github.com/Zizka-ai/ZizkaDB/issues"
 
 [tool.setuptools.packages.find]
 where = ["."]

--- a/mcp/zizkadb_mcp/__init__.py
+++ b/mcp/zizkadb_mcp/__init__.py
@@ -1,3 +1,3 @@
 """ZizkaDB MCP Server — give any AI agent persistent memory and observability."""
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/mcp/zizkadb_mcp/server.py
+++ b/mcp/zizkadb_mcp/server.py
@@ -36,7 +36,7 @@ try:
 
     __version__ = _pkg_version("zizkadb-mcp")
 except Exception:
-    __version__ = "0.1.5"
+    __version__ = "0.1.7"
 
 DEFAULT_DEV_API_KEY = "zizkadb_dev_local"
 _HOST = (

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -1,6 +1,6 @@
 # zizkadb-sdk
 
-**PyPI:** [zizkadb-sdk 0.2.7](https://pypi.org/project/zizkadb-sdk/0.2.7/)
+**PyPI:** [zizkadb-sdk 0.2.8](https://pypi.org/project/zizkadb-sdk/0.2.8/)
 
 Python SDK for [ZizkaDB](https://github.com/Zizka-ai/ZizkaDB) — **Why did your agent do that?** Call `db.why(event_id)` or `zizkadb why <id>` after logging with `parent_id`.
 

--- a/sdk/python/pyproject.toml
+++ b/sdk/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "zizkadb-sdk"
-version = "0.2.7"
+version = "0.2.8"
 description = "Self-hosted audit trail for AI agents — prove why an agent did something with causal lineage (why()), time-travel state, and drift baselines."
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -23,7 +23,7 @@ keywords = [
     "observability",
 ]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",

--- a/sdk/python/zizkadb/__init__.py
+++ b/sdk/python/zizkadb/__init__.py
@@ -6,7 +6,7 @@ try:
 
     __version__ = _pkg_version("zizkadb-sdk")
 except Exception:
-    __version__ = "0.2.6"
+    __version__ = "0.2.8"
 
 __all__ = [
     "ZizkaDB",

--- a/sdk/python/zizkadb/templates/basic/requirements.txt
+++ b/sdk/python/zizkadb/templates/basic/requirements.txt
@@ -1,1 +1,1 @@
-zizkadb-sdk>=0.2.7
+zizkadb-sdk>=0.2.8

--- a/sdk/python/zizkadb/templates/crewai/requirements.txt
+++ b/sdk/python/zizkadb/templates/crewai/requirements.txt
@@ -1,4 +1,4 @@
-zizkadb-sdk>=0.2.7
-zizkadb-crewai>=0.1.2
+zizkadb-sdk>=0.2.8
+zizkadb-crewai>=0.1.3
 crewai>=0.80.0
 langchain-openai>=0.2.0

--- a/sdk/python/zizkadb/templates/langchain/requirements.txt
+++ b/sdk/python/zizkadb/templates/langchain/requirements.txt
@@ -1,3 +1,3 @@
-zizkadb-sdk>=0.2.7
-zizkadb-langchain>=0.1.2
+zizkadb-sdk>=0.2.8
+zizkadb-langchain>=0.1.3
 langchain-openai>=0.2.0

--- a/sdk/python/zizkadb/templates/openai/requirements.txt
+++ b/sdk/python/zizkadb/templates/openai/requirements.txt
@@ -1,1 +1,1 @@
-zizkadb-sdk>=0.2.7
+zizkadb-sdk>=0.2.8

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -7,10 +7,10 @@
 | GitHub | [Zizka-ai/ZizkaDB](https://github.com/Zizka-ai/ZizkaDB) |
 | OSS quickstart (no clone) | `curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh \| bash` |
 | Connect guide | [CONNECT.md](https://github.com/Zizka-ai/ZizkaDB/blob/main/CONNECT.md) |
-| PyPI SDK | [zizkadb-sdk](https://pypi.org/project/zizkadb-sdk/) **0.2.7** |
-| PyPI MCP | [zizkadb-mcp](https://pypi.org/project/zizkadb-mcp/) **0.1.6** |
-| PyPI LangChain | [zizkadb-langchain](https://pypi.org/project/zizkadb-langchain/) **0.1.2** |
-| PyPI CrewAI | [zizkadb-crewai](https://pypi.org/project/zizkadb-crewai/) **0.1.2** |
+| PyPI SDK | [zizkadb-sdk](https://pypi.org/project/zizkadb-sdk/) **0.2.8** |
+| PyPI MCP | [zizkadb-mcp](https://pypi.org/project/zizkadb-mcp/) **0.1.7** |
+| PyPI LangChain | [zizkadb-langchain](https://pypi.org/project/zizkadb-langchain/) **0.1.3** |
+| PyPI CrewAI | [zizkadb-crewai](https://pypi.org/project/zizkadb-crewai/) **0.1.3** |
 | PyPI LiveKit | [zizkadb-livekit](https://pypi.org/project/zizkadb-livekit/) **0.1.0** |
 | npm SDK | [zizkadb-sdk](https://www.npmjs.com/package/zizkadb-sdk) **0.2.7** |
 | Docs site | [db.zizka.ai/docs](https://db.zizka.ai/docs) |

--- a/wiki/MCP-and-Cursor.md
+++ b/wiki/MCP-and-Cursor.md
@@ -1,6 +1,6 @@
 # MCP and Cursor
 
-**Package:** `zizkadb-mcp` on PyPI (**0.1.6**)  
+**Package:** `zizkadb-mcp` on PyPI (**0.1.7**)  
 **Run:** `uvx zizkadb-mcp`
 
 ## Install uv (for uvx)

--- a/wiki/Python-SDK.md
+++ b/wiki/Python-SDK.md
@@ -1,6 +1,6 @@
 # Python SDK
 
-**Package:** `zizkadb-sdk` on PyPI (**0.2.7**)  
+**Package:** `zizkadb-sdk` on PyPI (**0.2.8**)  
 **Import:** `from zizkadb import ZizkaDB`
 
 ```bash


### PR DESCRIPTION
Mark zizkadb-sdk, zizkadb-mcp, zizkadb-langchain, and zizkadb-crewai as Production/Stable on PyPI and align README, wiki, CONNECT, examples, and requirement pins with the published versions.

## Summary

<!-- What changed and why (1–3 bullets). -->

## Test plan

- [ ] `ruff check core/ sdk/python/ mcp/ integrations/` (if Python touched)
- [ ] `pytest core/tests/ -m "not integration"` (if core touched)
- [ ] `cd dashboard && npm run lint && npm test && npm run build` (if dashboard touched)
- [ ] Manual: <!-- steps or "docs only" -->

## Areas touched

- [ ] API / schema
- [ ] SDK (Python / TypeScript)
- [ ] Dashboard
- [ ] MCP / integrations
- [ ] Docs only
- [ ] Infra / CI

## Breaking changes

<!-- None, or describe migration. -->

Fixes #<!-- issue number if applicable -->
