### PR TITLE
README and dashboard KB accuracy for self-host OSS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Expanded [DEVELOPMENT.md](DEVELOPMENT.md) with first SDK call and `scripts/smoke-example.sh`
 - Added [dashboard/README.md](dashboard/README.md); CONTRIBUTING cross-links and clarifies dashboard ports 3000 vs 3001
+- README self-host first with REPO_SPLIT link; dashboard KB middleware matcher and vitest-in-CI accuracy (§4, §13, §15)
 
 ### Integrations
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,6 +32,8 @@ Dev login: http://localhost:3001/login → **Open my dashboard** (no email when 
 
 Dev API key: `zizkadb_dev_local` (accepted when `ENV=development`).
 
+**Troubleshooting:** [wiki/Troubleshooting.md](wiki/Troubleshooting.md)
+
 Verify the stack:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Self-hosted audit trail for AI agents — one command or one dashboard click fro
 [![LiveKit](https://img.shields.io/pypi/v/zizkadb-livekit?label=LiveKit)](https://pypi.org/project/zizkadb-livekit/)
 [![MCP](https://img.shields.io/pypi/v/zizkadb-mcp?label=MCP)](https://pypi.org/project/zizkadb-mcp/)
 
-**[Try it ↓](#try-it-60-seconds)** · **[START_HERE.md](START_HERE.md)** · **[CONNECT.md](CONNECT.md)** · **[Cloud →](https://db.zizka.ai/signup)**
+**[Try it ↓](#try-it-60-seconds)** · **[DEVELOPMENT.md](DEVELOPMENT.md)** · **[CONNECT.md](CONNECT.md)** · **[Contributing](CONTRIBUTING.md)**
 
 </div>
 
@@ -42,6 +42,21 @@ tool_call · lookup_order · ORD-8842
 ```
 
 Run again anytime: `pip install zizkadb-sdk && zizkadb demo`
+
+### Self-host from a clone
+
+```bash
+git clone https://github.com/Zizka-ai/ZizkaDB.git && cd ZizkaDB
+bash scripts/setup-local.sh
+```
+
+| Service | URL |
+|---------|-----|
+| API | http://localhost:8000 |
+| Dashboard | http://localhost:3001/login |
+| Swagger | http://localhost:8000/swagger |
+
+Full guide: **[DEVELOPMENT.md](DEVELOPMENT.md)** · Troubleshooting: [wiki/Troubleshooting.md](wiki/Troubleshooting.md)
 
 ---
 
@@ -103,6 +118,8 @@ One LiveKit call → one **Session** in Activity (transcript only, no audio in Z
 
 Same **Why?** feature — hosted at [db.zizka.ai](https://db.zizka.ai). No Docker to maintain.
 
+The operator admin console, VPC deploy, and cloud-only marketing routes live in the private **[zizkadb-cloud](https://github.com/Zizka-ai/zizkadb-cloud)** repo — see [docs/REPO_SPLIT.md](docs/REPO_SPLIT.md).
+
 | | **Pro** | **Team** |
 | --- | --- | --- |
 | Price | €29 / mo | €69 / mo |
@@ -156,7 +173,8 @@ Start the stack: `curl -fsSL …/quickstart-remote.sh | bash` or `bash scripts/s
 | Worked example | [worked/01-support-order-delay](worked/01-support-order-delay/) |
 | Examples | [examples/](examples/) — includes [LiveKit voice agent](examples/livekit-agent/) |
 | LiveKit integration | [docs/integrations/livekit.md](docs/integrations/livekit.md) |
-| Self-hosting | [wiki/Self-Hosting](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) |
+| Self-hosting | [DEVELOPMENT.md](DEVELOPMENT.md) · [wiki/Self-Hosting](https://github.com/Zizka-ai/ZizkaDB/wiki/Self-Hosting) |
+| Troubleshooting | [wiki/Troubleshooting.md](wiki/Troubleshooting.md) |
 | Integrate any agent | [docs/integrate/](docs/integrate/) |
 | Issues · Discussions | [Issues](https://github.com/Zizka-ai/ZizkaDB/issues) · [Discussions](https://github.com/Zizka-ai/ZizkaDB/discussions) |
 | Contributing · Security | [CONTRIBUTING.md](CONTRIBUTING.md) · [SECURITY.md](SECURITY.md) |

--- a/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
+++ b/dashboard/DASHBOARD_KNOWLEDGE_BASE.md
@@ -2,7 +2,7 @@
 
 > Single source of truth for the Dashboard module. Reverse-engineered directly from the codebase.
 >
-> **Last verified:** 2026-09-04 · API key limits: Self-Hosted 1 / Pro 2 / Team 5 (enforcement via `API_KEY_LIMITS_ENFORCED`, default OFF; self-hosted resolved via `DEPLOYMENT_MODE`, not `users.plan`). Self-host embeddings off unless `EMBEDDINGS_ENABLED=true`.
+> **Last verified:** 2026-09-10 · API key limits: Self-Hosted 1 / Pro 2 / Team 5 (enforcement via `API_KEY_LIMITS_ENFORCED`, default OFF; self-hosted resolved via `DEPLOYMENT_MODE`, not `users.plan`). Self-host embeddings off unless `EMBEDDINGS_ENABLED=true`.
 >
 > **OSS scope:** This repo ships the tenant dashboard and public marketing/community surfaces. The managed-cloud **operator admin console** (`/admin`, `/v1/admin/*`, `core/api/admin.py`) is **not in this tree** — there is no `app/admin/` and no admin API routes here. Sections §16 (admin paragraph), §18.6, and §20.5 below are **managed-cloud reference only**; do not implement them in OSS.
 >
@@ -82,7 +82,7 @@ app/dashboard/layout.tsx
 
 ```
 dashboard/
-├── middleware.ts            # Edge auth guard for /dashboard
+├── middleware.ts            # Edge auth guard — matcher: /dashboard, /dashboard/:path* (no /admin* in OSS)
 ├── app/
 │   ├── layout.tsx           # Root layout + global metadata
 │   ├── page.tsx             # Landing page (marketing + pricing SECTION)
@@ -205,7 +205,7 @@ back with a visible notice when it names an agent that no longer exists.
 OSS**. `/dashboard/fleet` redirects to Activity on OSS.
 
 **Route guards / redirects:**
-- **Edge (`middleware.ts`):** `/dashboard*` without `zizkadb_token` cookie → `/login?next=<path>` (all responses `X-Robots-Tag: noindex`). Matcher is `/dashboard` only — no `/admin` routes in OSS.
+- **Edge (`middleware.ts`):** `/dashboard` and `/dashboard/*` without `zizkadb_token` cookie → `/login?next=<path>` (all responses `X-Robots-Tag: noindex`). Matcher is `['/dashboard', '/dashboard/:path*']` only — **no `/admin*` routes in OSS** (admin is managed-cloud only; see [docs/REPO_SPLIT.md](../docs/REPO_SPLIT.md)).
 - **Client fallback:** `getToken()` reads localStorage, then falls back to the `zizkadb_token` cookie when localStorage is empty.
 
 ---
@@ -405,7 +405,7 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 ## 12. Technical Notes
 
 - Suspense wrappers are mandatory around `useSearchParams` pages (Next 14 CSR bailout).
-- `middleware` adds `noindex` to all dashboard/admin responses; `dashboard/layout` also sets `robots:false` metadata.
+- `middleware` adds `noindex` to all `/dashboard*` responses; `dashboard/layout` also sets `robots:false` metadata.
 - `postAuthRedirect` always returns `/dashboard` — reuse it after OTP verify for consistency.
 - Styling is inconsistent: dashboard uses Tailwind; marketing/signup use inline styles + a raw `<style>` block for responsive breakpoints (`page.tsx:44-63`).
 - Plans are duplicated: landing (`page.tsx`), `/signup/plan` (`PLANS`), and backend `PLAN_CATALOG` in `billing.py` all define plan data independently.
@@ -435,7 +435,7 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 5. **No analytics/telemetry** on funnel steps → hard to measure drop-off.
 6. **No React Query/SWR** → manual polling + no dedupe/caching; billing status fetched on mount by `TenantPlanBanner`.
 7. **Inconsistent styling systems** (Tailwind vs inline).
-8. ~~**No frontend tests**~~ — **partial:** vitest (`npm test`) runs in CI alongside lint and build. Coverage includes hooks, report/suggestions helpers, and `apiFetch` auth/timeout behavior. Still expand funnel guards and billing helpers.
+8. ~~**No frontend tests**~~ — **CI done (2026-09):** vitest (`npm test`) runs in `.github/workflows/ci.yml` on every PR alongside lint and build. Coverage includes hooks, report/suggestions helpers, and `apiFetch` auth/timeout behavior. **Still expand:** funnel guards and billing helpers.
 9. ~~**`apiFetch` is effectively untyped**~~ — **done 2026-07-08:** `apiFetch<T>()` is now generic (defaults to `any` only where a call site's shape is intentionally left flexible, e.g. `searchEvents`'s dual array/`{results}` response) and every endpoint has an explicit interface (`Agent`, `ApiKey`, `AgentEvent`, `AgentStats`, `WhyChain`, `AgentSession`, `AgentBaseline`, the admin analytics types, etc. — see `lib/api.ts`). Compile-time only; no runtime behavior changed. **Follow-up done the same day:** the page-level local duplicates of these types in `app/dashboard/page.tsx` (`Agent`), `app/dashboard/settings/page.tsx` + `components/AgentApiKeys.tsx` (`ApiKey`/`AgentApiKey`), and all 9 in `app/admin/page.tsx` were removed and replaced with `import { type X } from '@/lib/api'` — a code-review pass flagged these as hand-copied duplicates that would silently drift, and each was confirmed structurally identical before consolidating (verified via a clean `npm run build` with unchanged route/bundle sizes). **Deliberately left alone:** `app/dashboard/agents/[id]/page.tsx`'s local `Event`/`Session`/`Stats`/`WhyChain`/`BaselineWindow`/`BaselineChange`/`BaselineResponse` cluster (→ `AgentEvent`/`AgentSession`/`AgentStats`/`WhyChain`/`AgentBaseline` in `lib/api.ts`) is the same kind of duplicate but sits in the single largest, most stateful file in the app (1,361 lines) where a bare `Event` rename touches many call sites and risks colliding with the global DOM `Event` type — treat as a separate, explicitly-approved change, not a drive-by.
 
 ---
@@ -457,7 +457,9 @@ Landing → (Pricing: Pro) → `/signup?plan=pro` → `/signup/start` (consent) 
 
 ## 15. Local Development, Build & Environment
 
-**Scripts (`package.json`):** `dev` (`next dev`), `build` (`next build`), `start` (`next start`), `lint` (`next lint`), `test` (`vitest run`), `test:watch` (`vitest`). CI runs lint + vitest + build.
+**Scripts (`package.json`):** `dev` (`next dev`), `build` (`next build`), `start` (`next start`), `lint` (`next lint`), `test` (`vitest run`), `test:watch` (`vitest`). **CI** (`.github/workflows/ci.yml` dashboard job): `npm run lint` → `npm test` (vitest) → `npm run build` on every PR to `main`.
+
+**Ports:** Docker Compose (`scripts/setup-local.sh`) serves the dashboard on **3001**. `npm run dev` alone uses **3000** — set `NEXT_PUBLIC_API_URL=http://localhost:8000` when the API runs separately.
 
 **Build output:** `output: 'standalone'` (`next.config.mjs`) for containerized deploy.
 


### PR DESCRIPTION
Fixes #192

README and dashboard KB accuracy for self-host OSS

## Summary

- **README:** self-host header links, clone quickstart section, REPO_SPLIT in managed-cloud details, troubleshooting link in docs table
- **DASHBOARD_KNOWLEDGE_BASE.md:** middleware matcher matches `middleware.ts` (`/dashboard`, `/dashboard/:path*` — no `/admin*` in OSS); §13/§15 vitest-in-CI accuracy; port 3000 vs 3001 in §15
- **DEVELOPMENT.md:** troubleshooting link in self-host path

## Test plan

- [x] `bash scripts/check-doc-drift.sh`
- [x] Manual review of README/KB sections cited above


