### PR TITLE
Align SDK and API display versions

### DIFF
--- a/.cursor/skills/zizkadb-release/SKILL.md
+++ b/.cursor/skills/zizkadb-release/SKILL.md
@@ -11,7 +11,7 @@ description: Bumps versions, runs pre-push verification, and publishes ZizkaDB S
 | Python SDK | `sdk/python/pyproject.toml` |
 | TypeScript SDK | `sdk/typescript/package.json` |
 | MCP | `mcp/pyproject.toml` |
-| API (display) | `core/main.py` `version=` |
+| API (display) | `core/main.py` `API_VERSION` |
 
 Keep SDK versions aligned when possible.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Suggestions endpoint rate limit uses Redis in production (`SUGGESTIONS_RATE_LIMIT_STORAGE`) with fail-open in-memory fallback when Redis is unavailable
 - Public demo-request and community rate limits fail-open to per-worker memory when Redis is unavailable
 - Production startup logs a warning when `CORS_ALLOWED_ORIGINS` is unset (wildcard `*` allowed)
+- TypeScript SDK 0.2.8; API `/health` and OpenAPI version aligned with Python SDK release line; `check-doc-drift.sh` enforces version sync
 
 ### Integrations
 

--- a/core/main.py
+++ b/core/main.py
@@ -25,6 +25,9 @@ from api.marketing_subscriptions import router as marketing_subscriptions_router
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Display/API release line — keep in sync with zizkadb-sdk (see scripts/check-doc-drift.sh).
+API_VERSION = "0.2.8"
+
 
 def warn_if_production_cors_wildcard(cors_allowed_origins: list[str]) -> None:
     """Log when production runs with default wildcard CORS."""
@@ -73,7 +76,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title="ZizkaDB",
     description="The operational database for AI agents",
-    version="0.1.0",
+    version=API_VERSION,
     lifespan=lifespan,
     docs_url=None,
     redoc_url=None,
@@ -154,7 +157,7 @@ app.include_router(marketing_subscriptions_router, prefix="/v1/marketing-subscri
 
 @app.get("/health")
 async def health():
-    return {"status": "ok", "version": "0.1.0"}
+    return {"status": "ok", "version": API_VERSION}
 
 
 @app.get("/health/deep")

--- a/core/tests/test_api_version.py
+++ b/core/tests/test_api_version.py
@@ -1,0 +1,16 @@
+"""API display version stays aligned with the SDK release line."""
+
+from main import API_VERSION, app
+
+
+def test_api_version_matches_openapi():
+    assert app.version == API_VERSION
+
+
+def test_health_reports_api_version():
+    from fastapi.testclient import TestClient
+
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json()["version"] == API_VERSION

--- a/scripts/check-doc-drift.sh
+++ b/scripts/check-doc-drift.sh
@@ -61,4 +61,23 @@ if [[ "$MDC_LINES" -gt 55 ]]; then
   fail "coding-standards.mdc has $MDC_LINES lines (max 55) — move detail to CODING_STANDARDS.md"
 fi
 
-echo "check-doc-drift: OK (${ROUTER_COUNT} routers, AI docs present)"
+PY_SDK_VER="$(grep '^version' sdk/python/pyproject.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')"
+TS_SDK_VER="$(grep '"version"' sdk/typescript/package.json | head -1 | sed 's/.*"\([0-9][0-9.]*\)".*/\1/')"
+API_VER="$(grep '^API_VERSION' core/main.py | sed 's/.*"\(.*\)".*/\1/')"
+
+[[ -n "$PY_SDK_VER" ]] || fail "could not read Python SDK version"
+[[ -n "$TS_SDK_VER" ]] || fail "could not read TypeScript SDK version"
+[[ -n "$API_VER" ]] || fail "could not read API_VERSION from core/main.py"
+
+if [[ "$PY_SDK_VER" != "$TS_SDK_VER" ]]; then
+  fail "Python SDK ($PY_SDK_VER) != TypeScript SDK ($TS_SDK_VER)"
+fi
+if [[ "$PY_SDK_VER" != "$API_VER" ]]; then
+  fail "Python SDK ($PY_SDK_VER) != API display version ($API_VER)"
+fi
+
+if grep -q "SDK_VERSION = '" sdk/typescript/src/index.ts 2>/dev/null; then
+  fail "sdk/typescript/src/index.ts must not hardcode SDK_VERSION — import from package.json"
+fi
+
+echo "check-doc-drift: OK (${ROUTER_COUNT} routers, AI docs present, release line ${PY_SDK_VER})"

--- a/sdk/typescript/CLAUDE.md
+++ b/sdk/typescript/CLAUDE.md
@@ -2,7 +2,7 @@
 
 See root [`CLAUDE.md`](../../CLAUDE.md) for full project context.
 
-Package: **`zizkadb-sdk` 0.2.7** on npm. Import: `import { ZizkaDB } from 'zizkadb-sdk'`.
+Package: **`zizkadb-sdk` 0.2.8** on npm. Import: `import { ZizkaDB } from 'zizkadb-sdk'`.
 
 ---
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -1,6 +1,6 @@
 # zizkadb-sdk
 
-**npm:** [zizkadb-sdk 0.2.7](https://www.npmjs.com/package/zizkadb-sdk)
+**npm:** [zizkadb-sdk 0.2.8](https://www.npmjs.com/package/zizkadb-sdk)
 
 TypeScript SDK for [ZizkaDB](https://db.zizka.ai) — causal lineage, time travel, and semantic search for AI agents.
 

--- a/sdk/typescript/package-lock.json
+++ b/sdk/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zizkadb-sdk",
-  "version": "0.2.6",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "zizkadb-sdk",
-      "version": "0.2.6",
+      "version": "0.2.8",
       "license": "AGPL-3.0",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zizkadb-sdk",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Self-hosted audit trail for AI agents — prove why an agent did something with causal lineage (why()), time-travel state, and drift baselines.",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -35,12 +35,13 @@ import type {
   SearchOptions,
 } from './types'
 import { ZizkaDBError, AuthError, NotFoundError, AgentScopeError, RateLimitError } from './types'
+import packageJson from '../package.json'
 
 export * from './types'
 
 const CLOUD_HOST = 'https://db.zizka.ai'
 const TELEMETRY_URL = 'https://db.zizka.ai/v1/telemetry'
-const SDK_VERSION = '0.2.6'
+export const SDK_VERSION = packageJson.version
 const DEFAULT_DEV_API_KEY = 'zizkadb_dev_local'
 
 function isLocalHost(host: string): boolean {

--- a/sdk/typescript/src/tests/client.test.ts
+++ b/sdk/typescript/src/tests/client.test.ts
@@ -381,3 +381,15 @@ describe('at()', () => {
     expect(state.eventCount).toBe(3)
   })
 })
+
+// ─────────────────────────────────────────
+// Version
+// ─────────────────────────────────────────
+
+describe('SDK version', () => {
+  it('SDK_VERSION matches package.json', async () => {
+    const { SDK_VERSION } = await import('../index')
+    const packageJson = await import('../../package.json')
+    expect(SDK_VERSION).toBe(packageJson.version)
+  })
+})


### PR DESCRIPTION
Fixes #186

Align SDK and API display versions

## Summary

- Bump TypeScript SDK to **0.2.8** (matches Python SDK)
- Derive `SDK_VERSION` from `package.json` instead of a hardcoded string
- Add `API_VERSION` constant in `core/main.py` for OpenAPI + `/health`
- Extend `scripts/check-doc-drift.sh` to fail when Python SDK, TS SDK, and API versions diverge
- Tests: TS version parity + API health/OpenAPI version

## Test plan

- [x] `bash scripts/check-doc-drift.sh`
- [x] `pytest core/tests/ -m "not integration"` (355 passed)
- [x] `cd sdk/typescript && npm test && npm run build`
