### PR TITLE
Add TypeScript SDK tests for contextFor, memoryDiff, and agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `scripts/smoke-test.sh` runs `scripts/smoke-example.sh` by default (`SKIP_EXAMPLE=1` to skip)
+- TypeScript SDK vitest coverage for `contextFor()`, `memoryDiff()`, and `agents()`
 
 ### Documentation
 
 - [examples/minimal-python/README.md](examples/minimal-python/README.md): expected `why()` output and dashboard Activity view
+- [sdk/typescript/README.md](sdk/typescript/README.md): `token_usage` on `log()` is Python SDK only
 - Expanded [DEVELOPMENT.md](DEVELOPMENT.md) with first SDK call and `scripts/smoke-example.sh`
 - Added [dashboard/README.md](dashboard/README.md); CONTRIBUTING cross-links and clarifies dashboard ports 3000 vs 3001
 - README self-host first with REPO_SPLIT link; dashboard KB middleware matcher and vitest-in-CI accuracy (§4, §13, §15)

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -36,6 +36,13 @@ const chain = await db.why(result.eventId)
 chain.print()
 ```
 
+## Python vs TypeScript
+
+| Feature | Python SDK | TypeScript SDK |
+|---------|------------|----------------|
+| `token_usage` on `log()` | `token_usage={...}` kwarg merges into event `data` | **Not supported** — pass token counts inside `data` manually, or use the Python SDK |
+| `db.token_usage()` analytics | Yes | Yes (`tokenUsage()`) |
+
 ## Multi-agent apps (one key, many agent names)
 
 If your app logs to **different agent ids** per user (e.g. `conv-alice`, `conv-bob`), create a **tenant-wide key** in **Settings → Tenant-wide API key**. Per-agent keys only work for that one agent name.

--- a/sdk/typescript/src/tests/client.test.ts
+++ b/sdk/typescript/src/tests/client.test.ts
@@ -338,6 +338,124 @@ describe('error mapping', () => {
 })
 
 // ─────────────────────────────────────────
+// contextFor()
+// ─────────────────────────────────────────
+
+describe('contextFor()', () => {
+  it('POSTs /v1/memory/context and returns the context string', async () => {
+    mockFetch(200, {
+      context: 'Recent: user asked about billing.\nRelevant: prior refund on file.',
+      event_count: 3,
+      estimated_tokens: 42,
+      sources: [],
+    })
+
+    const db = new ZizkaDB({ apiKey: 'zizkadb_live_test' })
+    const context = await db.contextFor({
+      agent: 'support-bot',
+      task: 'user asking about their invoice',
+      maxTokens: 1500,
+      sessionId: 'sess-abc',
+    })
+
+    expect(context).toContain('billing')
+
+    const [url, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    expect(url).toContain('/v1/memory/context')
+    expect(opts.method).toBe('POST')
+
+    const body = JSON.parse(opts.body as string)
+    expect(body.agent).toBe('support-bot')
+    expect(body.task).toBe('user asking about their invoice')
+    expect(body.max_tokens).toBe(1500)
+    expect(body.session_id).toBe('sess-abc')
+  })
+
+  it('defaults maxTokens to 2000 and sessionId to null', async () => {
+    mockFetch(200, { context: 'ok', event_count: 0, estimated_tokens: 0, sources: [] })
+
+    const db = new ZizkaDB({ apiKey: 'zizkadb_live_test' })
+    await db.contextFor({ agent: 'my-bot', task: 'hello' })
+
+    const [, opts] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string, RequestInit]
+    const body = JSON.parse(opts.body as string)
+    expect(body.max_tokens).toBe(2000)
+    expect(body.session_id).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────
+// memoryDiff()
+// ─────────────────────────────────────────
+
+describe('memoryDiff()', () => {
+  it('GETs /v1/memory/diff/:sessionId and maps the response', async () => {
+    mockFetch(200, {
+      session_id: 'sess-abc',
+      agent: 'support-bot',
+      event_count: 4,
+      event_types: { user_message: 2, tool_call: 2 },
+      causal_depth: 3,
+      has_errors: false,
+      duration_seconds: 12.5,
+      new_event_types: ['tool_call'],
+      summary: 'Session completed with 4 events.',
+    })
+
+    const db = new ZizkaDB({ apiKey: 'zizkadb_live_test' })
+    const diff = await db.memoryDiff('sess-abc')
+
+    expect(diff.sessionId).toBe('sess-abc')
+    expect(diff.agent).toBe('support-bot')
+    expect(diff.eventCount).toBe(4)
+    expect(diff.eventTypes).toEqual({ user_message: 2, tool_call: 2 })
+    expect(diff.causalDepth).toBe(3)
+    expect(diff.hasErrors).toBe(false)
+    expect(diff.durationSeconds).toBe(12.5)
+    expect(diff.newEventTypes).toEqual(['tool_call'])
+    expect(diff.summary).toContain('4 events')
+
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string]
+    expect(url).toContain('/v1/memory/diff/sess-abc')
+  })
+})
+
+// ─────────────────────────────────────────
+// agents()
+// ─────────────────────────────────────────
+
+describe('agents()', () => {
+  it('GETs /v1/agents and maps agent metadata', async () => {
+    mockFetch(200, [
+      {
+        agent: 'support-bot',
+        first_seen: '2026-06-01T00:00:00Z',
+        last_seen: '2026-06-02T12:00:00Z',
+        event_count: 42,
+      },
+      {
+        agent: 'sales-bot',
+        first_seen: '2026-06-01T06:00:00Z',
+        last_seen: '2026-06-01T18:00:00Z',
+        event_count: 7,
+      },
+    ])
+
+    const db = new ZizkaDB({ apiKey: 'zizkadb_live_test' })
+    const agents = await db.agents()
+
+    expect(agents).toHaveLength(2)
+    expect(agents[0].agent).toBe('support-bot')
+    expect(agents[0].eventCount).toBe(42)
+    expect(agents[0].firstSeen).toBeInstanceOf(Date)
+    expect(agents[0].lastSeen).toBeInstanceOf(Date)
+
+    const [url] = (fetch as ReturnType<typeof vi.fn>).mock.calls[0] as [string]
+    expect(url).toContain('/v1/agents')
+  })
+})
+
+// ─────────────────────────────────────────
 // baseline()
 // ─────────────────────────────────────────
 


### PR DESCRIPTION
Fixes #199

## Summary

- Vitest coverage for `contextFor()`, `memoryDiff()`, and `agents()` success paths (mocked fetch, no network)
- Documents that `token_usage` on `log()` is Python SDK only in `sdk/typescript/README.md`

## Test plan

- [x] `cd sdk/typescript && npm test` (34 tests pass)
