### PR TITLE
Wire minimal-python example into smoke-test and document dashboard expectations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - TypeScript SDK 0.2.8; API `/health` and OpenAPI version aligned with Python SDK release line; `check-doc-drift.sh` enforces version sync
 - API responses include `X-Request-ID`; request start/end logged for operator tracing
 
+### Added
+
+- `scripts/smoke-test.sh` runs `scripts/smoke-example.sh` by default (`SKIP_EXAMPLE=1` to skip)
+
 ### Documentation
 
+- [examples/minimal-python/README.md](examples/minimal-python/README.md): expected `why()` output and dashboard Activity view
 - Expanded [DEVELOPMENT.md](DEVELOPMENT.md) with first SDK call and `scripts/smoke-example.sh`
 - Added [dashboard/README.md](dashboard/README.md); CONTRIBUTING cross-links and clarifies dashboard ports 3000 vs 3001
 - README self-host first with REPO_SPLIT link; dashboard KB middleware matcher and vitest-in-CI accuracy (§4, §13, §15)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,8 +88,8 @@ Local dev uses `DEV_API_KEY=zizkadb_dev_local` (see `infra/.env`). The Python SD
 ### Verify your environment
 
 ```bash
-bash scripts/smoke-test.sh
-bash scripts/smoke-example.sh   # optional: minimal Python log → why()
+bash scripts/smoke-test.sh      # includes minimal-python example (SKIP_EXAMPLE=1 for curl-only)
+bash scripts/smoke-example.sh   # example only: log → why()
 python scripts/demo-why.py
 bash scripts/check-doc-drift.sh
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,9 +37,11 @@ Dev API key: `zizkadb_dev_local` (accepted when `ENV=development`).
 Verify the stack:
 
 ```bash
-bash scripts/smoke-test.sh
-bash scripts/smoke-example.sh   # minimal Python agent: log → why()
+bash scripts/smoke-test.sh      # health, curl checks, then minimal-python example
+bash scripts/smoke-example.sh   # example only (log → why())
 ```
+
+Use `SKIP_EXAMPLE=1` on `smoke-test.sh` for curl-only checks (e.g. staging without Python).
 
 ### First SDK call (Python)
 

--- a/core/tests/test_smoke.py
+++ b/core/tests/test_smoke.py
@@ -127,6 +127,27 @@ def test_causal_chain_model_and_print(capsys):
     assert "└── llm_response" in captured.out
 
 
+def test_smoke_scripts_wire_minimal_python_example():
+    """Repo smoke scripts exist and smoke-test delegates to smoke-example."""
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+    smoke_test = os.path.join(root, "scripts", "smoke-test.sh")
+    smoke_example = os.path.join(root, "scripts", "smoke-example.sh")
+    agent_py = os.path.join(root, "examples", "minimal-python", "agent.py")
+
+    assert os.path.isfile(smoke_test)
+    assert os.path.isfile(smoke_example)
+    assert os.path.isfile(agent_py)
+
+    with open(smoke_test, encoding="utf-8") as f:
+        body = f.read()
+    assert "smoke-example.sh" in body
+    assert "SKIP_EXAMPLE" in body
+
+    with open(smoke_example, encoding="utf-8") as f:
+        example_body = f.read()
+    assert "minimal-python/agent.py" in example_body
+
+
 def test_safe_print_handles_encoding_error(capsys, monkeypatch):
     """Test that _safe_print handles UnicodeEncodeError gracefully by falling back."""
     import builtins

--- a/examples/README.md
+++ b/examples/README.md
@@ -28,6 +28,11 @@ Voice agents: **`pip install zizkadb-livekit`** — see [livekit-agent/](livekit
 
 ```bash
 bash scripts/setup-local.sh
+bash scripts/smoke-test.sh              # health + curl + minimal-python example
+# or:
+bash scripts/smoke-example.sh           # example only
 export ZIZKADB_HOST=http://localhost:8000
 python examples/minimal-python/agent.py
 ```
+
+Dashboard: http://localhost:3001/dashboard/activity?agent=my-agent — see [minimal-python/README.md](minimal-python/README.md).

--- a/examples/minimal-python/README.md
+++ b/examples/minimal-python/README.md
@@ -1,9 +1,61 @@
 # ZizkaDB basic agent
 
+Minimal **log → `parent_id` → `why()`** example. Two events (`user_message` → `tool_call`) and a printed causal chain.
+
+## Prerequisites
+
+1. ZizkaDB API running (local: `bash scripts/setup-local.sh` from repo root).
+2. Python 3.10+.
+
+## Run locally
+
+From this directory:
+
 ```bash
-cp .env.example .env
+cp .env.example .env   # optional; localhost uses dev key auto-injection
 pip install -r requirements.txt
+export ZIZKADB_HOST=http://localhost:8000   # omit if using managed cloud + API key in .env
 python agent.py
 ```
 
-Logs a user message and tool call, then prints the causal chain with `why()`.
+From repo root (health check + SDK install + agent):
+
+```bash
+bash scripts/smoke-example.sh
+# or full stack smoke (curl + example):
+bash scripts/smoke-test.sh
+```
+
+Set `SKIP_EXAMPLE=1` on `smoke-test.sh` to run API curl checks only.
+
+## Expected terminal output
+
+`why()` prints a tree with two nodes — root `user_message`, child `tool_call`:
+
+```
+Causal chain for evt_... (length=2)
+├── user_message
+│   data: {"text": "Hello from my first agent"}
+└── tool_call
+    data: {"tool": "echo", "args": {"message": "hello"}}
+```
+
+(Event IDs and formatting may vary; both event types must appear.)
+
+## Expected dashboard
+
+1. Open http://localhost:3001/dashboard/activity?agent=my-agent (dev login: **Open my dashboard**).
+2. Agent filter: **my-agent** (override with `ZIZKADB_AGENT` in `.env`).
+3. Activity list shows **user_message** and **tool_call** with timestamps; open an event to inspect `parent_id` linkage.
+
+If the list is empty, confirm the API URL (`ZIZKADB_HOST`) matches your stack and `ENV=development` for localhost dev keys.
+
+## Environment
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ZIZKADB_HOST` | `http://localhost:8000` | Self-hosted API base URL |
+| `ZIZKADB_API_KEY` | (dev key on localhost) | Managed cloud or production |
+| `ZIZKADB_AGENT` | `my-agent` | Agent name in events and dashboard filter |
+
+See [`.env.example`](.env.example).

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -15,6 +15,7 @@
 # Optional:
 #   SKIP_SEARCH=1          skip semantic search check
 #   SKIP_DEEP_HEALTH=1     skip /health/deep (not recommended)
+#   SKIP_EXAMPLE=1         skip minimal-python example (curl-only smoke)
 
 set -euo pipefail
 
@@ -78,3 +79,8 @@ else
 fi
 
 echo "✓ All smoke checks passed ($BASE)"
+
+if [ "${SKIP_EXAMPLE:-}" != "1" ]; then
+  echo ""
+  bash "$ROOT/scripts/smoke-example.sh" "$BASE"
+fi


### PR DESCRIPTION
Fixes #197

## Summary

- `scripts/smoke-test.sh` runs `scripts/smoke-example.sh` after curl checks by default (`SKIP_EXAMPLE=1` to skip)
- Expanded `examples/minimal-python/README.md` with expected `why()` output and Activity dashboard steps
- Added unit test asserting smoke scripts reference the minimal-python example path
- Updated DEVELOPMENT.md, CONTRIBUTING.md, examples/README.md, and CHANGELOG

## Test plan

- [x] `pytest core/tests/test_smoke.py::test_smoke_scripts_wire_minimal_python_example -v`
- [ ] `bash scripts/smoke-test.sh` against local stack (optional integration)
- [ ] `SKIP_EXAMPLE=1 bash scripts/smoke-test.sh` skips the Python example
