### PR TITLE
Add request-ID middleware and operator health docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Public demo-request and community rate limits fail-open to per-worker memory when Redis is unavailable
 - Production startup logs a warning when `CORS_ALLOWED_ORIGINS` is unset (wildcard `*` allowed)
 - TypeScript SDK 0.2.8; API `/health` and OpenAPI version aligned with Python SDK release line; `check-doc-drift.sh` enforces version sync
+- API responses include `X-Request-ID`; request start/end logged for operator tracing
 
 ### Documentation
 
 - Expanded [DEVELOPMENT.md](DEVELOPMENT.md) with first SDK call and `scripts/smoke-example.sh`
 - Added [dashboard/README.md](dashboard/README.md); CONTRIBUTING cross-links and clarifies dashboard ports 3000 vs 3001
 - README self-host first with REPO_SPLIT link; dashboard KB middleware matcher and vitest-in-CI accuracy (§4, §13, §15)
+- [DEVELOPMENT.md](DEVELOPMENT.md) operator section: `/health` liveness vs `/health/deep` readiness, `X-Request-ID` tracing
 
 ### Integrations
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -80,6 +80,23 @@ Docker Compose serves the dashboard on **3001**; `npm run dev` uses **3000**.
 
 ---
 
+## Operators (self-host / production)
+
+### Health probes
+
+| Endpoint | Use | Behavior |
+|----------|-----|----------|
+| `GET /health` | **Liveness** — is the API process responding? | Always `200` with `{"status":"ok","version":"..."}` when uvicorn is up. Does not check Postgres/Redis/Qdrant. |
+| `GET /health/deep` | **Readiness** — can the stack serve real traffic? | `status: ok` when Postgres, Redis, and Qdrant all pass; `degraded` otherwise (still `200` — inspect `checks`). |
+
+Use `/health` for load-balancer or container **liveness** probes. Use `/health/deep` after deploy, for monitoring, or before sending user traffic — `scripts/smoke-test.sh` hits both by default (`SKIP_DEEP_HEALTH=1` to skip deep).
+
+### Request tracing
+
+Every response includes an **`X-Request-ID`** header. Pass the same value on retries to correlate API logs (`request start` / `request end` lines in the API container). If the client omits the header, the server generates a UUID.
+
+---
+
 ## Contributor path (change code and open a PR)
 
 1. Read [CONTRIBUTING.md](CONTRIBUTING.md) and [AGENTS.md](AGENTS.md).

--- a/core/main.py
+++ b/core/main.py
@@ -21,6 +21,7 @@ from api.account import router as account_router
 from api.demo_requests import router as demo_requests_router
 from api.community import router as community_router
 from api.marketing_subscriptions import router as marketing_subscriptions_router
+from middleware.request_id import RequestIdMiddleware
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -139,6 +140,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.add_middleware(RequestIdMiddleware)
 
 app.include_router(auth_router,      prefix="/v1/auth",      tags=["auth"])
 app.include_router(events_router,    prefix="/v1/events",    tags=["events"])

--- a/core/middleware/request_id.py
+++ b/core/middleware/request_id.py
@@ -1,0 +1,39 @@
+"""Attach X-Request-ID to every API response and log request start/end."""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+log = logging.getLogger(__name__)
+
+
+class RequestIdMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        incoming = (request.headers.get(REQUEST_ID_HEADER) or "").strip()
+        request_id = incoming or str(uuid.uuid4())
+        request.state.request_id = request_id
+
+        start = time.perf_counter()
+        log.info("[%s] %s %s", request_id, request.method, request.url.path)
+
+        response = await call_next(request)
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        log.info(
+            "[%s] %s %s -> %s %.1fms",
+            request_id,
+            request.method,
+            request.url.path,
+            response.status_code,
+            duration_ms,
+        )
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response

--- a/core/tests/test_request_id.py
+++ b/core/tests/test_request_id.py
@@ -1,0 +1,41 @@
+"""Request-ID middleware — header propagation and logging."""
+
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from middleware.request_id import REQUEST_ID_HEADER
+from main import app
+
+client = TestClient(app)
+
+
+def test_response_includes_generated_request_id():
+    response = client.get("/health")
+    assert response.status_code == 200
+    request_id = response.headers.get(REQUEST_ID_HEADER)
+    assert request_id
+    assert len(request_id) >= 8
+
+
+def test_client_request_id_is_echoed():
+    request_id = "11111111-1111-1111-1111-111111111111"
+    response = client.get("/health", headers={REQUEST_ID_HEADER: request_id})
+    assert response.status_code == 200
+    assert response.headers[REQUEST_ID_HEADER] == request_id
+
+
+@patch("middleware.request_id.log")
+def test_request_start_and_end_logged(mock_log):
+    request_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    client.get("/health", headers={REQUEST_ID_HEADER: request_id})
+
+    assert mock_log.info.call_count == 2
+    start_msg = mock_log.info.call_args_list[0].args
+    end_msg = mock_log.info.call_args_list[1].args
+    assert start_msg[0] == "[%s] %s %s"
+    assert start_msg[1] == request_id
+    assert start_msg[2] == "GET"
+    assert start_msg[3] == "/health"
+    assert end_msg[1] == request_id
+    assert end_msg[4] == 200


### PR DESCRIPTION
Fixes #195

Add request-ID middleware and operator health docs

## Summary

- **`RequestIdMiddleware`:** sets `X-Request-ID` on every response (echoes client header or generates UUID); logs request start/end with duration
- **`DEVELOPMENT.md`:** operator section — `/health` liveness vs `/health/deep` readiness, request tracing guidance
- Tests: header generation, client echo, log lines

## Test plan

- [x] `ruff check core/main.py core/middleware/request_id.py`
- [x] `pytest core/tests/test_request_id.py -v` (3 passed)
- [x] `pytest core/tests/ -m "not integration"` (374 passed)