### PR TITLE
docs: require issue link at top of PR descriptions

### DIFF
--- a/.cursor/rules/ai-workflow.mdc
+++ b/.cursor/rules/ai-workflow.mdc
@@ -16,7 +16,7 @@ Full standards: [docs/ai/CODING_STANDARDS.md](../../docs/ai/CODING_STANDARDS.md)
 5. **Test** — run layer commands from [zizkadb-test skill](../skills/zizkadb-test/SKILL.md).
 6. **Document** — update canonical docs in the **same** PR when behavior changes.
 7. **Senior review** — review your own diff; fix before PR.
-8. **PR** — per [CONTRIBUTING.md](../../CONTRIBUTING.md): open a GitHub issue with the right label (`bug`, `enhancement`, `documentation`) before the branch; PR body must include `Fixes #N` so the issue auto-closes on merge; CI must pass.
+8. **PR** — per [CONTRIBUTING.md](../../CONTRIBUTING.md): open a GitHub issue with the right label (`bug`, `enhancement`, `documentation`) before the branch; **PR description must start with `Fixes #N`** (issue mentioned in the body, not only the branch name); CI must pass.
 
 ## Must not
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,15 @@
+## Related issue
+
+<!-- REQUIRED — put this at the top of every PR description -->
+
+Fixes #<!-- number -->
+
+Link the GitHub issue this PR completes. Use **`Fixes #123`** (or `Closes #123`) so GitHub auto-closes the issue on merge. Use `Related to #123` only if the issue must stay open.
+
+Issue: <!-- paste issue title for reviewers, e.g. "Run dashboard vitest in CI (#179)" -->
+
+---
+
 ## Summary
 
 <!-- What changed? (CODING_STANDARDS §39) -->
@@ -37,9 +49,3 @@
 ## Breaking changes
 
 <!-- None, or describe migration — §31 -->
-
-## Related issue
-
-Fixes #<!-- number --> — use this keyword so GitHub **closes the issue automatically when the PR merges**. Use `Related to #<!-- number -->` only if the issue should stay open.
-
-<!-- Maintainers: docs/ai/MAINTAINER.md for labels and assignee -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -239,13 +239,14 @@ git checkout -b docs/181-what-you-changed     # documentation only
 
 Target the `main` branch on [Zizka-ai/ZizkaDB](https://github.com/Zizka-ai/ZizkaDB).
 
-**PR description must include:**
+**The PR description must start with the linked issue** — first line: `Fixes #<number>` (or `Closes #<number>`). Optionally repeat the issue title on the next line for reviewers. GitHub closes the issue when the PR merges.
 
-1. **`Fixes #<issue>`** (or `Closes #<issue>`) — auto-closes the issue when merged
-2. **What** changed and **why**
-3. **How to test** (commands, curl, screenshots for UI)
-4. **Areas touched** (API / schema / SDK / dashboard / MCP)
-5. **Breaking changes** (if any)
+**PR description must also include:**
+
+1. **What** changed and **why**
+2. **How to test** (commands, curl, screenshots for UI)
+3. **Areas touched** (API / schema / SDK / dashboard / MCP)
+4. **Breaking changes** (if any)
 
 **CI must pass** before merge (Python lint + tests, TS SDK tests, dashboard lint + vitest + build, doc drift).
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -57,7 +57,7 @@ Docker Compose serves the dashboard on **3001**; `npm run dev` uses **3000**.
 2. **Open a GitHub issue** with the right label (`bug`, `enhancement`, `documentation`, …) — see CONTRIBUTING §Pull request workflow.
 3. Branch from `main`: `git checkout -b fix/179-short-description` (include issue number when possible).
 4. Run the gates for the area you touched (see [Baseline](#baseline) below).
-5. Open a PR with **`Fixes #<issue>`** in the description so the issue closes on merge. CI must pass before merge.
+5. Open a PR — **first line of the description must be `Fixes #<issue>`** (issue title on the next line is helpful). CI must pass before merge.
 
 **Module guides:** [core/CLAUDE.md](core/CLAUDE.md) · [dashboard/CLAUDE.md](dashboard/CLAUDE.md) · [dashboard/DASHBOARD_KNOWLEDGE_BASE.md](dashboard/DASHBOARD_KNOWLEDGE_BASE.md)
 

--- a/docs/ai/MAINTAINER.md
+++ b/docs/ai/MAINTAINER.md
@@ -31,7 +31,7 @@ gh pr create \
 ```
 
 - Labels: `enhancement`, `bug`, and/or `documentation` (add `documentation` when KB/ADR/`CLAUDE.md` changed). Do **not** use `good first issue` on PRs.
-- Body: `Closes #N` when the PR completes the issue, or `Related to #N` when it must stay open.
+- PR description **must start with** `Fixes #N` or `Closes #N` (issue title on the next line helps reviewers). Use `Related to #N` only when the issue must stay open.
 - Optional footer for team PRs: **Made with [Cursor](https://cursor.com) and Saad**
 
 Fork contributors: a normal PR title + description + test plan is enough. Maintainers will assign reviewers.


### PR DESCRIPTION
Fixes #180

Issue: Require issue link at top of every PR description (#180)

## Summary

PR descriptions must visibly reference the GitHub issue — not only the branch name.

## Changes

- `.github/pull_request_template.md` — **Related issue** is now the first section (required `Fixes #N` + optional issue title)
- `CONTRIBUTING.md` — PR description must start with `Fixes #<number>`
- `DEVELOPMENT.md`, `docs/ai/MAINTAINER.md`, `.cursor/rules/ai-workflow.mdc` — same rule for contributors and AI agents

## Testing

Docs only — no code changes.

## Breaking changes

None.

Made with [Cursor](https://cursor.com)