### PR TITLE
Fail-open public rate limits and production CORS warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Dashboard CI runs `npm test` (vitest) alongside lint and build
 - Suggestions endpoint rate limit uses Redis in production (`SUGGESTIONS_RATE_LIMIT_STORAGE`) with fail-open in-memory fallback when Redis is unavailable
+- Public demo-request and community rate limits fail-open to per-worker memory when Redis is unavailable
+- Production startup logs a warning when `CORS_ALLOWED_ORIGINS` is unset (wildcard `*` allowed)
 
 ### Integrations
 

--- a/core/api/agents.py
+++ b/core/api/agents.py
@@ -4,7 +4,7 @@ import os
 import re
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, Query
 from services.exceptions import bad_request, conflict, not_found, service_unavailable
 from pydantic import BaseModel, Field
 
@@ -16,6 +16,7 @@ from services.rate_limiter import (
     RateLimitStorage,
     RedisStorage,
     SlidingWindowStrategy,
+    check_rate_fail_open,
 )
 from services import reports, token_optimization, token_usage
 from services import token_optimization_config
@@ -107,16 +108,9 @@ async def _check_suggestions_rate(
     limiter: RateLimiter, fallback: RateLimiter, key: str
 ) -> None:
     """Check tenant throttle; fail-open to per-worker memory when Redis is down."""
-    try:
-        await limiter.check(key)
-    except HTTPException:
-        raise
-    except Exception:
-        log.warning(
-            "Suggestions rate limit backend unavailable; using in-memory fallback",
-            exc_info=True,
-        )
-        await fallback.check(key)
+    await check_rate_fail_open(
+        limiter, fallback, key, context="suggestions rate limit"
+    )
 
 
 def _validate_agent_id(agent_id: str) -> str:

--- a/core/api/community.py
+++ b/core/api/community.py
@@ -18,7 +18,13 @@ from pydantic import BaseModel, Field
 
 from api.utils import client_ip
 from db.connection import get_pool
-from services.rate_limiter import RateLimiter, RedisStorage, SlidingWindowStrategy
+from services.rate_limiter import (
+    InMemoryStorage,
+    RateLimiter,
+    RedisStorage,
+    SlidingWindowStrategy,
+    check_rate_fail_open,
+)
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -39,6 +45,25 @@ community_limiter = RateLimiter(
     strategy=SlidingWindowStrategy(),
     detail="Too many posts. Try again later."
 )
+
+_community_fallback_storage = InMemoryStorage()
+
+community_limiter_fallback = RateLimiter(
+    limit=RATE_MAX_POSTS,
+    window_sec=RATE_WINDOW_SEC,
+    storage=_community_fallback_storage,
+    strategy=SlidingWindowStrategy(),
+    detail="Too many posts. Try again later.",
+)
+
+
+async def _check_community_rate(key: str) -> None:
+    await check_rate_fail_open(
+        community_limiter,
+        community_limiter_fallback,
+        key,
+        context="community rate limit",
+    )
 
 
 class CreatePostBody(BaseModel):
@@ -165,7 +190,7 @@ async def create_post(body: CreatePostBody, request: Request):
         raise bad_request("Invalid submission")
     if body.category not in CATEGORIES:
         raise bad_request("Invalid category")
-    await community_limiter.check(client_ip(request))
+    await _check_community_rate(client_ip(request))
     pool = get_pool()
     urls = [u for u in body.image_urls if isinstance(u, str) and u.startswith("/v1/community/media/")][:6]
 
@@ -191,7 +216,7 @@ async def create_post(body: CreatePostBody, request: Request):
 async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
     if body.website:
         raise bad_request("Invalid submission")
-    await community_limiter.check(client_ip(request))
+    await _check_community_rate(client_ip(request))
     pool = get_pool()
     try:
         pid = uuid.UUID(post_id)
@@ -228,7 +253,7 @@ async def create_reply(post_id: str, body: CreateReplyBody, request: Request):
 
 @router.post("/upload")
 async def upload_image(request: Request, file: UploadFile = File(...)):
-    await community_limiter.check(client_ip(request) + ":upload")
+    await _check_community_rate(client_ip(request) + ":upload")
 
     if not file.filename:
         raise bad_request("No file")

--- a/core/api/demo_requests.py
+++ b/core/api/demo_requests.py
@@ -11,7 +11,13 @@ from pydantic import BaseModel, EmailStr, Field
 
 from api.utils import client_ip
 from db.connection import get_pool
-from services.rate_limiter import RateLimiter, RedisStorage, SlidingWindowStrategy
+from services.rate_limiter import (
+    InMemoryStorage,
+    RateLimiter,
+    RedisStorage,
+    SlidingWindowStrategy,
+    check_rate_fail_open,
+)
 
 router = APIRouter()
 log = logging.getLogger(__name__)
@@ -27,6 +33,16 @@ demo_limiter = RateLimiter(
     storage=RedisStorage(key_prefix="ratelimit:demo-requests"),
     strategy=SlidingWindowStrategy(),
     detail="Too many requests. Try again later."
+)
+
+_demo_fallback_storage = InMemoryStorage()
+
+demo_limiter_fallback = RateLimiter(
+    limit=RATE_MAX,
+    window_sec=RATE_WINDOW_SEC,
+    storage=_demo_fallback_storage,
+    strategy=SlidingWindowStrategy(),
+    detail="Too many requests. Try again later.",
 )
 
 
@@ -50,7 +66,9 @@ async def create_demo_request(body: CreateDemoRequestBody, request: Request):
         raise bad_request("Invalid submission")
 
     ip = client_ip(request)
-    await demo_limiter.check(ip)
+    await check_rate_fail_open(
+        demo_limiter, demo_limiter_fallback, ip, context="demo request rate limit"
+    )
 
     source = (body.source.strip() or None) if body.source else None
     if source and source not in VALID_SOURCES:

--- a/core/main.py
+++ b/core/main.py
@@ -26,6 +26,15 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+def warn_if_production_cors_wildcard(cors_allowed_origins: list[str]) -> None:
+    """Log when production runs with default wildcard CORS."""
+    if not cors_allowed_origins:
+        logger.warning(
+            "CORS_ALLOWED_ORIGINS is unset in production — allowing all origins (*). "
+            "Set CORS_ALLOWED_ORIGINS to your dashboard origin(s) for browser security."
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     env = os.getenv("ENV", "development")
@@ -49,6 +58,8 @@ async def lifespan(app: FastAPI):
                 "API_KEY_LIMITS_ENFORCED is false in production — per-plan API key "
                 "caps are not enforced until you enable the kill switch."
             )
+        if not _cors_allowed_origins:
+            warn_if_production_cors_wildcard(_cors_allowed_origins)
     await init_db()
     # Seed dev tenant for local self-host (ENV=development) or when DEV_API_KEY is set.
     if os.getenv("ENV", "development") == "development" or os.getenv("DEV_API_KEY"):

--- a/core/services/rate_limiter.py
+++ b/core/services/rate_limiter.py
@@ -7,6 +7,9 @@ import logging
 import threading
 import uuid
 from abc import ABC, abstractmethod
+
+from fastapi import HTTPException
+
 from services.exceptions import rate_limit_exceeded
 from db.connection import get_redis
 
@@ -316,3 +319,24 @@ class RateLimiter:
         Raises HTTPException 429 if the limit is exceeded.
         """
         await self.strategy.check(key, self.limit, self.window_sec, self.storage, self.detail)
+
+
+async def check_rate_fail_open(
+    limiter: RateLimiter,
+    fallback: RateLimiter,
+    key: str,
+    *,
+    context: str = "rate limit",
+) -> None:
+    """Check limiter; on backend errors, fall back to per-worker in-memory limits."""
+    try:
+        await limiter.check(key)
+    except HTTPException:
+        raise
+    except Exception:
+        logger.warning(
+            "%s backend unavailable; using in-memory fallback",
+            context,
+            exc_info=True,
+        )
+        await fallback.check(key)

--- a/core/tests/test_community.py
+++ b/core/tests/test_community.py
@@ -8,7 +8,7 @@ from uuid import UUID
 import pytest
 from fastapi.testclient import TestClient
 
-from api.community import community_limiter
+from api.community import community_limiter, community_limiter_fallback
 from main import app
 from services.rate_limiter import InMemoryStorage
 
@@ -36,7 +36,9 @@ def _mock_pool(fetch_return=None, fetchrow_return=None):
 class TestCommunityPosts:
     def setup_method(self):
         community_limiter.storage = InMemoryStorage()
+        community_limiter_fallback.storage = InMemoryStorage()
         asyncio.run(community_limiter.storage.clear())
+        asyncio.run(community_limiter_fallback.storage.clear())
 
     @patch("api.community.get_pool")
     def test_list_posts_empty(self, mock_get_pool):
@@ -83,3 +85,17 @@ class TestCommunityPosts:
             assert client.post("/v1/community/posts", json=POST_BODY).status_code == 201
         res = client.post("/v1/community/posts", json=POST_BODY)
         assert res.status_code == 429
+
+    @patch("api.community.get_pool")
+    def test_create_post_fail_open_when_redis_unavailable(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool(
+            fetchrow_return={
+                "post_id": UUID("11111111-1111-1111-1111-111111111111"),
+                "created_at": datetime(2026, 7, 1, tzinfo=timezone.utc),
+            }
+        )
+        community_limiter.storage = MagicMock()
+        community_limiter.storage.get_hits = AsyncMock(side_effect=RuntimeError("redis down"))
+        community_limiter.storage.record_hit = AsyncMock()
+        res = client.post("/v1/community/posts", json=POST_BODY)
+        assert res.status_code == 201

--- a/core/tests/test_demo_requests.py
+++ b/core/tests/test_demo_requests.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
-from api.demo_requests import demo_limiter
+from api.demo_requests import demo_limiter, demo_limiter_fallback
 from main import app
 from services.rate_limiter import InMemoryStorage
 
@@ -38,7 +38,9 @@ def _mock_pool_row():
 class TestDemoRequests:
     def setup_method(self):
         demo_limiter.storage = InMemoryStorage()
+        demo_limiter_fallback.storage = InMemoryStorage()
         asyncio.run(demo_limiter.storage.clear())
+        asyncio.run(demo_limiter_fallback.storage.clear())
 
     @patch("api.demo_requests.get_pool")
     def test_create_minimal_fields(self, mock_get_pool):
@@ -154,3 +156,12 @@ class TestDemoRequests:
         del payload["company_name"]
         response = client.post("/v1/demo-requests", json=payload)
         assert response.status_code == 422
+
+    @patch("api.demo_requests.get_pool")
+    def test_fail_open_when_redis_unavailable(self, mock_get_pool):
+        mock_get_pool.return_value = _mock_pool_row()
+        demo_limiter.storage = MagicMock()
+        demo_limiter.storage.get_hits = AsyncMock(side_effect=RuntimeError("redis down"))
+        demo_limiter.storage.record_hit = AsyncMock()
+        response = client.post("/v1/demo-requests", json=VALID_PAYLOAD)
+        assert response.status_code == 201

--- a/core/tests/test_rate_limiting.py
+++ b/core/tests/test_rate_limiting.py
@@ -27,7 +27,8 @@ from services.rate_limiter import (
     InMemoryStorage,
     RedisStorage,
     FixedWindowStrategy,
-    RateLimiter
+    RateLimiter,
+    check_rate_fail_open,
 )
 
 try:
@@ -388,4 +389,41 @@ class TestSuggestionsStorageSelection:
         monkeypatch.delenv("SUGGESTIONS_RATE_LIMIT_STORAGE", raising=False)
         monkeypatch.setenv("ENV", "development")
         assert isinstance(_suggestions_storage(), InMemoryStorage)
+
+
+class TestCheckRateFailOpen:
+    def test_passes_through_429(self):
+        primary = RateLimiter(
+            limit=1,
+            window_sec=60,
+            storage=InMemoryStorage(),
+            strategy=FixedWindowStrategy(),
+        )
+        fallback = RateLimiter(
+            limit=10,
+            window_sec=60,
+            storage=InMemoryStorage(),
+            strategy=FixedWindowStrategy(),
+        )
+        asyncio.run(primary.check("key"))
+        from fastapi import HTTPException
+        with pytest.raises(HTTPException) as exc:
+            asyncio.run(check_rate_fail_open(primary, fallback, "key"))
+        assert exc.value.status_code == 429
+
+    def test_uses_fallback_on_backend_error(self):
+        primary = RateLimiter(
+            limit=1,
+            window_sec=60,
+            storage=MagicMock(),
+            strategy=FixedWindowStrategy(),
+        )
+        primary.storage.get_hits = AsyncMock(side_effect=RuntimeError("redis down"))
+        fallback = RateLimiter(
+            limit=10,
+            window_sec=60,
+            storage=InMemoryStorage(),
+            strategy=FixedWindowStrategy(),
+        )
+        asyncio.run(check_rate_fail_open(primary, fallback, "key"))
 

--- a/core/tests/test_startup_warnings.py
+++ b/core/tests/test_startup_warnings.py
@@ -1,0 +1,17 @@
+"""Unit tests for production startup configuration warnings."""
+
+import logging
+
+from main import warn_if_production_cors_wildcard
+
+
+def test_cors_wildcard_warning_logged(caplog):
+    with caplog.at_level(logging.WARNING):
+        warn_if_production_cors_wildcard([])
+    assert "CORS_ALLOWED_ORIGINS is unset in production" in caplog.text
+
+
+def test_cors_explicit_origins_no_warning(caplog):
+    with caplog.at_level(logging.WARNING):
+        warn_if_production_cors_wildcard(["https://db.zizka.ai"])
+    assert "CORS_ALLOWED_ORIGINS" not in caplog.text

--- a/docs/adr/005-in-process-rate-limiting.md
+++ b/docs/adr/005-in-process-rate-limiting.md
@@ -66,6 +66,8 @@ The marketing and community routes are low-traffic surfaces; burst requests slip
 
 **Current state (2026-09):** Suggestions throttle (`GET /v1/agents/{id}/suggestions`) is Redis-backed in production with fail-open fallback to per-worker in-memory limits when Redis is unavailable. OTP fails closed on Redis outage; suggestions fail open so the endpoint stays available at reduced coordination.
 
+**Current state (2026-09):** Public demo-request and community rate limits use Redis with the same fail-open in-memory fallback. Marketing subscriptions still use Redis-only (no fallback yet).
+
 ---
 
 ## Future path


### PR DESCRIPTION
Fixes #184

Fail-open public rate limits and production CORS warning

## Summary

- Add shared `check_rate_fail_open()` in `services/rate_limiter.py`
- Wire fail-open in-memory fallback for demo-request and community rate limiters
- Refactor suggestions throttle to use the shared helper
- Log startup warning when `ENV=production` and `CORS_ALLOWED_ORIGINS` is unset (wildcard `*`)
- Regression tests for fail-open paths and CORS warning

## Test plan

- [x] `ruff check core/`
- [x] `pytest core/tests/ -m "not integration"` (353 passed)


Made with [Cursor](https://cursor.com)