### PR TITLE
fix: run dashboard vitest in CI and align contributor docs

### DIFF
--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -16,7 +16,7 @@ Full standards: [docs/ai/CODING_STANDARDS.md](../../docs/ai/CODING_STANDARDS.md)
 5. **Test** — run layer commands from [zizkadb-test skill](../skills/zizkadb-test/SKILL.md).
 6. **Document** — update canonical docs in the **same** PR when behavior changes.
 7. **Senior review** — review your own diff; fix before PR.
-8. **PR** — per [CONTRIBUTING.md](../../CONTRIBUTING.md); link issue when applicable.
+8. **PR** — per [CONTRIBUTING.md](../../CONTRIBUTING.md): open a GitHub issue with the right label (`bug`, `enhancement`, `documentation`) before the branch; PR body must include `Fixes #N` so the issue auto-closes on merge; CI must pass.
 
 ## Must not
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,6 +40,6 @@
 
 ## Related issue
 
-Fixes #<!-- number --> or Related to #<!-- number -->
+Fixes #<!-- number --> — use this keyword so GitHub **closes the issue automatically when the PR merges**. Use `Related to #<!-- number -->` only if the issue should stay open.
 
 <!-- Maintainers: docs/ai/MAINTAINER.md for labels and assignee -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,4 +87,5 @@ jobs:
 
       - run: npm ci
       - run: npm run lint
+      - run: npm test
       - run: npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Removed
+
+- Enterprise marketing (`/enterprise`), enterprise pricing tier, and enterprise-specific docs — OSS repo is self-host only; commercial VPC lives in the private cloud repo ([docs/REPO_SPLIT.md](docs/REPO_SPLIT.md))
+- `enterprise` plan from `PLAN_ENTITLEMENTS`; demo-request `source` allowlist is now `landing` and `newsletter` only
+
+### Changed
+
+- Dashboard CI runs `npm test` (vitest) alongside lint and build
+
 ### Integrations
 
 - **`zizkadb-livekit` 0.2.0** (PyPI) — LiveKit Agents voice calls → ZizkaDB Sessions + Events (transcript only, no audio stored). Depends on `zizkadb-sdk>=0.2.8` + `livekit-agents>=1.3.0`. Docs: [docs/integrations/livekit.md](docs/integrations/livekit.md), example: [examples/livekit-agent/](examples/livekit-agent/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ This guide explains how to get started, what we expect in pull requests, and the
 | Repository | https://github.com/Zizka-ai/ZizkaDB |
 | OSS quickstart (no clone) | `curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh \| bash` |
 | Connect guide | [CONNECT.md](CONNECT.md) |
+| Development setup | [DEVELOPMENT.md](DEVELOPMENT.md) |
 | Docs | https://db.zizka.ai/docs |
 | Architecture / trust | https://db.zizka.ai/trust |
 | Wiki | https://github.com/Zizka-ai/ZizkaDB/wiki |
@@ -63,7 +64,7 @@ For significant contributions, we may ask you to confirm you have the right to s
 
 - **Docker** + Docker Compose v2
 - **Python 3.10+** (API tests, SDK, demos)
-- **Node.js 18+** (optional — only if you work on `dashboard/`)
+- **Node.js 20+** (optional — only if you work on `dashboard/`)
 - **Git**
 
 ### One-command local stack
@@ -131,8 +132,9 @@ Or run the dashboard alone for UI work:
 cd dashboard
 npm install
 npm run dev    # http://localhost:3000 — set NEXT_PUBLIC_API_URL=http://localhost:8000
-npm run build
 npm run lint
+npm test
+npm run build
 ```
 
 ### Reset local data (dev only)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -192,7 +192,24 @@ When your change affects documented behavior, update the matching KB, ADR, or ru
 
 ## Making a change
 
-### 1. Discuss first (for non-trivial work)
+### 1. Open or link a GitHub issue
+
+Every branch that becomes a PR should trace to an issue so work is trackable and **auto-closes on merge** when you use `Fixes #N` in the PR description.
+
+| Change type | Issue | Label(s) |
+|-------------|-------|----------|
+| Bug fix | Required | `bug` |
+| New feature / capability | Required | `enhancement` |
+| Docs / DX / CI | Required | `documentation` (add `enhancement` if CI or tooling changes) |
+| Security | Required | Report via [SECURITY.md](SECURITY.md) or `bug` |
+
+```bash
+gh issue create --title "Short description" --label documentation --body "Problem, solution, acceptance criteria"
+```
+
+For non-trivial work (new API, schema, auth), discuss in the issue before coding.
+
+### 2. Discuss first (for large changes)
 
 Open an issue or community post if your change:
 
@@ -202,33 +219,35 @@ Open an issue or community post if your change:
 - Removes or renames public SDK methods
 - Changes default retention, billing, or AGPL-covered network behavior
 
-Small fixes (typos, obvious bugs, test gaps) can go straight to a PR.
+### 3. Fork and branch
 
-### 2. Fork and branch
+Include the issue number in the branch name when possible:
 
 ```bash
-git checkout -b feat/short-description    # features
-git checkout -b fix/issue-123-description # bug fixes
-git checkout -b docs/what-you-changed     # documentation only
+git checkout -b fix/179-dashboard-ci-vitest   # bug / fix
+git checkout -b feat/180-short-description    # feature
+git checkout -b docs/181-what-you-changed     # documentation only
 ```
 
-### 3. Write focused commits
+### 4. Write focused commits
 
 - One logical change per commit when possible
 - Use clear messages: `fix(api): reject events without tenant scope`
-- Reference issues: `Fixes #123` in the PR description
+- Put `Fixes #123` in the **PR description** (GitHub closes the issue on merge)
 
-### 4. Open a pull request
+### 5. Open a pull request
 
 Target the `main` branch on [Zizka-ai/ZizkaDB](https://github.com/Zizka-ai/ZizkaDB).
 
-**PR description should include:**
+**PR description must include:**
 
-1. **What** changed and **why**
-2. **How to test** (commands, curl, screenshots for UI)
-3. **Areas touched** (API / schema / SDK / dashboard / MCP)
-4. **Breaking changes** (if any)
-5. Link to related issue(s)
+1. **`Fixes #<issue>`** (or `Closes #<issue>`) — auto-closes the issue when merged
+2. **What** changed and **why**
+3. **How to test** (commands, curl, screenshots for UI)
+4. **Areas touched** (API / schema / SDK / dashboard / MCP)
+5. **Breaking changes** (if any)
+
+**CI must pass** before merge (Python lint + tests, TS SDK tests, dashboard lint + vitest + build, doc drift).
 
 Keep PRs small and reviewable. Split large work into stacked PRs when you can.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,9 +54,10 @@ Docker Compose serves the dashboard on **3001**; `npm run dev` uses **3000**.
 ## Contributor path (change code and open a PR)
 
 1. Read [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
-2. Branch from `main`: `git checkout -b fix/short-description`.
-3. Run the gates for the area you touched (see [Baseline](#baseline) below).
-4. Open a PR using the template in [.github/pull_request_template.md](.github/pull_request_template.md).
+2. **Open a GitHub issue** with the right label (`bug`, `enhancement`, `documentation`, …) — see CONTRIBUTING §Pull request workflow.
+3. Branch from `main`: `git checkout -b fix/179-short-description` (include issue number when possible).
+4. Run the gates for the area you touched (see [Baseline](#baseline) below).
+5. Open a PR with **`Fixes #<issue>`** in the description so the issue closes on merge. CI must pass before merge.
 
 **Module guides:** [core/CLAUDE.md](core/CLAUDE.md) · [dashboard/CLAUDE.md](dashboard/CLAUDE.md) · [dashboard/DASHBOARD_KNOWLEDGE_BASE.md](dashboard/DASHBOARD_KNOWLEDGE_BASE.md)
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,95 @@
+# Development guide
+
+Single entry for **self-hosting locally** and **contributing** to the OSS repo.
+
+Managed-cloud marketing, `/enterprise`, and the operator admin console live in the private **zizkadb-cloud** repo — see [docs/REPO_SPLIT.md](docs/REPO_SPLIT.md).
+
+---
+
+## Self-host path (run ZizkaDB locally)
+
+### Quickstart (no clone)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/Zizka-ai/ZizkaDB/main/scripts/quickstart-remote.sh | bash
+```
+
+### Full dev stack (from a clone)
+
+```bash
+git clone https://github.com/Zizka-ai/ZizkaDB.git && cd ZizkaDB
+bash scripts/setup-local.sh
+```
+
+| Service | URL |
+|---------|-----|
+| API | http://localhost:8000 |
+| Swagger | http://localhost:8000/swagger |
+| Dashboard | http://localhost:3001 |
+| Postgres | localhost:5432 |
+
+Dev login: http://localhost:3001/login → **Open my dashboard** (no email when `ENV=development`).
+
+Dev API key: `zizkadb_dev_local` (accepted when `ENV=development`).
+
+Verify the stack:
+
+```bash
+bash scripts/smoke-test.sh
+```
+
+### Dashboard UI only (port 3000)
+
+```bash
+cd dashboard
+npm install
+export NEXT_PUBLIC_API_URL=http://localhost:8000
+npm run dev   # http://localhost:3000
+```
+
+Docker Compose serves the dashboard on **3001**; `npm run dev` uses **3000**.
+
+---
+
+## Contributor path (change code and open a PR)
+
+1. Read [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).
+2. Branch from `main`: `git checkout -b fix/short-description`.
+3. Run the gates for the area you touched (see [Baseline](#baseline) below).
+4. Open a PR using the template in [.github/pull_request_template.md](.github/pull_request_template.md).
+
+**Module guides:** [core/CLAUDE.md](core/CLAUDE.md) · [dashboard/CLAUDE.md](dashboard/CLAUDE.md) · [dashboard/DASHBOARD_KNOWLEDGE_BASE.md](dashboard/DASHBOARD_KNOWLEDGE_BASE.md)
+
+**Troubleshooting:** [wiki/Troubleshooting.md](wiki/Troubleshooting.md)
+
+---
+
+## Baseline
+
+Recorded on **2026-09-04** (local macOS). Re-run before release or large refactors.
+
+| Gate | Command | Result |
+|------|---------|--------|
+| Python lint | `ruff check core/ sdk/python/ mcp/ integrations/` | Pass |
+| Doc drift | `bash scripts/check-doc-drift.sh` | Pass (13 routers) |
+| Core unit tests | `pytest core/tests/ -m "not integration" -v` | Run locally (requires venv + deps) |
+| Python SDK | `pytest sdk/python/tests/ -v` | Run locally |
+| MCP | `pytest mcp/tests/ -v` | Run locally |
+| TypeScript SDK | `cd sdk/typescript && npm test` | Run locally |
+| Dashboard lint | `cd dashboard && npm run lint` | Pass |
+| Dashboard tests | `cd dashboard && npm test` | Pass (170 tests, 27 files) |
+| Dashboard build | `cd dashboard && npm run build` | Pass (29 routes) |
+
+Full matrix (copy-paste):
+
+```bash
+ruff check core/ sdk/python/ mcp/ integrations/
+bash scripts/check-doc-drift.sh
+pytest core/tests/ -m "not integration" -v
+pytest sdk/python/tests/ -v
+pytest mcp/tests/ -v
+cd sdk/typescript && npm ci && npm test
+cd dashboard && npm ci && npm run lint && npm test && npm run build
+```
+
+CI runs the Python jobs, TypeScript SDK tests, and dashboard lint + **vitest** + build on every PR to `main`.

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -82,7 +82,7 @@ app/dashboard/layout.tsx
 
 ```
 dashboard/
-├── middleware.ts            # Edge auth guard for /dashboard and /admin
+├── middleware.ts            # Edge auth guard for /dashboard
 ├── app/
 │   ├── layout.tsx           # Root layout + global metadata
 │   ├── page.tsx             # Landing page (marketing + pricing SECTION)
@@ -107,7 +107,6 @@ dashboard/
 │   │   ├── agents/[id]/page.tsx  # redirect → /dashboard/activity?agent={id}
 │   │   ├── search/page.tsx  # redirect → /dashboard/activity (search is inline now)
 │   │   └── settings/page.tsx# API keys (tenant + per-agent), embeddings, account
-│   ├── admin/               # Operator console (separate auth)
 │   ├── community/           # Public community board
 │   ├── docs/                # Docs pages
 │   └── trust/page.tsx
@@ -166,7 +165,7 @@ DashboardLayout (app/dashboard/layout.tsx)
 
 ## 4. Navigation Diagram
 
-**Routing library:** Next.js App Router (`next/navigation`: `useRouter`, `usePathname`, `useSearchParams`; `next/link`). Guarding via `middleware.ts` (matcher `/dashboard*`, `/admin*`).
+**Routing library:** Next.js App Router (`next/navigation`: `useRouter`, `usePathname`, `useSearchParams`; `next/link`). Guarding via `middleware.ts` (matcher `/dashboard*` only in OSS).
 
 ```mermaid
 flowchart TD

--- a/dashboard/app/page.tsx
+++ b/dashboard/app/page.tsx
@@ -27,7 +27,7 @@ import {
 import { GITHUB_URL } from "@/lib/constants";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
-const HERO_TITLE = "Dont Observe - Audit your AI Agent";
+const HERO_TITLE = "Don't Observe — Audit your AI Agent";
 const HERO_VALUE =
   "When production agents drift, guesswork costs hours. ZizkaDB gives you replay, lineage, and drift alerts so you fix behavior before users notice.";
 

--- a/dashboard/components/marketing/MarketingFooter.tsx
+++ b/dashboard/components/marketing/MarketingFooter.tsx
@@ -49,7 +49,7 @@ export function MarketingFooter() {
             <span style={{ fontSize: 18, fontWeight: 700, color: '#fff', letterSpacing: -0.3 }}>ZizkaDB</span>
           </div>
           <p style={{ margin: '0 0 20px', fontSize: 14, lineHeight: 1.65, color: '#ffffff', maxWidth: 280 }}>
-            Dont Observe - Audit your AI Agent. Causal lineage, time travel, and drift for production agents.
+            Don't Observe — Audit your AI Agent. Causal lineage, time travel, and drift for production agents.
           </p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             <a

--- a/dashboard/components/marketing/MarketingFooter.tsx
+++ b/dashboard/components/marketing/MarketingFooter.tsx
@@ -49,7 +49,7 @@ export function MarketingFooter() {
             <span style={{ fontSize: 18, fontWeight: 700, color: '#fff', letterSpacing: -0.3 }}>ZizkaDB</span>
           </div>
           <p style={{ margin: '0 0 20px', fontSize: 14, lineHeight: 1.65, color: '#ffffff', maxWidth: 280 }}>
-            Don't Observe — Audit your AI Agent. Causal lineage, time travel, and drift for production agents.
+            Don&apos;t Observe — Audit your AI Agent. Causal lineage, time travel, and drift for production agents.
           </p>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
             <a

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,5 +42,5 @@ Start here if you are not sure which file to read.
 
 ## Plan limits (honest)
 
-- **Enforced today (when `API_KEY_LIMITS_ENFORCED=true`):** active API keys per plan (Self-Hosted 1, Pro 2, Team 5, Enterprise 50).
+- **Enforced today (when `API_KEY_LIMITS_ENFORCED=true`):** active API keys per plan (Self-Hosted 1, Pro 2, Team 5).
 - **Marketing targets, not enforced in API yet:** monthly event caps (50k / 100k on Pro/Team copy).


### PR DESCRIPTION
Fixes #179

## Summary

- Add `npm test` to the dashboard CI job so vitest runs on every PR
- Add `DEVELOPMENT.md` for self-host + contributor workflow
- Fix stale docs after enterprise removal
- Fix landing hero/footer copy typo
- Document issue → PR workflow (`Fixes #N` auto-closes on merge)

## Testing

- `cd dashboard && npm run lint && npm test && npm run build` — pass (170 tests)

## Documentation

DEVELOPMENT.md, CONTRIBUTING, KB, CHANGELOG, PR template.