### PR TITLE
Move suggestions rate limit to Redis with fail-open fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - Dashboard CI runs `npm test` (vitest) alongside lint and build
+- Suggestions endpoint rate limit uses Redis in production (`SUGGESTIONS_RATE_LIMIT_STORAGE`) with fail-open in-memory fallback when Redis is unavailable
 
 ### Integrations
 

--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -4,13 +4,19 @@ import os
 import re
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
 from services.exceptions import bad_request, conflict, not_found, service_unavailable
 from pydantic import BaseModel, Field
 
 from api.deps import assert_agent_allowed, get_tenant, require_dashboard_session
-from api.utils import check_rate
 from db.connection import get_pool, get_redis, get_qdrant, QDRANT_COLLECTION
+from services.rate_limiter import (
+    InMemoryStorage,
+    RateLimiter,
+    RateLimitStorage,
+    RedisStorage,
+    SlidingWindowStrategy,
+)
 from services import reports, token_optimization, token_usage
 from services import token_optimization_config
 from services.ai import config as ai_config
@@ -32,9 +38,85 @@ _AGENT_ID_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]{0,254}$")
 # Per-tenant throttle for the AI suggestions endpoint. Cache + Redis lock already
 # coalesce repeat reads, but `refresh=true` bypasses both and triggers a live
 # (paid, ~20s) Claude call, so cap how often a tenant can force regeneration.
-# In-process dict — same per-worker semantics as the other limiters in this app.
-_SUGGESTIONS_REFRESH_RATE: dict[str, list[float]] = {}
-_SUGGESTIONS_RATE: dict[str, list[float]] = {}
+_SUGGESTIONS_REFRESH_WINDOW_SEC = 3600
+_SUGGESTIONS_REFRESH_MAX = 20
+_SUGGESTIONS_RATE_WINDOW_SEC = 60
+_SUGGESTIONS_RATE_MAX = 30
+
+_suggestions_fallback_storage = InMemoryStorage()
+
+
+def _suggestions_storage() -> RateLimitStorage:
+    """
+    Choose suggestions rate-limit storage.
+
+    SUGGESTIONS_RATE_LIMIT_STORAGE=redis|memory overrides the default.
+    Default: redis when ENV=production (shared across uvicorn workers),
+    memory otherwise (local dev + unit tests).
+    """
+    choice = (os.getenv("SUGGESTIONS_RATE_LIMIT_STORAGE") or "").strip().lower()
+    if not choice:
+        choice = (
+            "redis" if os.getenv("ENV", "development") == "production" else "memory"
+        )
+    if choice == "redis":
+        return RedisStorage(key_prefix="suggestions")
+    if choice == "memory":
+        return InMemoryStorage()
+    log.warning(
+        "Unknown SUGGESTIONS_RATE_LIMIT_STORAGE=%r; falling back to memory",
+        choice,
+    )
+    return InMemoryStorage()
+
+
+suggestions_refresh_limiter = RateLimiter(
+    limit=_SUGGESTIONS_REFRESH_MAX,
+    window_sec=_SUGGESTIONS_REFRESH_WINDOW_SEC,
+    storage=_suggestions_storage(),
+    strategy=SlidingWindowStrategy(),
+    detail="Suggestion regeneration limit reached. Try again later.",
+)
+
+suggestions_rate_limiter = RateLimiter(
+    limit=_SUGGESTIONS_RATE_MAX,
+    window_sec=_SUGGESTIONS_RATE_WINDOW_SEC,
+    storage=_suggestions_storage(),
+    strategy=SlidingWindowStrategy(),
+    detail="Too many suggestion requests. Try again shortly.",
+)
+
+suggestions_refresh_fallback = RateLimiter(
+    limit=_SUGGESTIONS_REFRESH_MAX,
+    window_sec=_SUGGESTIONS_REFRESH_WINDOW_SEC,
+    storage=_suggestions_fallback_storage,
+    strategy=SlidingWindowStrategy(),
+    detail="Suggestion regeneration limit reached. Try again later.",
+)
+
+suggestions_rate_fallback = RateLimiter(
+    limit=_SUGGESTIONS_RATE_MAX,
+    window_sec=_SUGGESTIONS_RATE_WINDOW_SEC,
+    storage=_suggestions_fallback_storage,
+    strategy=SlidingWindowStrategy(),
+    detail="Too many suggestion requests. Try again shortly.",
+)
+
+
+async def _check_suggestions_rate(
+    limiter: RateLimiter, fallback: RateLimiter, key: str
+) -> None:
+    """Check tenant throttle; fail-open to per-worker memory when Redis is down."""
+    try:
+        await limiter.check(key)
+    except HTTPException:
+        raise
+    except Exception:
+        log.warning(
+            "Suggestions rate limit backend unavailable; using in-memory fallback",
+            exc_info=True,
+        )
+        await fallback.check(key)
 
 
 def _validate_agent_id(agent_id: str) -> str:
@@ -492,13 +574,11 @@ async def agent_suggestions(
     # and forces a live Claude call, so it gets a much tighter cap.
     tenant_key = tenant["tenant_id"]
     if refresh:
-        check_rate(
-            _SUGGESTIONS_REFRESH_RATE, tenant_key, window_sec=3600, max_hits=20,
-            detail="Suggestion regeneration limit reached. Try again later.",
+        await _check_suggestions_rate(
+            suggestions_refresh_limiter, suggestions_refresh_fallback, tenant_key
         )
-    check_rate(
-        _SUGGESTIONS_RATE, tenant_key, window_sec=60, max_hits=30,
-        detail="Too many suggestion requests. Try again shortly.",
+    await _check_suggestions_rate(
+        suggestions_rate_limiter, suggestions_rate_fallback, tenant_key
     )
 
     # Default to the last 30 days when the caller omits an explicit window.

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -12,6 +12,17 @@ import pytest
 from fastapi.testclient import TestClient
 from main import app
 from api.auth import otp_limiter, verify_otp_limiter, _otp_storage, _OTP_RATE_MAX, _OTP_RATE_WINDOW_SEC, _VERIFY_OTP_RATE_MAX
+from api.agents import (
+    suggestions_rate_limiter,
+    suggestions_rate_fallback,
+    suggestions_refresh_limiter,
+    suggestions_refresh_fallback,
+    _suggestions_storage,
+    _SUGGESTIONS_RATE_MAX,
+    _SUGGESTIONS_RATE_WINDOW_SEC,
+    _SUGGESTIONS_REFRESH_MAX,
+)
+from api.deps import get_tenant
 from services.rate_limiter import (
     InMemoryStorage,
     RedisStorage,
@@ -289,4 +300,92 @@ class TestVerifyOTPRateLimiting:
             )
             assert response.status_code == 429
             assert "Too many verification attempts" in response.json()["detail"]
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Suggestions Rate Limiting Tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+_TEST_TENANT = {"tenant_id": "suggestions-rate-test-tenant"}
+
+
+def _override_tenant():
+    return _TEST_TENANT
+
+
+class TestSuggestionsRateLimiting:
+    def setup_method(self):
+        suggestions_rate_limiter.storage = InMemoryStorage()
+        suggestions_refresh_limiter.storage = InMemoryStorage()
+        suggestions_rate_fallback.storage = InMemoryStorage()
+        suggestions_refresh_fallback.storage = InMemoryStorage()
+        asyncio.run(suggestions_rate_limiter.storage.clear())
+        asyncio.run(suggestions_refresh_limiter.storage.clear())
+        asyncio.run(suggestions_rate_fallback.storage.clear())
+        asyncio.run(suggestions_refresh_fallback.storage.clear())
+        app.dependency_overrides[get_tenant] = _override_tenant
+
+    def teardown_method(self):
+        app.dependency_overrides.pop(get_tenant, None)
+
+    @patch("services.ai.config.ai_configured", return_value=False)
+    def test_suggestions_requests_exceed_limit(self, _mock_ai):
+        start_time = 1000000.0
+        with patch("time.time", return_value=start_time):
+            for _ in range(_SUGGESTIONS_RATE_MAX):
+                response = client.get("/v1/agents/test-agent/suggestions")
+                assert response.status_code == 200
+
+            response = client.get("/v1/agents/test-agent/suggestions")
+            assert response.status_code == 429
+            assert "Too many suggestion requests" in response.json()["detail"]
+
+    @patch("services.ai.config.ai_configured", return_value=False)
+    def test_suggestions_refresh_exceed_limit(self, _mock_ai):
+        start_time = 1000000.0
+        with patch("time.time", return_value=start_time):
+            for _ in range(_SUGGESTIONS_REFRESH_MAX):
+                response = client.get(
+                    "/v1/agents/test-agent/suggestions?refresh=true"
+                )
+                assert response.status_code == 200
+
+            response = client.get(
+                "/v1/agents/test-agent/suggestions?refresh=true"
+            )
+            assert response.status_code == 429
+            assert "Suggestion regeneration limit" in response.json()["detail"]
+
+    @patch("services.ai.config.ai_configured", return_value=False)
+    def test_suggestions_fail_open_on_redis_error(self, _mock_ai):
+        suggestions_rate_limiter.storage = MagicMock()
+        suggestions_rate_limiter.storage.get_hits = AsyncMock(
+            side_effect=RuntimeError("redis down")
+        )
+        suggestions_rate_limiter.storage.record_hit = AsyncMock()
+
+        start_time = 1000000.0
+        with patch("time.time", return_value=start_time):
+            response = client.get("/v1/agents/test-agent/suggestions")
+            assert response.status_code == 200
+
+
+class TestSuggestionsStorageSelection:
+    def test_explicit_redis(self, monkeypatch):
+        monkeypatch.setenv("SUGGESTIONS_RATE_LIMIT_STORAGE", "redis")
+        assert isinstance(_suggestions_storage(), RedisStorage)
+
+    def test_explicit_memory(self, monkeypatch):
+        monkeypatch.setenv("SUGGESTIONS_RATE_LIMIT_STORAGE", "memory")
+        assert isinstance(_suggestions_storage(), InMemoryStorage)
+
+    def test_production_defaults_to_redis(self, monkeypatch):
+        monkeypatch.delenv("SUGGESTIONS_RATE_LIMIT_STORAGE", raising=False)
+        monkeypatch.setenv("ENV", "production")
+        assert isinstance(_suggestions_storage(), RedisStorage)
+
+    def test_development_defaults_to_memory(self, monkeypatch):
+        monkeypatch.delenv("SUGGESTIONS_RATE_LIMIT_STORAGE", raising=False)
+        monkeypatch.setenv("ENV", "development")
+        assert isinstance(_suggestions_storage(), InMemoryStorage)
 

--- a/core/tests/test_route_authz.py
+++ b/core/tests/test_route_authz.py
@@ -182,9 +182,10 @@ def test_key_management_routes_require_dashboard_session():
 
 
 def test_suggestions_route_is_rate_limited():
-    """The expensive AI endpoint declares per-tenant throttle stores."""
-    assert hasattr(agents_api, "_SUGGESTIONS_REFRESH_RATE")
-    assert hasattr(agents_api, "_SUGGESTIONS_RATE")
+    """The expensive AI endpoint uses shared RateLimiter instances."""
+    assert hasattr(agents_api, "suggestions_refresh_limiter")
+    assert hasattr(agents_api, "suggestions_rate_limiter")
+    assert hasattr(agents_api, "_check_suggestions_rate")
 
 
 # ── per-agent analytics routes: get_tenant + assert_agent_allowed ────────────

--- a/docs/adr/005-in-process-rate-limiting.md
+++ b/docs/adr/005-in-process-rate-limiting.md
@@ -1,6 +1,6 @@
 # ADR-005: In-Process Python Dict Rate Limiting
 
-**Status**: Accepted (with known limitations); **OTP path updated 2026** — `POST /v1/auth/request-otp` uses Redis via `OTP_RATE_LIMIT_STORAGE` / `ENV=production` default (see `core/api/auth.py`). Other in-process limiters may still apply where those routes exist.  
+**Status**: Accepted (with known limitations); **OTP path updated 2026** — `POST /v1/auth/request-otp` uses Redis via `OTP_RATE_LIMIT_STORAGE` / `ENV=production` default (see `core/api/auth.py`). **Suggestions path updated 2026** — `GET /v1/agents/{id}/suggestions` uses Redis via `SUGGESTIONS_RATE_LIMIT_STORAGE` / `ENV=production` default with fail-open in-memory fallback (see `core/api/agents.py`). Other in-process limiters may still apply where those routes exist.  
 **Date**: 2024 (OTP Redis note: 2026)
 
 ---
@@ -63,6 +63,8 @@ The marketing and community routes are low-traffic surfaces; burst requests slip
 **The OTP route is different.** `POST /v1/auth/request-otp` uses Redis when `ENV=production` or `OTP_RATE_LIMIT_STORAGE=redis` (see `core/api/auth.py`). Community, demo, and other `check_rate()` stores remain in-process and still multiply by uvicorn `--workers` (4× in production compose).
 
 **Current state (2026-08):** OTP brute-force protection is Redis-backed in production. Do not assume every limiter is Redis — in-process `check_rate()` is unchanged.
+
+**Current state (2026-09):** Suggestions throttle (`GET /v1/agents/{id}/suggestions`) is Redis-backed in production with fail-open fallback to per-worker in-memory limits when Redis is unavailable. OTP fails closed on Redis outage; suggestions fail open so the endpoint stays available at reduced coordination.
 
 ---
 


### PR DESCRIPTION
Fixes #182

Move suggestions rate limit to Redis with fail-open fallback

## Summary

- Replace in-process dict throttles on `GET /v1/agents/{id}/suggestions` with `RateLimiter` + `RedisStorage` (production default via `ENV=production` or `SUGGESTIONS_RATE_LIMIT_STORAGE=redis`)
- Fail-open to per-worker `InMemoryStorage` when Redis is unavailable (opposite of OTP fail-closed behavior)
- Add regression tests for 429 responses, refresh cap, Redis-down fallback, and storage selection
- ADR-005 addendum + CHANGELOG entry

## Test plan

- [x] `ruff check core/api/agents.py core/tests/test_rate_limiting.py`
- [x] `pytest core/tests/ -m "not integration" -v` (347 passed)


Made with [Cursor](https://cursor.com)